### PR TITLE
Making it possible to create read only graph store

### DIFF
--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -49,13 +49,27 @@ const getOneId = (coll: Coll, id: string): Elem =>
   getOne(coll, x => x.id === id);
 
 export default class Store {
-  @observable state: StateT = { mode: 'normal' };
+  @observable _state: StateT;
   @observable connectionStore = new ConnectionStore();
   @observable activityStore = new ActivityStore();
   @observable operatorStore = new OperatorStore();
   @observable ui = new UI();
   @observable graphId: string = '';
   @observable history = [];
+
+  constructor(readOnly) {
+    this.readOnly = readOnly;
+  }
+
+  set state(newState: StateT) {
+    if (!this.readOnly) {
+      this._state = newState;
+    }
+  }
+
+  @computed get state(): StateT {
+    return this._state || { mode: 'normal' };
+  }
 
   findId = ({ type, id }: { type: ElementTypes, id: string }): Elem => {
     if (type === 'activity') {

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -56,18 +56,16 @@ export default class Store {
   @observable ui = new UI();
   @observable graphId: string = '';
   @observable history = [];
-
-  constructor(readOnly) {
-    this.readOnly = readOnly;
-  }
+  @observable readOnly: Boolean;
 
   set state(newState: StateT) {
-    if (!this.readOnly) {
-      this._state = newState;
-    }
+    this._state = newState;
   }
 
   @computed get state(): StateT {
+    if (this.readOnly) {
+      return { mode: 'readOnly' };
+    }
     return this._state || { mode: 'normal' };
   }
 
@@ -94,8 +92,9 @@ export default class Store {
     }
   };
 
-  @action setId = (id: string): void => {
+  @action setId = (id: string, readOnly?: Boolean = false): void => {
     setCurrentGraph(id);
+    this.readOnly = readOnly;
     this.graphId = id;
     this.activityStore.all = Activities
       .find({ graphId: id }, { reactive: false })


### PR DESCRIPTION
I turned state into a setter and getter, which checks whether store is read-only or not. All actions check whether
they are in the correct "mode", so this basically makes the entire store read-only (or not). 

To test, change new Store() to new Store(true) in /store/index.js