### PR TITLE
Don't show activity internal elements if small

### DIFF
--- a/frog/imports/ui/GraphEditor/Activities.js
+++ b/frog/imports/ui/GraphEditor/Activities.js
@@ -49,61 +49,64 @@ const Activity = connect(({
         highlighted={activity.highlighted}
         selected={activity.selected}
       />
-      <svg style={{ overflow: 'hidden' }} width={width + x - 20}>
-        <text x={x + 3} y={activity.y + 20}>
-          {activity.title}
-        </text>
-      </svg>
-      <circle
-        cx={x + width - 10}
-        cy={activity.y + 15}
-        r={5}
-        fill="transparent"
-        stroke="black"
-      />
-      <DraggableCore
-        onStart={() => startDragging(activity)}
-        onStop={stopDragging}
-      >
-        <circle
-          cx={x + width - 10}
-          cy={activity.y + 15}
-          r={10}
-          fill="transparent"
-          stroke="transparent"
-          style={{ cursor: 'crosshair' }}
-        />
-      </DraggableCore>
-      <DraggableCore
-        onStart={() => startResizing(activity)}
-        onDrag={(_, { deltaX }) => activity.resize(deltaX)}
-        onStop={stopResizing}
-      >
-        <rect
-          fill="transparent"
-          stroke="transparent"
-          x={x + width - 5}
-          y={activity.y}
-          width={5}
-          height={30}
-          style={{ cursor: 'ew-resize' }}
-        />
-      </DraggableCore>
-      <DraggableCore
-        onStart={() => startMoving(activity)}
-        onDrag={(_, { deltaX }) => activity.move(deltaX)}
-        onStop={stopMoving}
-      >
-        <rect
-          x={x}
-          y={activity.y}
-          fill="transparent"
-          stroke="transparent"
-          width={width - 20}
-          height={30}
-          style={{ cursor: 'move' }}
-        />
-      </DraggableCore>
+      {width > 21 &&
+        <g>
+          <svg style={{ overflow: 'hidden' }} width={width + x - 20}>
+            <text x={x + 3} y={activity.y + 20}>
+              {activity.title}
+            </text>
+          </svg>
+          <circle
+            cx={x + width - 10}
+            cy={activity.y + 15}
+            r={5}
+            fill="transparent"
+            stroke="black"
+          />
+          <DraggableCore
+            onStart={() => startDragging(activity)}
+            onStop={stopDragging}
+          >
+            <circle
+              cx={x + width - 10}
+              cy={activity.y + 15}
+              r={10}
+              fill="transparent"
+              stroke="transparent"
+              style={{ cursor: 'crosshair' }}
+            />
+          </DraggableCore>
+          <DraggableCore
+            onStart={() => startResizing(activity)}
+            onDrag={(_, { deltaX }) => activity.resize(deltaX)}
+            onStop={stopResizing}
+          >
+            <rect
+              fill="transparent"
+              stroke="transparent"
+              x={x + width - 5}
+              y={activity.y}
+              width={5}
+              height={30}
+              style={{ cursor: 'ew-resize' }}
+            />
+          </DraggableCore>
+          <DraggableCore
+            onStart={() => startMoving(activity)}
+            onDrag={(_, { deltaX }) => activity.move(deltaX)}
+            onStop={stopMoving}
+          >
+            <rect
+              x={x}
+              y={activity.y}
+              fill="transparent"
+              stroke="transparent"
+              width={width - 20}
+              height={30}
+              style={{ cursor: 'move' }}
+            />
+          </DraggableCore>
+        </g>}
     </g>
   );
 });

--- a/frog/imports/ui/GraphEditor/Activities.js
+++ b/frog/imports/ui/GraphEditor/Activities.js
@@ -91,22 +91,22 @@ const Activity = connect(({
               style={{ cursor: 'ew-resize' }}
             />
           </DraggableCore>
-          <DraggableCore
-            onStart={() => startMoving(activity)}
-            onDrag={(_, { deltaX }) => activity.move(deltaX)}
-            onStop={stopMoving}
-          >
-            <rect
-              x={x}
-              y={activity.y}
-              fill="transparent"
-              stroke="transparent"
-              width={width - 20}
-              height={30}
-              style={{ cursor: 'move' }}
-            />
-          </DraggableCore>
         </g>}
+      <DraggableCore
+        onStart={() => startMoving(activity)}
+        onDrag={(_, { deltaX }) => activity.move(deltaX)}
+        onStop={stopMoving}
+      >
+        <rect
+          x={x}
+          y={activity.y}
+          fill="transparent"
+          stroke="transparent"
+          width={width > 20 ? width - 20 : width}
+          height={30}
+          style={{ cursor: 'move' }}
+        />
+      </DraggableCore>
     </g>
   );
 });


### PR DESCRIPTION
This hides the text and circle if the activity is too small, avoiding JS errors resulting from width - 20, when width is < 20, etc.