### PR TITLE
Using yarn and symlinks to decrease install time and size

### DIFF
--- a/ac/ac-ck-board/package.json
+++ b/ac/ac-ck-board/package.json
@@ -7,24 +7,16 @@
     "watch": "watch 'npm run build' ./src",
     "prepublish": "npm run build"
   },
-  "devDependencies": {
-    "babel-cli": "^6.8.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-es2017": "^6.16.0",
-    "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-0": "^6.16.0",
-    "watch": "^0.18.0"
-  },
   "dependencies": {
     "json-stable-stringify": "^1.0.1",
-    "jsxstyle": "0.0.18",
+    "jsxstyle": "1.0.1",
     "lodash": "^4.17.2",
-    "material-ui": "^0.15.4",
+    "material-ui": "^0.16.4",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-draggable": "github:houshuang/react-draggable",
     "react-dropzone": "^3.5.1",
     "react-icons": "^2.2.1",
-    "react-tap-event-plugin": "1.0.0"
+    "react-tap-event-plugin": "2.0.1"
   }
 }

--- a/ac/ac-collab-form/package.json
+++ b/ac/ac-collab-form/package.json
@@ -8,16 +8,7 @@
     "watch": "watch 'npm run build' ./src",
     "prepublish": "npm run build"
   },
-  "devDependencies": {
-    "babel-cli": "^6.8.0",
-    "babel-plugin-transform-class-properties": "^6.18.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-es2017": "^6.16.0",
-    "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-0": "^6.16.0",
-    "watch": "^0.18.0"
-  },
-  "author": "",
+ "author": "",
   "license": "ISC",
   "dependencies": {
     "lodash": "^4.16.6",

--- a/ac/ac-form/package.json
+++ b/ac/ac-form/package.json
@@ -8,15 +8,6 @@
     "watch": "watch 'npm run build' ./src",
     "prepublish": "npm run build"
   },
-  "devDependencies": {
-    "babel-cli": "^6.8.0",
-    "babel-plugin-transform-class-properties": "^6.18.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-es2017": "^6.16.0",
-    "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-0": "^6.16.0",
-    "watch": "^0.18.0"
-  },
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/ac/ac-iframe/package.json
+++ b/ac/ac-iframe/package.json
@@ -8,12 +8,6 @@
     "watch": "watch 'npm run build' ./src",
     "prepublish": "npm run build"
   },
-  "devDependencies": {
-    "babel-cli": "^6.8.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
-    "watch": "^0.18.0"
-  },
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/ac/ac-quiz/package.json
+++ b/ac/ac-quiz/package.json
@@ -8,14 +8,6 @@
     "watch": "watch 'npm run build' ./src",
     "prepublish": "npm run build"
   },
-  "devDependencies": {
-    "babel-cli": "^6.8.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-es2017": "^6.16.0",
-    "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-0": "^6.16.0",
-    "watch": "^0.18.0"
-  },
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/ac/ac-text/package.json
+++ b/ac/ac-text/package.json
@@ -8,12 +8,6 @@
     "watch": "watch 'npm run build' ./src",
     "prepublish": "npm run build"
   },
-  "devDependencies": {
-    "babel-cli": "^6.8.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
-    "watch": "^0.18.0"
-  },
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/ac/ac-video/package.json
+++ b/ac/ac-video/package.json
@@ -8,15 +8,6 @@
     "watch": "watch 'npm run build' ./src",
     "prepublish": "npm run build"
   },
-  "devDependencies": {
-    "babel-cli": "^6.8.0",
-    "babel-plugin-transform-class-properties": "^6.18.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-es2017": "^6.16.0",
-    "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-0": "^6.16.0",
-    "watch": "^0.18.0"
-  },
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 0.10.43
+    version: 7.2.0
 
 dependencies:
   override:

--- a/frog-utils/package.json
+++ b/frog-utils/package.json
@@ -8,14 +8,6 @@
     "watch": "watch 'npm run build' ./src",
     "prepublish": "npm run build"
   },
-  "devDependencies": {
-    "babel-cli": "^6.8.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
-    "babel-plugin-transform-class-properties": "^6.18.0",
-    "babel-preset-stage-0": "^6.16.0",
-    "watch": "^0.18.0"
-  },
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/frog/.babelrc
+++ b/frog/.babelrc
@@ -1,10 +1,4 @@
 {
-	"presets": [
-		"meteor",
-		"es2015",
-		"stage-1"
-	],
-
 	"plugins": [
 		"transform-class-properties"
 	]

--- a/frog/package.json
+++ b/frog/package.json
@@ -6,7 +6,6 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "bcrypt": "^0.8.7",
     "chai": "^3.5.0",
     "check": "^1.0.0",
     "color-hash": "^1.0.3",

--- a/frog/package.json
+++ b/frog/package.json
@@ -20,11 +20,5 @@
     "react-dom": "^15.3.2",
     "react-fontawesome": "^1.3.1",
     "react-jsonschema-form": "^0.40.0"
-  },
-  "devDependencies": {
-    "babel-plugin-transform-class-properties": "^6.18.0",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-meteor": "^6.13.0",
-    "babel-preset-stage-1": "^6.16.0"
   }
 }

--- a/initial_setup.sh
+++ b/initial_setup.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 FROG=`pwd`
-
-yarn install
+YARN=yarn
+which yarn | grep -qw yarn || npm install yarn  
+which yarn | grep -qw yarn || YARN=$FROG/node_modules/.bin/yarn
+$YARN install
 
 # install package frog-utils
 cd $FROG/frog-utils
 mkdir -p node_modules
 ln -s $FROG/node_modules/* node_modules/
-yarn install
+$YARN install
 
 # install activities and operators packages
 for dir in $FROG/ac/ac-*/ $FROG/op/op-*/
@@ -16,7 +18,8 @@ do
     mkdir -p node_modules
     ln -s $FROG/node_modules/* node_modules/
     ln -s $FROG/frog-utils node_modules/
-    yarn install
+    $YARN install
+    npm run build &
 done
 
 # links all packages to the frog/ meteor project
@@ -24,10 +27,16 @@ cd $FROG/frog
 mkdir -p node_modules
 ln -s $FROG/node_modules/* node_modules/
 ln -s $FROG/frog-utils node_modules/
-for dir in `ls $FROG/ac |grep 'ac'` `ls $FROG/op |grep 'op'`
+
+for dir in `ls $FROG/ac |grep 'ac'` 
 do
-    ln -s $dir node_modules/
+    ln -s $FROG/ac/$dir node_modules/
 done
 
-yarn install
+for dir in `ls $FROG/op |grep 'op'`
+do
+    ln -s $FROG/op/$dir node_modules/
+done
+
+$YARN install
 

--- a/initial_setup.sh
+++ b/initial_setup.sh
@@ -1,26 +1,35 @@
 #!/bin/bash
 FROG=`pwd`
 
+yarn install
+
 # install package frog-utils
 cd $FROG/frog-utils
-npm install
-npm link
+mkdir -p node_modules
+ln -s $FROG/node_modules/* node_modules/
+yarn install
+yarn link
 
 # install activities and operators packages
 for dir in $FROG/ac/ac-*/ $FROG/op/op-*/
 do
     cd $dir
-    npm link frog-utils
-    npm install
-    npm link
+    mkdir -p node_modules
+    ln -s $FROG/node_modules/* node_modules/
+    yarn link frog-utils
+    yarn install
+    yarn link
 done
 
 # links all packages to the frog/ meteor project
 cd $FROG/frog
-npm link frog-utils
+mkdir -p node_modules
+ln -s $FROG/node_modules/* node_modules/
+yarn link frog-utils
 for dir in `ls $FROG/ac |grep 'ac'` `ls $FROG/op |grep 'op'`
 do
-    npm link $dir
+    yarn link $dir
 done
 
-npm install
+yarn install
+

--- a/initial_setup.sh
+++ b/initial_setup.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# include hidden files (like node_modules/.bin)
+shopt -s dotglob
+
 FROG=`pwd`
 YARN=yarn
 which yarn | grep -qw yarn || npm install yarn  

--- a/initial_setup.sh
+++ b/initial_setup.sh
@@ -8,7 +8,6 @@ cd $FROG/frog-utils
 mkdir -p node_modules
 ln -s $FROG/node_modules/* node_modules/
 yarn install
-yarn link
 
 # install activities and operators packages
 for dir in $FROG/ac/ac-*/ $FROG/op/op-*/
@@ -16,19 +15,18 @@ do
     cd $dir
     mkdir -p node_modules
     ln -s $FROG/node_modules/* node_modules/
-    yarn link frog-utils
+    ln -s $FROG/frog-utils node_modules/
     yarn install
-    yarn link
 done
 
 # links all packages to the frog/ meteor project
 cd $FROG/frog
 mkdir -p node_modules
 ln -s $FROG/node_modules/* node_modules/
-yarn link frog-utils
+ln -s $FROG/frog-utils node_modules/
 for dir in `ls $FROG/ac |grep 'ac'` `ls $FROG/op |grep 'op'`
 do
-    yarn link $dir
+    ln -s $dir node_modules/
 done
 
 yarn install

--- a/op/op-aggregate-ck-board/package.json
+++ b/op/op-aggregate-ck-board/package.json
@@ -8,12 +8,6 @@
     "watch": "watch 'npm run build' ./src",
     "prepublish": "npm run build"
   },
-  "devDependencies": {
-    "babel-cli": "^6.8.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
-    "watch": "^0.18.0"
-  },
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/op/op-aggregate-text/package.json
+++ b/op/op-aggregate-text/package.json
@@ -8,12 +8,6 @@
     "watch": "watch 'npm run build' ./src",
     "prepublish": "npm run build"
   },
-  "devDependencies": {
-    "babel-cli": "^6.8.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
-    "watch": "^0.18.0"
-  },
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/op/op-like-with-like/package.json
+++ b/op/op-like-with-like/package.json
@@ -8,12 +8,6 @@
     "watch": "watch 'npm run build' ./src",
     "prepublish": "npm run build"
   },
-  "devDependencies": {
-    "babel-cli": "^6.8.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
-    "watch": "^0.18.0"
-  },
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "frog-package",
+  "version": "1.0.0",
+  "devDependencies": {
+    "babel-cli": "^6.8.0",
+    "babel-plugin-transform-class-properties": "^6.18.0",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-es2017": "^6.16.0",
+    "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-0": "^6.16.0",
+    "watch": "^1.0.1"
+  },
+  "license": "ISC"
+}

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
     "babel-cli": "^6.18.0",
     "babel-plugin-transform-class-properties": "^6.19.0",
     "babel-preset-es2015": "^6.18.0",
-    "babel-preset-es2017": "^6.18.0",
+    "babel-preset-es2017": "^6.16.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
-    "watch": "^1.0.1"
+    "watch": "^1.0.1",
+    "yarn": "^0.17.8"
   },
   "license": "ISC"
 }

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "frog-package",
   "version": "1.0.0",
   "devDependencies": {
-    "babel-cli": "^6.8.0",
-    "babel-plugin-transform-class-properties": "^6.18.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-es2017": "^6.16.0",
-    "babel-preset-react": "^6.5.0",
+    "babel-cli": "^6.18.0",
+    "babel-plugin-transform-class-properties": "^6.19.0",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-es2017": "^6.18.0",
+    "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
     "watch": "^1.0.1"
   },


### PR DESCRIPTION
I reorganized the mono-repo to use yarn, and to only install the dev-dependencies once, and symlink them into all the other repositories. 

This approach takes 50 seconds, and results in a total size of 200 MB. The old approach takes 4 minutes, and generates 560 MB of data. Note that this will only increase once we add twenty more operators and activities etc :)

I couldn't figure out how to check for the presence of a binary, but this script should also work perfectly well with npm instead of yarn, so could you add a test that it uses npm if yarn is not installed?