### PR TITLE
Fix graph movement

### DIFF
--- a/frog/imports/ui/GraphEditor/Activities.js
+++ b/frog/imports/ui/GraphEditor/Activities.js
@@ -43,7 +43,6 @@ const Activity = connect((
       onMouseLeave={activity.onLeave}
       onDoubleClick={activity.setRename}
       onClick={activity.select}
-      style={{ opacity: 1 - activity.fade }}
     >
       <Box
         x={x}
@@ -51,7 +50,6 @@ const Activity = connect((
         width={width}
         highlighted={activity.highlighted}
         selected={activity.selected}
-        fade={activity.fade}
       />
       <svg style={{ overflow: 'hidden' }} width={width + x - 20}>
         <text x={x + 3} y={activity.y + 20}>

--- a/frog/imports/ui/GraphEditor/Activities.js
+++ b/frog/imports/ui/GraphEditor/Activities.js
@@ -106,7 +106,6 @@ const Activity = connect((
           style={{ cursor: 'move' }}
         />
       </DraggableCore>
-
     </g>
   );
 });

--- a/frog/imports/ui/GraphEditor/Activities.js
+++ b/frog/imports/ui/GraphEditor/Activities.js
@@ -43,6 +43,7 @@ const Activity = connect((
       onMouseLeave={activity.onLeave}
       onDoubleClick={activity.setRename}
       onClick={activity.select}
+      style={{ opacity: 1 - activity.fade }}
     >
       <Box
         x={x}
@@ -50,6 +51,7 @@ const Activity = connect((
         width={width}
         highlighted={activity.highlighted}
         selected={activity.selected}
+        fade={activity.fade}
       />
       <svg style={{ overflow: 'hidden' }} width={width + x - 20}>
         <text x={x + 3} y={activity.y + 20}>
@@ -106,6 +108,7 @@ const Activity = connect((
           style={{ cursor: 'move' }}
         />
       </DraggableCore>
+
     </g>
   );
 });

--- a/frog/imports/ui/GraphEditor/store/activity.js
+++ b/frog/imports/ui/GraphEditor/store/activity.js
@@ -3,7 +3,7 @@ import { observable, computed, action } from 'mobx';
 import cuid from 'cuid';
 import { store } from './index';
 import Elem from './elemClass';
-import { timeToPx, pxToTime, timeToPxScreen, between } from '../utils';
+import { timeToPx, timeToPxScreen, between } from '../utils';
 import { calculateBounds } from './activityStore';
 import type { BoundsT } from './store';
 
@@ -110,14 +110,14 @@ export default class Activity extends Elem {
     }
   };
 
-  @action resize(deltax: number) {
+  @action resize() {
     const state = store.state;
     if (state.mode === 'resizing') {
-      const deltaTime = pxToTime(deltax, store.ui.scale);
+      const newTime = Math.round(store.ui.socialCoordsTime[0]);
       this.length = between(
         1,
         state.bounds.rightBoundTime - this.startTime,
-        this.length + deltaTime
+        newTime - this.startTime
       );
     }
   }

--- a/frog/imports/ui/GraphEditor/store/activity.js
+++ b/frog/imports/ui/GraphEditor/store/activity.js
@@ -22,7 +22,6 @@ export default class Activity extends Elem {
     this.length = length;
     this.startTime = startTime;
     this.klass = 'activity';
-    this.fade = 0;
   };
 
   constructor(
@@ -39,7 +38,6 @@ export default class Activity extends Elem {
   plane: number;
   klass: string;
   id: string;
-  @observable fade: number;
   @observable over: boolean;
   @observable title: string;
   @observable length: number;
@@ -94,22 +92,11 @@ export default class Activity extends Elem {
           state.mouseOffset -
           this.startTime;
 
-        const fade = Math.min(Math.abs(overdrag) / 2, 1);
         if (
           this.startTime === this.bounds.leftBoundTime ||
           this.startTime + this.length === this.bounds.rightBoundTime
         ) {
-          console.log(overdrag, fade);
-          if (overdrag < 0 && this.bounds.leftBoundActivity) {
-            this.bounds.leftBoundActivity.fade = fade;
-          }
-
-          if (overdrag > 0 && this.bounds.rightBoundActivity) {
-            this.bounds.rightBoundActivity.fade = fade;
-          }
-
           if (overdrag < -2 && this.bounds.leftBoundActivity) {
-            this.bounds.leftBoundActivity.fade = 0;
             store.activityStore.swapActivities(
               this.bounds.leftBoundActivity,
               this
@@ -118,19 +105,11 @@ export default class Activity extends Elem {
           }
 
           if (overdrag > 2 && this.bounds.rightBoundActivity) {
-            this.bounds.rightBoundActivity.fade = 0;
             store.activityStore.swapActivities(
               this,
               this.bounds.rightBoundActivity
             );
             store.state = { mode: 'waitingDrag' };
-          }
-        } else {
-          if (this.bounds.leftBoundActivity) {
-            this.bounds.leftBoundActivity.fade = fade;
-          }
-          if (this.bounds.rightBoundActivity) {
-            this.bounds.rightBoundActivity.fade = fade;
           }
         }
       }

--- a/frog/imports/ui/GraphEditor/store/activity.js
+++ b/frog/imports/ui/GraphEditor/store/activity.js
@@ -1,5 +1,5 @@
 // @flow
-import { observable, computed, action, reaction } from 'mobx';
+import { observable, computed, action } from 'mobx';
 import cuid from 'cuid';
 import { store } from './index';
 import Elem from './elemClass';
@@ -81,36 +81,30 @@ export default class Activity extends Elem {
       if (store.overlapAllowed) {
         this.startTime = between(0, 120 - this.length, newTime);
       } else {
-        const newStartTime = between(
+        this.startTime = between(
           this.bounds.leftBoundTime,
           this.bounds.rightBoundTime - this.length,
           newTime
         );
 
-        this.startTime = newStartTime;
         const overdrag = store.ui.socialCoordsTime[0] -
           state.mouseOffset -
           this.startTime;
 
-        if (
-          this.startTime === this.bounds.leftBoundTime ||
-          this.startTime + this.length === this.bounds.rightBoundTime
-        ) {
-          if (overdrag < -2 && this.bounds.leftBoundActivity) {
-            store.activityStore.swapActivities(
-              this.bounds.leftBoundActivity,
-              this
-            );
-            store.state = { mode: 'waitingDrag' };
-          }
+        if (overdrag < -2 && this.bounds.leftBoundActivity) {
+          store.activityStore.swapActivities(
+            this.bounds.leftBoundActivity,
+            this
+          );
+          store.state = { mode: 'waitingDrag' };
+        }
 
-          if (overdrag > 2 && this.bounds.rightBoundActivity) {
-            store.activityStore.swapActivities(
-              this,
-              this.bounds.rightBoundActivity
-            );
-            store.state = { mode: 'waitingDrag' };
-          }
+        if (overdrag > 2 && this.bounds.rightBoundActivity) {
+          store.activityStore.swapActivities(
+            this,
+            this.bounds.rightBoundActivity
+          );
+          store.state = { mode: 'waitingDrag' };
         }
       }
     }

--- a/frog/imports/ui/GraphEditor/store/activityStore.js
+++ b/frog/imports/ui/GraphEditor/store/activityStore.js
@@ -88,6 +88,7 @@ export default class ActivityStore {
     store.state = {
       mode: 'moving',
       currentActivity: activity,
+      mouseOffset: store.ui.socialCoordsTime[0] - activity.startTime,
       bounds
     };
     activity.overdrag = 0;

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -28,8 +28,9 @@ type StateT =
   | {
       mode: 'moving',
       currentActivity: typeof Activity,
-      bounds: BoundsT
+      mouseOffset: number
     }
+  | { mode: 'waitingDrag' }
   | { mode: 'movingOperator', currentOperator: typeof Operator }
   | { mode: 'dragging', draggingFrom: typeof Activity | typeof Operator }
   | { mode: 'placingOperator', operatorType: OperatorTypes }

--- a/frog/imports/ui/GraphEditor/utils/index.js
+++ b/frog/imports/ui/GraphEditor/utils/index.js
@@ -9,11 +9,8 @@ export const timeToPxScreen = (time: number): number =>
   time * 3900 * store.ui.scale / 120 - store.ui.panx * 4 * store.ui.scale;
 
 export const between = (
-  rawminval: number,
-  rawmaxval: number,
+  minval: number = 0,
+  maxval: number = 9999999,
   x: number
-): number => {
-  const minval = rawminval == null ? 0 : rawminval;
-  const maxval = rawmaxval == null ? 99999 : rawmaxval;
-  return Math.min(Math.max(x, minval), maxval);
-};
+): number =>
+  Math.min(Math.max(x, minval), maxval);

--- a/frog/imports/ui/GraphEditor/utils/index.js
+++ b/frog/imports/ui/GraphEditor/utils/index.js
@@ -13,7 +13,7 @@ export const between = (
   rawmaxval: number,
   x: number
 ): number => {
-  const minval = rawminval || 0;
-  const maxval = rawmaxval || 99999;
+  const minval = rawminval == null ? 0 : rawminval;
+  const maxval = rawmaxval == null ? 99999 : rawmaxval;
   return Math.min(Math.max(x, minval), maxval);
 };


### PR DESCRIPTION
Graph startTime is always an integer (not float), which should help with activity alignment. Activities should not be above each other when they don't need to, and dragging activities "across" (swap) should work better. The activity swap still needs better UI feedback, but at least it should be fully functional.