### PR TITLE
Adding address bar routing for apps

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,12 @@
 module.exports = {
   plugins: ['flowtype', 'prettier'],
   globals: {
-    window: true,
-    document: true
+    document: true,
+    history: true,
+    window: true
   },
   rules: {
+    'consistent-return': 'off',
     'import/no-absolute-path': 'off',
     'no-else-return': 'off',
     'flowtype/space-after-type-colon': 'off',

--- a/frog/imports/ui/App.jsx
+++ b/frog/imports/ui/App.jsx
@@ -36,7 +36,7 @@ export default class App extends Component {
       admin: 'Admin',
       noname: 'Home'
     }[username] || 'Student View';
-    newApp = this.handleNewHash();
+    const newApp = this.handleNewHash();
     if (!newApp || username === 'noname') {
       this.setState({ app });
       this.updateAddressbar(app);
@@ -44,7 +44,7 @@ export default class App extends Component {
   };
 
   updateAddressbar = app => {
-    const url = Object.entries(appSlugs).find(([_, v]) => v === app);
+    const url = Object.entries(appSlugs).find(([, v]) => v === app);
     history.pushState(null, null, '/#/' + (url && url[0]));
   };
 

--- a/frog/imports/ui/App.jsx
+++ b/frog/imports/ui/App.jsx
@@ -7,6 +7,13 @@ import Body from './Body.jsx';
 import AccountsUIWrapper from './AccountsUIWrapper.jsx';
 
 const apps = ['Home', 'Admin', 'Graph Editor', 'Teacher View', 'Student View'];
+const appSlugs = {
+  '': 'Home',
+  admin: 'Admin',
+  graph: 'Graph Editor',
+  teacher: 'Teacher View',
+  student: 'Student View'
+};
 
 const Navigation = ({ appList, changeFn, currentApp }) => (
   <Nav bsStyle="pills" activeKey={currentApp} onSelect={changeFn}>
@@ -29,7 +36,31 @@ export default class App extends Component {
       admin: 'Admin',
       noname: 'Home'
     }[username] || 'Student View';
-    this.setState({ app });
+    newApp = this.handleNewHash();
+    if (!newApp || username === 'noname') {
+      this.setState({ app });
+      this.updateAddressbar(app);
+    }
+  };
+
+  updateAddressbar = app => {
+    const url = Object.entries(appSlugs).find(([_, v]) => v === app);
+    history.pushState(null, null, '/#/' + (url && url[0]));
+  };
+
+  handleNewHash = () => {
+    const location = window.location.hash
+      .replace(/^#\/?|\/$/g, '')
+      .split('/')[0]
+      .trim();
+    if (appSlugs[location]) {
+      this.setState({ app: appSlugs[location] });
+      return appSlugs[location];
+    }
+  };
+
+  componentDidMount = () => {
+    window.addEventListener('hashchange', this.handleNewHash, false);
   };
 
   render() {
@@ -44,7 +75,10 @@ export default class App extends Component {
           <Navigation
             appList={apps}
             currentApp={this.state.app}
-            changeFn={app => this.setState({ app })}
+            changeFn={app => {
+              this.setState({ app });
+              this.updateAddressbar(app);
+            }}
           />
         </div>
         <div id="body">

--- a/frog/imports/ui/GraphEditor/fixedComponents.js
+++ b/frog/imports/ui/GraphEditor/fixedComponents.js
@@ -58,29 +58,21 @@ export const LevelLines = connect(({
 
 export const TimeScale = connect(({
   store: { ui: { scale }, graphDuration }
-}) => {
-  let divider = Math.round(5 / scale) % 5 * 5;
-  if (divider === 0) {
-    divider = 20;
-  }
-  return (
-    <g>
-      {[...Array(graphDuration).keys()].map(index => {
-        const i = index + 1;
-        const boolToBit = b => b ? 1 : 0;
-        const length = boolToBit(i % 15 === 0) * 15 +
-          boolToBit(i % 5 === 0) * 10 +
-          5;
-        const x = timeToPx(i, scale);
-        return (
-          <g key={i}>
-            <line x1={x} y1={600 - length} x2={x} y2={600} stroke="grey" />
-            {i % divider === 0
-              ? <text x={x - 15} y={540}>{i + ' min.'}</text>
-              : null}
-          </g>
-        );
-      })}
-    </g>
-  );
-});
+}) => (
+  <g>
+    {[...Array(graphDuration).keys()].map(index => {
+      const i = index + 1;
+      const boolToBit = b => b ? 1 : 0;
+      const length = boolToBit(i % 15 === 0) * 15 +
+        boolToBit(i % 5 === 0) * 10 +
+        5;
+      const x = timeToPx(i, scale);
+      return (
+        <g key={i}>
+          <line x1={x} y1={600 - length} x2={x} y2={600} stroke="grey" />
+          {i % 15 === 0 ? <text x={x - 15} y={540}>{i + ' min.'}</text> : null}
+        </g>
+      );
+    })}
+  </g>
+));

--- a/frog/imports/ui/GraphEditor/fixedComponents.js
+++ b/frog/imports/ui/GraphEditor/fixedComponents.js
@@ -58,21 +58,29 @@ export const LevelLines = connect(({
 
 export const TimeScale = connect(({
   store: { ui: { scale }, graphDuration }
-}) => (
-  <g>
-    {[...Array(graphDuration).keys()].map(index => {
-      const i = index + 1;
-      const boolToBit = b => b ? 1 : 0;
-      const length = boolToBit(i % 15 === 0) * 15 +
-        boolToBit(i % 5 === 0) * 10 +
-        5;
-      const x = timeToPx(i, scale);
-      return (
-        <g key={i}>
-          <line x1={x} y1={600 - length} x2={x} y2={600} stroke="grey" />
-          {i % 15 === 0 ? <text x={x - 15} y={540}>{i + ' min.'}</text> : null}
-        </g>
-      );
-    })}
-  </g>
-));
+}) => {
+  let divider = Math.round(5 / scale) % 5 * 5;
+  if (divider === 0) {
+    divider = 20;
+  }
+  return (
+    <g>
+      {[...Array(graphDuration).keys()].map(index => {
+        const i = index + 1;
+        const boolToBit = b => b ? 1 : 0;
+        const length = boolToBit(i % 15 === 0) * 15 +
+          boolToBit(i % 5 === 0) * 10 +
+          5;
+        const x = timeToPx(i, scale);
+        return (
+          <g key={i}>
+            <line x1={x} y1={600 - length} x2={x} y2={600} stroke="grey" />
+            {i % divider === 0
+              ? <text x={x - 15} y={540}>{i + ' min.'}</text>
+              : null}
+          </g>
+        );
+      })}
+    </g>
+  );
+});

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -1,5 +1,5 @@
-import { computed, action, observable } from 'mobx';
 import { isEqual } from 'lodash';
+import { computed, action, observable } from 'mobx';
 import Stringify from 'json-stable-stringify';
 
 import ActivityStore from './activityStore';
@@ -85,15 +85,12 @@ export default class Store {
   @action changeDuration = duration => {
     this._graphDuration = duration;
     if (duration && duration >= 30 && duration <= 1200) {
-      const oldPanTime = this.ui.panTime
+      const oldPanTime = this.ui.panTime;
       // changes the scale on duration change
-      this.ui.setScaleValue(
-        this.ui.scale / this.graphDuration * duration
-      )
+      this.ui.setScaleValue(this.ui.scale / this.graphDuration * duration);
       this.graphDuration = duration;
-      const needPanDelta = timeToPx(oldPanTime - this.ui.panTime, 1)
-      this.ui.panDelta(needPanDelta)
-
+      const needPanDelta = timeToPx(oldPanTime - this.ui.panTime, 1);
+      this.ui.panDelta(needPanDelta);
     }
   };
 


### PR DESCRIPTION
In the future we might add something more complex, but for now this works reasonably well - it updates the address bar when you switch to another app (tab), and checks the URL bar on startup/change to update the route. This let's us be in localhost:3000/graph, and on reload, it will put us straight back into graph. 

Right now the logic with switchAppByUser is a bit convoluted - it checks whether the user has entered something in the URL bar, and then uses that (unless not logged in), otherwise uses the result of switchAppByUser. I'm not sure if we even need that anymore... Anyway we eventually want to separate out the logic for students, from that for teachers completely. (Ie users should not see the bar, etc).;wq