### PR TITLE
Adding integration test - checks that frontpage renders successfully

### DIFF
--- a/frog/imports/ui/Home.app-test.js
+++ b/frog/imports/ui/Home.app-test.js
@@ -1,0 +1,12 @@
+import { Meteor } from 'meteor/meteor';
+import { Tracker } from 'meteor/tracker';
+import { DDP } from 'meteor/ddp-client';
+import { assert } from 'meteor/practicalmeteor:chai';
+import { Promise } from 'meteor/promise';
+import { $ } from 'meteor/jquery';
+
+if (Meteor.isClient) {
+  it('renders the correct list when routed to', () => {
+        assert.equal($('h1')[0].textContent, "FROG - FABRICATING AND RUNNING ORCHESTRATION GRAPHS");
+  });
+};

--- a/frog/package.json
+++ b/frog/package.json
@@ -2,7 +2,7 @@
   "name": "frog",
   "private": true,
   "scripts": {
-    "test": "meteor test --once --driver-package dispatch:mocha-phantomjs",
+    "test": "meteor test --once --full-app --driver-package dispatch:mocha-phantomjs",
     "start": "meteor run"
   },
   "dependencies": {


### PR DESCRIPTION
Currently just checks that the header on the frontpage is what is expected, however this entails compiling and running the entire app, which should catch spelling mistakes etc as well. We should extend in the future. Responds to #29. 