### PR TITLE
Resize

### DIFF
--- a/frog/client/main.css
+++ b/frog/client/main.css
@@ -1,4 +1,8 @@
-body {
+html {
+  height: 100%;
+}
+
+body, #render-target {
   font-family: sans-serif;
   background-color: #fff;
   background-attachment: fixed;
@@ -12,13 +16,14 @@ body {
   padding: 0;
   margin: 0;
 
+  height: 100%;
+
   font-size: 14px;
 }
 
 #body {
-  padding: 20px 15px 20px 15px;
-  margin: 0 auto;
-  background: #eee;
+  background: #f8f8f8;
+  height: 100%;
 }
 
 #header {
@@ -29,3 +34,54 @@ body {
   margin: 10px;
 }
 
+.Resizer {
+    background: #000;
+    opacity: .2;
+    z-index: 1;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    -moz-background-clip: padding;
+    -webkit-background-clip: padding;
+    background-clip: padding-box;
+}
+
+ .Resizer:hover {
+    -webkit-transition: all 2s ease;
+    transition: all 2s ease;
+}
+
+ .Resizer.horizontal {
+    height: 11px;
+    margin: -5px 0;
+    border-top: 5px solid rgba(255, 255, 255, 0);
+    border-bottom: 5px solid rgba(255, 255, 255, 0);
+    cursor: row-resize;
+    width: 100%;
+}
+
+.Resizer.horizontal:hover {
+    border-top: 5px solid rgba(0, 0, 0, 0.5);
+    border-bottom: 5px solid rgba(0, 0, 0, 0.5);
+}
+
+.Resizer.vertical {
+    width: 11px;
+    margin: 0 -5px;
+    border-left: 5px solid rgba(255, 255, 255, 0);
+    border-right: 5px solid rgba(255, 255, 255, 0);
+    cursor: col-resize;
+}
+
+.Resizer.vertical:hover {
+    border-left: 5px solid rgba(0, 0, 0, 0.5);
+    border-right: 5px solid rgba(0, 0, 0, 0.5);
+}
+
+Resizer.disabled {
+  cursor: not-allowed;
+}
+
+Resizer.disabled:hover {
+  border-color: transparent;
+}

--- a/frog/imports/ui/App.jsx
+++ b/frog/imports/ui/App.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Meteor } from 'meteor/meteor';
 import { Nav, NavItem } from 'react-bootstrap';
+import SplitPane from 'react-split-pane';
 
 import Body from './Body.jsx';
 import AccountsUIWrapper from './AccountsUIWrapper.jsx';
@@ -33,7 +34,7 @@ export default class App extends Component {
 
   render() {
     return (
-      <div>
+      <SplitPane split="horizontal" allowResize={false}>
         <div id="header">
           <AccountsUIWrapper />
           <Navigation
@@ -42,18 +43,17 @@ export default class App extends Component {
             changeFn={app => this.setState({ app })}
           />
         </div>
-        {this.state.app === 'Home'
-          ? <div className="page-header" style={{ marginTop: '0px' }}>
-              <h1>
+        <div id="body">
+          {this.state.app === 'Home'
+            ? <h1>
                 FROG{' '}
                 <small> - Fabricating and Running Orchestration Graphs</small>
               </h1>
-            </div>
-          : null}
-        <div id="body">
+            : null}
           <Body app={this.state.app} />
         </div>
-      </div>
+
+      </SplitPane>
     );
   }
 }

--- a/frog/imports/ui/GraphEditor/EditorContainer.js
+++ b/frog/imports/ui/GraphEditor/EditorContainer.js
@@ -36,7 +36,7 @@ const Editor = (
         <Graph
           width={graphWidth}
           height={150}
-          viewBox={'0 0 4000 600'}
+          viewBox={[0, 0, 4 * graphWidth, 600].join(' ')}
           hasPanMap
         />
         <HelpModal />

--- a/frog/imports/ui/GraphEditor/EditorContainer.js
+++ b/frog/imports/ui/GraphEditor/EditorContainer.js
@@ -32,7 +32,7 @@ const Editor = (
           height={600}
           viewBox={[panOffset, 0, graphWidth, 600].join(' ')}
         />
-        <Rename />
+        <RenameBox />
         <Graph
           width={graphWidth}
           height={150}

--- a/frog/imports/ui/GraphEditor/EditorContainer.js
+++ b/frog/imports/ui/GraphEditor/EditorContainer.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 // $FlowFixMe
 import styled from 'styled-components';
+import SplitPane from 'react-split-pane';
 
 import { connect } from './store';
 import type { StoreProp } from './store';
@@ -12,54 +13,53 @@ import SidePanel from './SidePanel';
 import GraphList from './GraphList';
 import HelpModal from './HelpModal';
 
-const Editor = ({ store: { ui: { panOffset } } }: StoreProp) => (
-  <div>
+const Editor = (
+  { store: { ui: { panOffset, graphWidth, changeGraphWidth } } }: StoreProp
+) => (
+  <SplitPane split="horizontal" allowResize={false}>
     <GraphConfigPanelContainer>
       <GraphList />
     </GraphConfigPanelContainer>
-    <Row>
-      <GraphContainer>
-        <Graph width={1000} height={600} viewBox={`${panOffset} 0 1000 600`} />
+    <SplitPane
+      split="vertical"
+      defaultSize={1000}
+      allowResize
+      onChange={changeGraphWidth}
+    >
+      <div>
+        <Graph
+          width={graphWidth}
+          height={600}
+          viewBox={[panOffset, 0, graphWidth, 600].join(' ')}
+        />
         <Rename />
-        <Graph width={1000} height={150} viewBox={'0 0 4000 600'} hasPanMap />
-      </GraphContainer>
-      <HelpModal />
+        <Graph
+          width={graphWidth}
+          height={150}
+          viewBox={'0 0 4000 600'}
+          hasPanMap
+        />
+        <HelpModal />
+      </div>
       <SidebarContainer>
         <SidePanel />
       </SidebarContainer>
-    </Row>
-  </div>
+    </SplitPane>
+  </SplitPane>
 );
 
 export default connect(Editor);
 
 const GraphConfigPanelContainer = styled.div`
-  position: relative;
   background-color: #ccccff;
-  padding: 10px;
-  margin-bottom: 10px;
-  width: 1510px;
-`;
-
-const Row = styled.div`
-  position: relative;
-  padding: 0px;
-  height: 760px;
-  margin: 0px;
-  display: flex;
-`;
-
-/* padding: 0; */
-const GraphContainer = styled.div`
-  position: relative;
-  width: 1000px;
-  height: 760px;
+  padding: 5px;
+  width: 100%;
 `;
 
 const SidebarContainer = styled.div`
-  padding: 0px;
-  width: 500px;
+  padding: 5px;
+  width: 100%;
+  height: 100%;
   background-color: #ffffff;
-  margin-left: 10px;
   overflow: scroll;
 `;

--- a/frog/imports/ui/GraphEditor/Graph.js
+++ b/frog/imports/ui/GraphEditor/Graph.js
@@ -13,7 +13,7 @@ import Operators from './Operators';
 const scrollMouse = e => {
   e.preventDefault();
   if (e.shiftKey) {
-    store.ui.setScaleDelta(e.deltaY * 0.01);
+    store.ui.setScaleDelta(e.deltaY);
   } else {
     store.ui.panDelta(e.deltaY);
   }
@@ -28,7 +28,8 @@ export default connect(({
     ui: {
       scale,
       scrollEnabled,
-      canvasClick
+      canvasClick,
+      graphWidth
     }
   },
   width,
@@ -42,7 +43,7 @@ export default connect(({
   viewBox: string
 }) => (
   <svg
-    width={width}
+    width={graphWidth}
     height={height}
     onMouseMove={mousemove}
     onWheel={scrollMouse}
@@ -55,10 +56,10 @@ export default connect(({
         fill="#fcf9e9"
         stroke="transparent"
         rx={10}
-        width={hasPanMap ? 4000 : width * 4 * scale}
-        height={height * 4}
+        width={hasPanMap ? 4 * graphWidth : graphWidth * scale}
+        height={hasPanMap ? 4 * height : height}
       />
-      <LevelLines />
+      <LevelLines hasPanMap={hasPanMap} />
       <Lines scaled={!hasPanMap} />
       <Activities scaled={!hasPanMap} />
       {!hasPanMap && scrollEnabled && <DragLine />}

--- a/frog/imports/ui/GraphEditor/fixedComponents.js
+++ b/frog/imports/ui/GraphEditor/fixedComponents.js
@@ -1,11 +1,13 @@
 // @flow
+
 import React from 'react';
 import { DraggableCore } from 'react-draggable';
+
 import { connect, store, type StoreProp } from './store';
 import { timeToPx } from './utils';
 
 export const PanMap = connect(({
-  store: { ui: { panx, panDelta, scale } }
+  store: { ui: { panx, panDelta, scale, graphWidth } }
 }: StoreProp) => (
   <DraggableCore onDrag={(_, { deltaX }) => panDelta(deltaX)}>
     <rect
@@ -15,7 +17,7 @@ export const PanMap = connect(({
       stroke="black"
       strokeWidth={4}
       rx={10}
-      width={250 / scale}
+      width={graphWidth / scale}
       height={150}
     />
   </DraggableCore>
@@ -25,14 +27,17 @@ const onDoubleClick = (x, e) => {
   store.activityStore.addActivity(x, e.nativeEvent.offsetX);
 };
 
-export const LevelLines = connect(({ store: { ui: { scale } } }: StoreProp) => (
+export const LevelLines = connect(({
+  store: { ui: { scale, graphWidth } },
+  hasPanMap
+}: StoreProp & { hasPanMap: boolean }) => (
   <g>
     {[1, 2, 3].map(x => (
       <g key={x}>
         <line
           x1={0}
           y1={x * 100 + 65}
-          x2={4000 * scale}
+          x2={graphWidth * (hasPanMap ? 4 : scale)}
           y2={x * 100 + 65}
           stroke="grey"
           strokeWidth={1}
@@ -42,7 +47,7 @@ export const LevelLines = connect(({ store: { ui: { scale } } }: StoreProp) => (
           onDoubleClick={e => onDoubleClick(x, e)}
           x={0}
           y={x * 100 + 45}
-          width={4000 * scale}
+          width={graphWidth * (hasPanMap ? 4 : scale)}
           fill="transparent"
           height={40}
         />

--- a/frog/imports/ui/GraphEditor/store/activity.js
+++ b/frog/imports/ui/GraphEditor/store/activity.js
@@ -49,7 +49,7 @@ export default class Activity extends Elem {
     return timeToPx(Math.floor(this.startTime), store.ui.scale);
   }
   @computed get x(): number {
-    return timeToPx(Math.floor(this.startTime), 1);
+    return timeToPx(Math.floor(this.startTime), 4);
   }
   @computed get screenX(): number {
     return timeToPxScreen(Math.floor(this.startTime), 1);
@@ -59,7 +59,7 @@ export default class Activity extends Elem {
     return timeToPx(Math.floor(this.length), store.ui.scale);
   }
   @computed get width(): number {
-    return timeToPx(Math.floor(this.length), 1);
+    return timeToPx(Math.floor(this.length), 4);
   }
 
   @action update = (newact: $Shape<Activity>) => {

--- a/frog/imports/ui/GraphEditor/store/activityStore.js
+++ b/frog/imports/ui/GraphEditor/store/activityStore.js
@@ -39,6 +39,7 @@ export default class ActivityStore {
   constructor() {
     this.all = [];
   }
+
   @observable all: Array<Activity> = [];
 
   @computed get activityOffsets(): any {

--- a/frog/imports/ui/GraphEditor/store/operator.js
+++ b/frog/imports/ui/GraphEditor/store/operator.js
@@ -41,7 +41,7 @@ export default class Operator extends Elem {
   }
 
   @computed get x(): number {
-    return timeToPx(this.time, 1);
+    return timeToPx(this.time, 4);
   }
 
   @computed get xScaled(): number {

--- a/frog/imports/ui/GraphEditor/store/uiStore.js
+++ b/frog/imports/ui/GraphEditor/store/uiStore.js
@@ -10,6 +10,11 @@ export default class uiStore {
   @observable scale: number;
   @observable selected: ?Elem;
   @observable showModal: Boolean;
+  @observable graphWidth: number = 1000;
+
+  @action changeGraphWidth = (newWidth: number) => {
+    this.graphWidth = newWidth;
+  };
 
   rawMouseToTime = (rawX: number, rawY: number): [number, number] => {
     const x = pxToTime(rawX, this.scale) + this.panTime;

--- a/frog/imports/ui/GraphEditor/store/uiStore.js
+++ b/frog/imports/ui/GraphEditor/store/uiStore.js
@@ -13,7 +13,7 @@ export default class uiStore {
       }
     });
   }
-  
+
   @observable panx: number = 0;
   @observable scale: number = 4;
   @observable selected: ?Elem;
@@ -27,6 +27,8 @@ export default class uiStore {
 
   @action changeGraphWidth = (newWidth: number) => {
     this.graphWidth = newWidth;
+    // avoids the pan box to bcome out of bounds when resizing the graph editor
+    this.panDelta(0)
   };
 
   rawMouseToTime = (rawX: number, rawY: number): [number, number] => {

--- a/frog/imports/ui/GraphEditor/store/uiStore.js
+++ b/frog/imports/ui/GraphEditor/store/uiStore.js
@@ -28,7 +28,7 @@ export default class uiStore {
   @action changeGraphWidth = (newWidth: number) => {
     this.graphWidth = newWidth;
     // avoids the pan box to bcome out of bounds when resizing the graph editor
-    this.panDelta(0)
+    this.panDelta(0);
   };
 
   rawMouseToTime = (rawX: number, rawY: number): [number, number] => {

--- a/frog/imports/ui/GraphEditor/utils/index.js
+++ b/frog/imports/ui/GraphEditor/utils/index.js
@@ -2,11 +2,14 @@
 import { store } from '../store';
 
 export const timeToPx = (time: number, scale: number): number =>
-  time * 3900 * scale / 120;
+  time * store.ui.graphWidth * scale / 120;
+
 export const pxToTime = (px: number, scale: number): number =>
-  px / 3900 / scale * 120;
+  px / store.ui.graphWidth / scale * 120;
+
 export const timeToPxScreen = (time: number): number =>
-  time * 3900 * store.ui.scale / 120 - store.ui.panx * 4 * store.ui.scale;
+  time * store.ui.graphWidth * store.ui.scale / 120 -
+  store.ui.panx * store.ui.scale;
 
 export const between = (
   minval: number = 0,

--- a/frog/package.json
+++ b/frog/package.json
@@ -37,6 +37,7 @@
     "react-draggable": "^2.2.3",
     "react-fontawesome": "^1.3.1",
     "react-jsonschema-form": "^0.43.0",
+    "react-split-pane": "^0.1.59",
     "styled-components": "^1.4.0"
   }
 }


### PR DESCRIPTION
## Changes

- uses `react-split-pane` for the resizable layout

- Added an observable `store.ui.graphWidth`, that changes when the layout is resized

- `scale` now goes from 1 to 8, where 1 corresponds to seeing the whole session and 8 seeing 1/8th of the session (15 minutes of 2 hours)

- The minimap has the same virtual size as the full graph, but is seen through a viewBox of dimensions divided by 4
