### PR TITLE
Fix paths

### DIFF
--- a/frog/imports/ui/GraphEditor/store/activity.js
+++ b/frog/imports/ui/GraphEditor/store/activity.js
@@ -1,9 +1,11 @@
 // @flow
+
 import { observable, computed, action } from 'mobx';
 import cuid from 'cuid';
 import { store } from './index';
 import Elem from './elemClass';
 import { timeToPx, pxToTime, timeToPxScreen, between } from '../utils';
+import type { AnchorT } from '../utils/path';
 import { calculateBounds } from './activityStore';
 import type { BoundsT } from './store';
 
@@ -163,7 +165,7 @@ export default class Activity extends Elem {
     };
   }
 
-  @computed get dragPointFromScaled(): [number, number] {
+  @computed get dragPointFromScaled(): AnchorT {
     return {
       X: this.xScaled + this.widthScaled - 15,
       Y: this.y + 15,
@@ -172,7 +174,7 @@ export default class Activity extends Elem {
     };
   }
 
-  @computed get dragPointToScaled(): [number, number] {
+  @computed get dragPointToScaled(): AnchorT {
     return {
       X: this.xScaled + 15,
       Y: this.y + 15,
@@ -181,7 +183,7 @@ export default class Activity extends Elem {
     };
   }
 
-  @computed get dragPointFrom(): [number, number] {
+  @computed get dragPointFrom(): AnchorT {
     return {
       X: this.x + this.width - 15,
       Y: this.y + 15,
@@ -190,7 +192,7 @@ export default class Activity extends Elem {
     };
   }
 
-  @computed get dragPointTo(): [number, number] {
+  @computed get dragPointTo(): AnchorT {
     return {
       X: this.x + 15,
       Y: this.y + 15,

--- a/frog/imports/ui/GraphEditor/store/activity.js
+++ b/frog/imports/ui/GraphEditor/store/activity.js
@@ -164,19 +164,39 @@ export default class Activity extends Elem {
   }
 
   @computed get dragPointFromScaled(): [number, number] {
-    return [this.xScaled + this.widthScaled - 15, this.y + 15];
+    return {
+      X: this.xScaled + this.widthScaled - 15,
+      Y: this.y + 15,
+      dX: 50,
+      dY: 0
+    };
   }
 
   @computed get dragPointToScaled(): [number, number] {
-    return [this.xScaled + 15, this.y + 15];
+    return {
+      X: this.xScaled + 15,
+      Y: this.y + 15,
+      dX: -50,
+      dY: 0
+    };
   }
 
   @computed get dragPointFrom(): [number, number] {
-    return [this.x + this.width - 15, this.y + 15];
+    return {
+      X: this.x + this.width - 15,
+      Y: this.y + 15,
+      dX: 50,
+      dY: 0
+    };
   }
 
   @computed get dragPointTo(): [number, number] {
-    return [this.x + 15, this.y + 15];
+    return {
+      X: this.x + 15,
+      Y: this.y + 15,
+      dX: -50,
+      dY: 0
+    };
   }
 
   @computed get bounds(): BoundsT {

--- a/frog/imports/ui/GraphEditor/store/activity.js
+++ b/frog/imports/ui/GraphEditor/store/activity.js
@@ -126,7 +126,10 @@ export default class Activity extends Elem {
   }
 
   @action onOver = () => this.over = true;
-  @action onLeave = () => this.over = false;
+
+  @action onLeave = () => {
+    this.over = false;
+  };
 
   @action setRename = () => {
     store.state = {

--- a/frog/imports/ui/GraphEditor/store/connection.js
+++ b/frog/imports/ui/GraphEditor/store/connection.js
@@ -38,14 +38,17 @@ export default class Connection extends Elem {
   }
 
   @computed get path(): string {
-    return drawPath(...this.source.dragPointFrom, ...this.target.dragPointTo);
+    return drawPath({
+      source: this.source.dragPointFrom,
+      target: this.target.dragPointTo
+    });
   }
 
   @computed get pathScaled(): string {
-    return drawPath(
-      ...this.source.dragPointFromScaled,
-      ...this.target.dragPointToScaled
-    );
+    return drawPath({
+      source: this.source.dragPointFromScaled,
+      target: this.target.dragPointToScaled
+    });
   }
 
   @computed get object(): Object {

--- a/frog/imports/ui/GraphEditor/store/connection.js
+++ b/frog/imports/ui/GraphEditor/store/connection.js
@@ -1,4 +1,5 @@
 // @flow
+
 import cuid from 'cuid';
 import { observable, action, computed } from 'mobx';
 import { drawPath } from '../utils/path';
@@ -39,6 +40,7 @@ export default class Connection extends Elem {
 
   @computed get path(): string {
     return drawPath({
+      dragging: false,
       source: this.source.dragPointFrom,
       target: this.target.dragPointTo
     });
@@ -46,6 +48,7 @@ export default class Connection extends Elem {
 
   @computed get pathScaled(): string {
     return drawPath({
+      dragging: false,
       source: this.source.dragPointFromScaled,
       target: this.target.dragPointToScaled
     });

--- a/frog/imports/ui/GraphEditor/store/connectionStore.js
+++ b/frog/imports/ui/GraphEditor/store/connectionStore.js
@@ -22,7 +22,9 @@ export default class ConnectionStore {
       source: store.state.draggingFrom.dragPointFromScaled,
       target: {
         X: store.ui.socialCoordsScaled[0],
-        Y: store.ui.socialCoordsScaled[1]
+        Y: store.ui.socialCoordsScaled[1],
+        dX: 0,
+        dY: 0
       }
     });
   }

--- a/frog/imports/ui/GraphEditor/store/connectionStore.js
+++ b/frog/imports/ui/GraphEditor/store/connectionStore.js
@@ -17,10 +17,14 @@ export default class ConnectionStore {
     if (store.state.mode !== 'dragging') {
       return null;
     }
-    return drawPath(
-      ...store.state.draggingFrom.dragPointFromScaled,
-      ...store.ui.socialCoordsScaled
-    );
+    return drawPath({
+      dragging: true,
+      source: store.state.draggingFrom.dragPointFromScaled,
+      target: {
+        X: store.ui.socialCoordsScaled[0],
+        Y: store.ui.socialCoordsScaled[1]
+      }
+    });
   }
 
   @action startDragging = (elem: Activity | Operator): void => {

--- a/frog/imports/ui/GraphEditor/store/operator.js
+++ b/frog/imports/ui/GraphEditor/store/operator.js
@@ -91,20 +91,42 @@ export default class Operator extends Elem {
 
   @computed get dragPointTo(): [number, number] {
     // operator has size of 60, finding midpoint
-    return [this.x + 25, this.y + 25];
+    return {
+      X: this.x + 25,
+      Y: this.y + 25,
+      dX: -150,
+      dY: 0
+    };
   }
 
   @computed get dragPointFrom(): [number, number] {
-    return this.dragPointTo;
+    // operator has size of 60, finding midpoint
+    return {
+      X: this.x + 25,
+      Y: this.y + 25,
+      dX: 150,
+      dY: 0
+    };
   }
 
   @computed get dragPointToScaled(): [number, number] {
     // operator has size of 60, finding midpoint
-    return [this.xScaled + 25, this.y + 25];
+    return {
+      X: this.xScaled + 25,
+      Y: this.y + 25,
+      dX: -150,
+      dY: 0
+    };
   }
 
   @computed get dragPointFromScaled(): [number, number] {
-    return this.dragPointToScaled;
+    // operator has size of 60, finding midpoint
+    return {
+      X: this.xScaled + 25,
+      Y: this.y + 25,
+      dX: 150,
+      dY: 0
+    };
   }
 
   @action update = (newopt: $Shape<Operator>) => {

--- a/frog/imports/ui/GraphEditor/store/operator.js
+++ b/frog/imports/ui/GraphEditor/store/operator.js
@@ -4,6 +4,7 @@ import { observable, action, computed } from 'mobx';
 import { store } from './index';
 import Elem from './elemClass';
 import { pxToTime, timeToPx } from '../utils';
+import type { AnchorT } from '../utils/path';
 
 export default class Operator extends Elem {
   id: string;
@@ -89,7 +90,7 @@ export default class Operator extends Elem {
     };
   }
 
-  @computed get dragPointTo(): [number, number] {
+  @computed get dragPointTo(): AnchorT {
     // operator has size of 60, finding midpoint
     return {
       X: this.x + 25,
@@ -99,7 +100,7 @@ export default class Operator extends Elem {
     };
   }
 
-  @computed get dragPointFrom(): [number, number] {
+  @computed get dragPointFrom(): AnchorT {
     // operator has size of 60, finding midpoint
     return {
       X: this.x + 25,
@@ -109,7 +110,7 @@ export default class Operator extends Elem {
     };
   }
 
-  @computed get dragPointToScaled(): [number, number] {
+  @computed get dragPointToScaled(): AnchorT {
     // operator has size of 60, finding midpoint
     return {
       X: this.xScaled + 25,
@@ -119,7 +120,7 @@ export default class Operator extends Elem {
     };
   }
 
-  @computed get dragPointFromScaled(): [number, number] {
+  @computed get dragPointFromScaled(): AnchorT {
     // operator has size of 60, finding midpoint
     return {
       X: this.xScaled + 25,

--- a/frog/imports/ui/GraphEditor/store/operator.js
+++ b/frog/imports/ui/GraphEditor/store/operator.js
@@ -91,7 +91,7 @@ export default class Operator extends Elem {
 
   @computed get dragPointTo(): [number, number] {
     // operator has size of 60, finding midpoint
-    return [this.x + 30, this.y + 30];
+    return [this.x + 25, this.y + 25];
   }
 
   @computed get dragPointFrom(): [number, number] {
@@ -100,7 +100,7 @@ export default class Operator extends Elem {
 
   @computed get dragPointToScaled(): [number, number] {
     // operator has size of 60, finding midpoint
-    return [this.xScaled + 30, this.y + 30];
+    return [this.xScaled + 25, this.y + 25];
   }
 
   @computed get dragPointFromScaled(): [number, number] {

--- a/frog/imports/ui/GraphEditor/utils/path.js
+++ b/frog/imports/ui/GraphEditor/utils/path.js
@@ -6,7 +6,7 @@ export const drawPath = (startX, startY, endX, endY) => {
   const o = 5;
   return ['M', startX, startY, 'C '].join(' ') +
     // distinguish the case when the two elements are close to each other
-    (Math.abs(startY - endY) + Math.abs(startX - endX) < 100
+    (Math.abs(startY - endY) < 100
       ? [startX - q, startY - q, endX + q, endY - q, endX - o, endY]
       : [startX + d, startY, endX - o - d, endY, endX - o, endY]).join(' ');
 };

--- a/frog/imports/ui/GraphEditor/utils/path.js
+++ b/frog/imports/ui/GraphEditor/utils/path.js
@@ -1,12 +1,24 @@
-export const drawPath = (startX, startY, endX, endY) => {
+export const drawPath = ({ dragging, source, target }) => {
   // parameters for the curviness of the connections
-  const d = 150;
   const q = 50;
   // parameter for the over bug (mouse can be over the connection while it is also over the activity, so onleave tiggers wrongly)
   const o = 5;
-  return ['M', startX, startY, 'C '].join(' ') +
-    // distinguish the case when the two elements are close to each other
-    (Math.abs(startY - endY) < 100
-      ? [startX - q, startY - q, endX + q, endY - q, endX - o, endY]
-      : [startX + d, startY, endX - o - d, endY, endX - o, endY]).join(' ');
+
+  if (dragging) {
+    return ['M', source.X, source.Y, 'L', target.X - o, target.Y].join(' ');
+  }
+
+  return ['M', source.X, source.Y, 'C']
+    .concat(
+      Math.abs(source.Y - target.Y) < 5
+        ? [source.X - q, source.Y - q, target.X + q, target.Y - q]
+        : [
+            source.X + source.dX,
+            source.Y + source.dY,
+            target.X + target.dX,
+            target.Y + target.dY
+          ]
+    )
+    .concat([target.X, target.Y])
+    .join(' ');
 };

--- a/frog/imports/ui/GraphEditor/utils/path.js
+++ b/frog/imports/ui/GraphEditor/utils/path.js
@@ -1,4 +1,19 @@
-export const drawPath = ({ dragging, source, target }) => {
+// @flow
+
+export type AnchorT = {
+  X: number,
+  Y: number,
+  dX: number,
+  dY: number
+};
+
+export const drawPath = (
+  {
+    dragging,
+    source,
+    target
+  }: { dragging: boolean, source: AnchorT, target: AnchorT }
+) => {
   // parameters for the curviness of the connections
   const q = 50;
   // parameter for the over bug (mouse can be over the connection while it is also over the activity, so onleave tiggers wrongly)

--- a/frog/imports/ui/GraphEditor/utils/path.js
+++ b/frog/imports/ui/GraphEditor/utils/path.js
@@ -1,105 +1,12 @@
-/* eslint-disable */
-const calcPath = (startX, startY, endX, endY) => {
-  const bb1 = { x: startX, y: startY, width: 0, height: 0 };
-  const bb2 = { y: endY, x: endX, width: 0, height: 0 };
-  const p = [
-    { x: bb1.x + bb1.width / 2, y: bb1.y - 1 },
-    { x: bb1.x + bb1.width / 2, y: bb1.y + bb1.height + 1 },
-    { x: bb1.x - 1, y: bb1.y + bb1.height / 2 },
-    { x: bb1.x + bb1.width + 1, y: bb1.y + bb1.height / 2 },
-    { x: bb2.x + bb2.width / 2, y: bb2.y - 1 },
-    { x: bb2.x + bb2.width / 2, y: bb2.y + bb2.height + 1 },
-    { x: bb2.x - 1, y: bb2.y + bb2.height / 2 },
-    { x: bb2.x + bb2.width + 1, y: bb2.y + bb2.height / 2 }
-  ],
-    d = {},
-    dis = [];
-  for (var i = 0; i < 4; i++) {
-    for (var j = 4; j < 8; j++) {
-      var dx = Math.abs(p[i].x - p[j].x), dy = Math.abs(p[i].y - p[j].y);
-      if (
-        i === j - 4 ||
-          (i !== 3 && j !== 6 || p[i].x < p[j].x) &&
-            (i !== 2 && j !== 7 || p[i].x > p[j].x) &&
-            (i !== 0 && j !== 5 || p[i].y > p[j].y) &&
-            (i !== 1 && j !== 4 || p[i].y < p[j].y)
-      ) {
-        dis.push(dx + dy);
-        d[dis[dis.length - 1]] = [ i, j ];
-      }
-    }
-  }
-  if (dis.length === 0) {
-    var res = [ 0, 4 ];
-  } else {
-    res = d[Math.min.apply(Math, dis)];
-  }
-  var x1 = p[res[0]].x, y1 = p[res[0]].y, x4 = p[res[1]].x, y4 = p[res[1]].y;
-  dx = Math.max(Math.abs(x1 - x4) / 2, 10);
-  dy = Math.max(Math.abs(y1 - y4) / 2, 10);
-  var x2 = [ x1, x1, x1 - dx, x1 + dx ][res[0]].toFixed(3),
-    y2 = [ y1 - dy, y1 + dy, y1, y1 ][res[0]].toFixed(3),
-    x3 = [ 0, 0, 0, 0, x4, x4, x4 - dx, x4 + dx ][res[1]].toFixed(3),
-    y3 = [ 0, 0, 0, 0, y1 + dy, y1 - dy, y4, y4 ][res[1]].toFixed(3);
-  var path = [
-    "M",
-    x1.toFixed(3),
-    y1.toFixed(3),
-    "C",
-    x2,
-    y2,
-    x3,
-    y3,
-    x4.toFixed(3),
-    y4.toFixed(3)
-  ].join(" ");
-  return path;
-};
-
 export const drawPath = (startX, startY, endX, endY) => {
-  // if (endX - startX > 30) {
-  //   let newstartX;
-  //   let newstartY;
-  //   if (startY < endY) {
-  //     newstartX = startX - 5;
-  //     newstartY = startY + 13;
-  //   } else if (startY >= endY) {
-  //     newstartX = startX - 5;
-  //     newstartY = startY - 13;
-  //   } else {
-  //     newstartX = startX;
-  //     newstartY = startY;
-  //   }
-
-  //   if (startY - endY >= 50) {
-  //     return [
-  //       calcPath(newstartX, newstartY, newstartX + 15, newstartY - 20),
-  //       calcPath(newstartX + 13, newstartY - 20, endX - 18, endY + 33),
-  //       calcPath(endX - 20, endY + 33, endX + 5, endY + 13)
-  //     ].join(" ");
-  //   }
-  //   if (Math.abs(startY - endY) < 50) {
-  //     return [
-  //       calcPath(newstartX, newstartY, newstartX + 15, newstartY - 20),
-  //       calcPath(newstartX + 13, newstartY - 20, endX - 25, newstartY - 20),
-  //       calcPath(endX - 27, newstartY - 20, endX + 5, endY - 13)
-  //     ].join(" ");
-  //   }
-  //   if (endY - startY >= 50) {
-  //     return [
-  //       calcPath(newstartX, newstartY, newstartX + 15, newstartY + 20),
-  //       calcPath(newstartX + 13, newstartY + 20, endX - 18, endY - 33),
-  //       calcPath(endX - 20, endY - 33, endX + 5, endY - 13)
-  //     ].join(" ");
-  //   }
-  // }
-
-  // // bubble for boxes that are too close
-  // if (endX - startX < 30 && endY === startY) {
-  //   const middle = (endX - startX) / 2 + startX;
-  //   return `M${startX}, ${startY} C${middle -
-  //     50}, ${startY - 50} ${middle + 50}, ${startY - 50} ${endX}, ${endY}`;
-  // }
-
-  return calcPath(startX, startY, endX, endY);
+  // parameters for the curviness of the connections
+  const d = 150;
+  const q = 50;
+  // parameter for the over bug (mouse can be over the connection while it is also over the activity, so onleave tiggers wrongly)
+  const o = 5;
+  return ['M', startX, startY, 'C '].join(' ') +
+    // distinguish the case when the two elements are close to each other
+    (Math.abs(startY - endY) + Math.abs(startX - endX) < 100
+      ? [startX - q, startY - q, endX + q, endY - q, endX - o, endY]
+      : [startX + d, startY, endX - o - d, endY, endX - o, endY]).join(' ');
 };


### PR DESCRIPTION
#81 #92 

Draw connections in a way that makes clear inputs and outputs for our dataflow

## comments
- The mouseOver bug on activities was due to the mouse mouse being over the connection and not over the activity. Thus the weird behavior of removing the highlight when the mouse goes backward.

- I tried drawing connections on top of activities, but it looks bad.

- The curves drawn by the `<path>` are bezier curves. They take 4 points to be described, starting point, endpoint and direction of start and direction of end (image from wikipedia). 

![bezier](https://cloud.githubusercontent.com/assets/8818081/23906318/e31aa8e0-08cd-11e7-88fc-09e9deca37c5.png)

