### PR TITLE
TimedComponent

### DIFF
--- a/ac/ac-collab-form/src/dashboard.js
+++ b/ac/ac-collab-form/src/dashboard.js
@@ -17,7 +17,7 @@ const GroupView = ({ members, group }) => {
   )
 }
 
-const CollabForm = ( {logs, timeNow} ) => { 
+const Dashboard = ( {logs, timeNow} ) => { 
   const groups = groupBy(logs, x => x.group)
   return(
     <div>
@@ -26,4 +26,4 @@ const CollabForm = ( {logs, timeNow} ) => {
   )
 }
 
-export default TimedComponent(CollabForm)
+export default TimedComponent(Dashboard)

--- a/ac/ac-collab-form/src/dashboard.js
+++ b/ac/ac-collab-form/src/dashboard.js
@@ -19,7 +19,6 @@ const GroupView = ({ members, group }) => {
 
 const CollabForm = ( {logs, timeNow} ) => { 
   const groups = groupBy(logs, x => x.group)
-  console.log(logs, groups)
   return(
     <div>
       {map(groups, (v, k) => <GroupView members={v} group={k} key={k} timeNow={timeNow} />)}

--- a/ac/ac-collab-form/src/dashboard.js
+++ b/ac/ac-collab-form/src/dashboard.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { groupBy, map, some } from 'lodash'
-import {color_range as color} from 'frog-utils'
+import {color_range as color, TimedComponent} from 'frog-utils'
 
 const GroupView = ({ members, group }) => {
   const completed = some(members, x => x.completed) 
@@ -17,28 +17,14 @@ const GroupView = ({ members, group }) => {
   )
 }
 
-class CollabForm extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {}
-  }
-
-  componentDidMount() {
-    const interval = setInterval(() =>
-      this.forceUpdate(), 3000)
-    this.setState({interval: interval})
-  }
-
-  componentWillUnmount() {
-    window.clearInterval(this.state.interval)
-  }
-
-  render() {
-    const groups = groupBy(this.props.logs, x => x.group)
-    return(<div>
-      {map(groups, (v, k) => <GroupView members={v} group={k} key={k} />)}
-    </div>)
-  }
+const CollabForm = ( {logs, timeNow} ) => { 
+  const groups = groupBy(logs, x => x.group)
+  console.log(logs, groups)
+  return(
+    <div>
+      {map(groups, (v, k) => <GroupView members={v} group={k} key={k} timeNow={timeNow} />)}
+    </div>
+  )
 }
 
-export default CollabForm
+export default TimedComponent(CollabForm)

--- a/frog-utils/src/TimedComponent.js
+++ b/frog-utils/src/TimedComponent.js
@@ -1,0 +1,32 @@
+// wrap a React component and it will receive a prop called timeNow
+// updated every x milliseconds (default 3000)
+// for example export default TimedComponent(Clock)
+
+import React, { Component } from 'react'
+
+class TimedComponentClass extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {timeNow: Date.now()}
+  }
+
+  componentDidMount() {
+    const interval = setInterval(
+      () => this.setState({timeNow: Date.now()}), 
+      this.props.interval || 3000)
+    this.setState({interval: interval})
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.state.interval)
+  }
+
+  render() {
+    return (
+      <this.props.component timeNow={this.state.timeNow} {...this.props.props} />
+    )
+  }
+}
+
+export default (component, interval) => (props) => 
+  <TimedComponentClass component={component} interval={interval} props={props}/>

--- a/frog-utils/src/index.js
+++ b/frog-utils/src/index.js
@@ -1,6 +1,7 @@
 export { default as color_range } from './color_range'
 export { default as Chat } from './chat'
 export { default as unrollProducts } from './unroll_products'
+export { default as TimedComponent } from './TimedComponent'
 
 export const uuid = () =>
   ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g,a=>(a^Math.random()*16>>a/4).toString(16))

--- a/initial_setup.sh
+++ b/initial_setup.sh
@@ -5,7 +5,7 @@ shopt -s dotglob
 
 FROG=`pwd`
 YARN=yarn
-which yarn | grep -qw yarn || npm install yarn  
+which yarn | grep -qw yarn || npm install yarn@0.17.8
 which yarn | grep -qw yarn || YARN=$FROG/node_modules/.bin/yarn
 $YARN install
 

--- a/run_and_watch_all.sh
+++ b/run_and_watch_all.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+FROG=`pwd`
+
+cd $FROG/frog-utils
+npm run watch &
+
+for dir in $FROG/ac/ac-*/ $FROG/op/op-*/
+do
+    cd $dir
+    npm run watch &
+done
+
+cd $FROG/frog
+meteor
+


### PR DESCRIPTION
Assuming that we might have a number of components that need to regularly update, but don't otherwise require component lifecycle methods, this Higher-Order Component can wrap a pure component providing the timeNow prop, which will update at a regular interval, thus making repeated rendering very easy. This is currently used for a dashboard with fading colors, but could also be used for Khalil's orchestration clock, etc.