### PR TITLE
Initialize splitPane width to be store.ui.graphWidth

### DIFF
--- a/frog/imports/ui/GraphEditor/EditorContainer.js
+++ b/frog/imports/ui/GraphEditor/EditorContainer.js
@@ -36,7 +36,7 @@ const Editor = (
     <TopPanel />
     <SplitPane
       split="vertical"
-      defaultSize={1000}
+      defaultSize={graphWidth}
       allowResize
       onChange={changeGraphWidth}
     >


### PR DESCRIPTION
When changing tabs, the graph editor splitpanes was reseting itself to 1000px, while the store still has store the previous changed size