### PR TITLE
This fixes some bugs with keyboard shortcuts

### DIFF
--- a/frog/imports/ui/GraphEditor/Graph.js
+++ b/frog/imports/ui/GraphEditor/Graph.js
@@ -75,30 +75,3 @@ export default connect((
       <ScrollFields width={width} height={height} />}
   </svg>
 ));
-
-const keyDown = e => {
-  console.log(e);
-  if (store.mode === 'rename') {
-    return;
-  }
-  if (e.ctrlKey || e.altKey || e.metaKey || e.shiftKey) {
-    return;
-  }
-  if (e.keyCode === 27) {
-    // esc
-    store.ui.cancelAll();
-    store.ui.unselect();
-  }
-  if (e.keyCode === 8) {
-    // backspace
-    store.deleteSelected();
-  }
-  if (e.keyCode === 83) {
-    // s - social operator
-    store.operatorStore.place('social');
-  }
-  if (e.keyCode === 80) {
-    // p - product operator
-    store.operatorStore.place('product');
-  }
-};

--- a/frog/imports/ui/GraphEditor/Graph.js
+++ b/frog/imports/ui/GraphEditor/Graph.js
@@ -27,7 +27,8 @@ export default connect((
       ui: {
         scale,
         scrollEnabled,
-        canvasClick
+        canvasClick,
+        setOverGraph
       }
     },
     width,
@@ -42,6 +43,8 @@ export default connect((
     width={width}
     height={height}
     onMouseMove={mousemove}
+    onMouseOver={() => !hasPanMap && setOverGraph(true)}
+    onMouseLeave={() => !hasPanMap && setOverGraph(false)}
     onWheel={scrollMouse}
     onClick={canvasClick}
   >
@@ -72,3 +75,30 @@ export default connect((
       <ScrollFields width={width} height={height} />}
   </svg>
 ));
+
+const keyDown = e => {
+  console.log(e);
+  if (store.mode === 'rename') {
+    return;
+  }
+  if (e.ctrlKey || e.altKey || e.metaKey || e.shiftKey) {
+    return;
+  }
+  if (e.keyCode === 27) {
+    // esc
+    store.ui.cancelAll();
+    store.ui.unselect();
+  }
+  if (e.keyCode === 8) {
+    // backspace
+    store.deleteSelected();
+  }
+  if (e.keyCode === 83) {
+    // s - social operator
+    store.operatorStore.place('social');
+  }
+  if (e.keyCode === 80) {
+    // p - product operator
+    store.operatorStore.place('product');
+  }
+};

--- a/frog/imports/ui/GraphEditor/index.js
+++ b/frog/imports/ui/GraphEditor/index.js
@@ -9,6 +9,11 @@ import EditorContainer from './EditorContainer';
 export default class AppClass extends Component {
   componentWillMount() {
     store.setId(assignGraph());
+    window.addEventListener('keydown', keyDown);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('keydown', keyDown);
   }
 
   render() {
@@ -21,3 +26,38 @@ export default class AppClass extends Component {
     );
   }
 }
+
+const keyDown = e => {
+  if (
+    !store.ui.overGraph ||
+    store.mode === 'rename' ||
+    e.ctrlKey ||
+    e.altKey ||
+    e.metaKey ||
+    e.shiftKey
+  ) {
+    return;
+  }
+
+  if (e.keyCode === 27) {
+    // esc
+    e.preventDefault();
+    store.ui.cancelAll();
+    store.ui.unselect();
+  }
+  if (e.keyCode === 8) {
+    // backspace
+    e.preventDefault();
+    store.deleteSelected();
+  }
+  if (e.keyCode === 83) {
+    // s - social operator
+    e.preventDefault();
+    store.operatorStore.place('social');
+  }
+  if (e.keyCode === 80) {
+    // p - product operator
+    e.preventDefault();
+    store.operatorStore.place('product');
+  }
+};

--- a/frog/imports/ui/GraphEditor/index.js
+++ b/frog/imports/ui/GraphEditor/index.js
@@ -9,11 +9,6 @@ import EditorContainer from './EditorContainer';
 export default class AppClass extends Component {
   componentWillMount() {
     store.setId(assignGraph());
-    window.addEventListener('keydown', keyDown);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('keydown', keyDown);
   }
 
   render() {
@@ -26,29 +21,3 @@ export default class AppClass extends Component {
     );
   }
 }
-
-const keyDown = e => {
-  if (store.mode === 'rename') {
-    return;
-  }
-  if (e.ctrlKey || e.altKey || e.metaKey || e.shiftKey) {
-    return;
-  }
-  if (e.keyCode === 27) {
-    // esc
-    store.ui.cancelAll();
-    store.ui.unselect();
-  }
-  if (e.keyCode === 8) {
-    // backspace
-    store.deleteSelected();
-  }
-  if (e.keyCode === 83) {
-    // s - social operator
-    store.operatorStore.place('social');
-  }
-  if (e.keyCode === 80) {
-    // p - product operator
-    store.operatorStore.place('product');
-  }
-};

--- a/frog/imports/ui/GraphEditor/index.js
+++ b/frog/imports/ui/GraphEditor/index.js
@@ -30,7 +30,7 @@ export default class AppClass extends Component {
 const keyDown = e => {
   if (
     !store.ui.overGraph ||
-    store.mode === 'rename' ||
+    store.state.mode === 'rename' ||
     e.ctrlKey ||
     e.altKey ||
     e.metaKey ||

--- a/frog/imports/ui/GraphEditor/store/uiStore.js
+++ b/frog/imports/ui/GraphEditor/store/uiStore.js
@@ -10,16 +10,27 @@ export default class uiStore {
   @observable panx: number;
   @observable scale: number;
   @observable selected: ?Elem;
-
-  @action unselect() {
-    this.selected = null;
-  }
+  @observable animatingPaths: Boolean;
+  @observable overGraph: Boolean;
 
   rawMouseToTime = (rawX: number, rawY: number): [number, number] => {
     const x = pxToTime(rawX - constants.GRAPH_LEFT, this.scale) + this.panTime;
     const y = rawY - constants.GRAPH_TOP;
     return [x, y];
   };
+
+  @action unselect() {
+    this.selected = null;
+  }
+
+  @action setAnimatingPaths = (set: Boolean) => {
+    this.animatingPaths = set;
+  };
+
+  @action setOverGraph = (set: Boolean) => {
+    this.overGraph = set;
+  };
+
   @action cancelAll = () => {
     this.selected = undefined;
     store.state = { mode: 'normal' };

--- a/frog/imports/ui/GraphEditor/store/uiStore.js
+++ b/frog/imports/ui/GraphEditor/store/uiStore.js
@@ -10,7 +10,6 @@ export default class uiStore {
   @observable panx: number;
   @observable scale: number;
   @observable selected: ?Elem;
-  @observable animatingPaths: Boolean;
   @observable overGraph: Boolean;
 
   rawMouseToTime = (rawX: number, rawY: number): [number, number] => {
@@ -22,10 +21,6 @@ export default class uiStore {
   @action unselect() {
     this.selected = null;
   }
-
-  @action setAnimatingPaths = (set: Boolean) => {
-    this.animatingPaths = set;
-  };
 
   @action setOverGraph = (set: Boolean) => {
     this.overGraph = set;


### PR DESCRIPTION
- Only allows keyboard shortcuts while mouse is over main graph (not minimap)
- Filters keyboard shortcuts with Cmd etc (to avoid Cmd-P for printing triggering operator)
- Avoid default, to avoid both creating operator and entering into the rename field, if rename field is active