### PR TITLE
Cleaning up graph menubar

### DIFF
--- a/frog/client/main.css
+++ b/frog/client/main.css
@@ -39,10 +39,7 @@ body {
   width: 100%;
   overflow: visible;
   display: flex;
-}
-
-#topPanel .topPanelUnit {
-  width: 25%;
+  justify-content: space-between;
 }
 
 #sidePanel {
@@ -51,54 +48,14 @@ body {
   height: 100%;
 }
 
-.Resizer {
-    background: #000;
-    opacity: .2;
-    z-index: 1;
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
-    -moz-background-clip: padding;
-    -webkit-background-clip: padding;
-    background-clip: padding-box;
+.edithover {
+    display: none;
+}
+    
+span:hover + .edithover {
+    display: inline;
 }
 
- .Resizer:hover {
-    -webkit-transition: all 2s ease;
-    transition: all 2s ease;
-}
-
- .Resizer.horizontal {
-    height: 11px;
-    margin: -5px 0;
-    border-top: 5px solid rgba(255, 255, 255, 0);
-    border-bottom: 5px solid rgba(255, 255, 255, 0);
-    cursor: row-resize;
-    width: 100%;
-}
-
-.Resizer.horizontal:hover {
-    border-top: 5px solid rgba(0, 0, 0, 0.5);
-    border-bottom: 5px solid rgba(0, 0, 0, 0.5);
-}
-
-.Resizer.vertical {
-    width: 11px;
-    margin: 0 -5px;
-    border-left: 5px solid rgba(255, 255, 255, 0);
-    border-right: 5px solid rgba(255, 255, 255, 0);
-    cursor: col-resize;
-}
-
-.Resizer.vertical:hover {
-    border-left: 5px solid rgba(0, 0, 0, 0.5);
-    border-right: 5px solid rgba(0, 0, 0, 0.5);
-}
-
-Resizer.disabled {
-  cursor: not-allowed;
-}
-
-Resizer.disabled:hover {
-  border-color: transparent;
+.edithover:hover {
+    display: inline;
 }

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel.js
@@ -55,7 +55,13 @@ class EditClass extends Component {
                 />
               </h3>
             : <h3>
-                <a href="#" onClick={() => this.setState({ editTitle: true })}>
+                <a
+                  href=""
+                  onClick={e => {
+                    e.preventDefault();
+                    this.setState({ editTitle: true });
+                  }}
+                >
                   <i className="fa fa-pencil" />
                 </a>
                 &nbsp;{graphActivity.title}

--- a/frog/imports/ui/GraphEditor/TopPanel/GraphConfigPanel.jsx
+++ b/frog/imports/ui/GraphEditor/TopPanel/GraphConfigPanel.jsx
@@ -1,35 +1,101 @@
-// @flow
-
-import React from 'react';
+import React, { Component } from 'react';
 import { createContainer } from 'meteor/react-meteor-data';
 
-import { connect } from '../store';
+import { connect, store } from '../store';
 import { Graphs, renameGraph } from '../../../api/graphs';
+import TextInput from '../utils/TextInput';
 
-const Config = ({ graph, graphId, _graphDuration, changeDuration }) => (
-  <div className="topPanelUnit">
-    <input
-      onChange={e => renameGraph(graphId, e.target.value)}
-      value={graph ? graph.name : 'untitled'}
-    />
-    <input
-      type="number"
-      name="duration"
-      min="30"
-      max="1200"
-      onChange={e => {
-        changeDuration(parseInt(e.target.value, 10));
-      }}
-      value={_graphDuration}
-    />
-  </div>
-);
+class Config extends Component {
+  state: { editingTitle: boolean, editingTime: false };
+
+  constructor(props) {
+    super(props);
+    this.state = { editingTitle: false, editingTime: false };
+  }
+
+  render() {
+    const { graph } = this.props;
+    return (
+      <div style={{ textAlign: 'center' }}>
+        {this.state.editingTitle
+          ? <TextInput
+              value={graph ? graph.name : 'untitled'}
+              onChange={e => this.setState({ title: e })}
+              onCancel={() => this.setState({ editingTitle: false })}
+              onSubmit={() => {
+                renameGraph(graph._id, this.state.title);
+                this.setState({ editingTitle: false });
+              }}
+            />
+          : <a
+              href="#"
+              style={{ textDecoration: 'none' }}
+              onClick={e => {
+                e.preventDefault();
+                this.setState({
+                  editingTitle: true,
+                  title: graph.name
+                });
+              }}
+            >
+              <span
+                style={{
+                  color: '#000000',
+                  fontSize: '20px',
+                  fontWeight: '900'
+                }}
+              >
+                {graph.name}
+              </span>
+              <i className="edithover fa fa-pencil" />
+            </a>}
+        <span style={{ marginLeft: '20px' }}>
+          {this.state.editingTime
+            ? <TextInput
+                style={{ width: '60px' }}
+                value={graph ? graph.duration : 30}
+                onChange={e => this.setState({ duration: e })}
+                onCancel={() => this.setState({ editingTime: false })}
+                onSubmit={() => {
+                  store.changeDuration(parseInt(this.state.duration, 10));
+                  this.setState({
+                    editingTime: false,
+                    duration: graph.duration
+                  });
+                }}
+              />
+            : <a
+                href="#"
+                style={{ textDecoration: 'none' }}
+                onClick={e => {
+                  e.preventDefault();
+                  this.setState({
+                    editingTime: true,
+                    duration: graph.duration
+                  });
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: '16px',
+                    color: '#000000'
+                  }}
+                >
+                  {graph.duration} mins.
+                </span>
+                <i className="edithover fa fa-pencil" />
+              </a>}
+        </span>
+      </div>
+    );
+  }
+}
 
 const GraphConfigPanel = createContainer(
   props => ({ ...props, graph: Graphs.findOne({ _id: props.graphId }) }),
-  props => <Config {...props} />
+  Config
 );
 
-export default connect(({
-  store: { graphId, _graphDuration, changeDuration }
-}) => <GraphConfigPanel {...{ graphId, _graphDuration, changeDuration }} />);
+export default connect(({ store: { graphId } }) => (
+  <GraphConfigPanel graphId={graphId} />
+));

--- a/frog/imports/ui/GraphEditor/TopPanel/GraphList.jsx
+++ b/frog/imports/ui/GraphEditor/TopPanel/GraphList.jsx
@@ -4,59 +4,28 @@ import { createContainer } from 'meteor/react-meteor-data';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 
 import { connect, store } from '../store';
-import { removeGraph } from '../../../api/activities';
-import {
-  Graphs,
-  addGraph,
-  assignGraph,
-  duplicateGraph
-} from '../../../api/graphs';
+import { Graphs } from '../../../api/graphs';
 
-const submitRemoveGraph = id => {
-  removeGraph(id);
-  store.setId(assignGraph());
-};
-
-const GraphList = createContainer(
-  props => ({ ...props, graphs: Graphs.find().fetch() }),
-  ({ graphs, graphId }) => (
-    <div className="topPanelUnit">
-      <button
-        className="btn btn-primary btn-sm"
-        onClick={() => store.setId(addGraph())}
-      >
-        New
-      </button>
-      <button
-        className="btn btn-danger btn-sm"
-        onClick={() => submitRemoveGraph(graphId)}
-      >
-        Delete
-      </button>
-      <button
-        className="btn btn-primary btn-sm"
-        onClick={() => duplicateGraph(graphId)}
-      >
-        Copy
-      </button>
-      <DropdownButton title="Select Graph" id="dropdown-basic-0">
-        {graphs.length
-          ? graphs.map(graph => (
-              <MenuItem
-                key={graph._id}
-                eventKey={graph._id}
-                active={graph._id === graphId}
-                onClick={() => store.setId(graph._id)}
-              >
-                {graph.name}
-              </MenuItem>
-            ))
-          : <MenuItem eventKey="0">No graph</MenuItem>}
-      </DropdownButton>
-    </div>
-  )
-);
-
-export default connect(({ store: { graphId } }) => (
-  <GraphList graphId={graphId} />
+export const GraphMenuSimple = connect(({ store: { graphId }, graphs }) => (
+  <DropdownButton title="Select Graph" id="dropdown-basic-0">
+    {graphs.length
+      ? graphs.map(graph => (
+          <MenuItem
+            key={graph._id}
+            eventKey={graph._id}
+            active={graph._id === graphId}
+            onClick={() => store.setId(graph._id)}
+          >
+            {graphId === graph._id &&
+              <i className="fa fa-check" aria-hidden="true" />}
+            {graph.name}
+          </MenuItem>
+        ))
+      : <MenuItem eventKey="0">No graph</MenuItem>}
+  </DropdownButton>
 ));
+
+export default createContainer(
+  props => ({ ...props, graphs: Graphs.find().fetch() }),
+  GraphMenuSimple
+);

--- a/frog/imports/ui/GraphEditor/TopPanel/Settings.js
+++ b/frog/imports/ui/GraphEditor/TopPanel/Settings.js
@@ -1,68 +1,51 @@
 import React from 'react';
-import { render } from 'react-dom';
-import { saveSvgAsPng } from 'save-svg-as-png';
-import { Provider } from 'mobx-react';
+import { DropdownButton, MenuItem, Button } from 'react-bootstrap';
 
 import { exportGraph, importGraph } from '../utils/export';
 import { connect, store } from '../store';
-import { timeToPx } from '../utils';
-import Graph from '../Graph';
+import exportPicture from '../utils/exportPicture';
+import { removeGraph } from '../../../api/activities';
+import { addGraph, assignGraph, duplicateGraph } from '../../../api/graphs';
 
-const download = e => {
-  e.preventDefault();
-  const canvas = document.createElement('canvas');
-
-  const oldScale = store.ui.scale;
-  store.ui.setScaleValue(store.graphDuration / 30);
-  store.ui.setGraphWidth(1768);
-  render(
-    <Provider store={store}>
-      <Graph viewBox={[0, 0, 1, 1].join(' ')} isSvg scaled hasTimescale />
-    </Provider>,
-    canvas
-  );
-  const pictureWidth = timeToPx(store.graphDuration, store.graphDuration / 30);
-  saveSvgAsPng(store.ui.svgRef, 'graph.png', {
-    width: pictureWidth,
-    height: 600
-  });
-  store.ui.setScaleValue(oldScale);
-  store.ui.updateGraphWidth();
+const submitRemoveGraph = id => {
+  removeGraph(id);
+  store.setId(assignGraph());
 };
 
-export default connect(({
-  store: { graphId, overlapAllowed, updateSettings, undo, canUndo, history }
-}) => (
-  <div className="topPanelUnit">
-    <input
-      type="checkbox"
-      id="cbox"
-      checked={overlapAllowed}
-      onChange={e => {
-        updateSettings({ overlapAllowed: e.target.checked });
-      }}
-    />
+export const UndoButton = connect(({ store: { undo } }) => (
+  <Button onClick={undo}>
+    <i className="fa fa-undo" aria-hidden="true" /> Undo
+  </Button>
+));
 
-    <label htmlFor="cbox">Overlap allowed</label>
-    {canUndo &&
-      <a href="#" onClick={undo} style={{ marginLeft: '50px' }}>
-        Undo ({history.length})
-      </a>}
-    <a
-      href="#"
-      onClick={e => exportGraph(e, graphId)}
-      style={{ marginLeft: '50px' }}
-    >
+export const ConfigMenu = connect(({
+  store: { overlapAllowed, graphId, toggleOverlapAllowed }
+}) => (
+  <DropdownButton
+    id="settings"
+    title={<span><i className="fa fa-bars" aria-hidden="true" /> Menu</span>}
+  >
+    <MenuItem eventKey="1" onSelect={toggleOverlapAllowed}>
+      {overlapAllowed && <i className="fa fa-check" aria-hidden="true" />}
+      Overlap allowed
+    </MenuItem>
+    <MenuItem divider />
+    <MenuItem eventKey="5" onSelect={() => store.setId(addGraph())}>
+      Add new graph
+    </MenuItem>
+    <MenuItem eventKey="9" onSelect={() => duplicateGraph(graphId)}>
+      Duplicate graph
+    </MenuItem>
+    <MenuItem eventKey="7" onSelect={() => submitRemoveGraph(graphId)}>
+      Delete current graph
+    </MenuItem>
+    <MenuItem divider />
+    <MenuItem eventKey="2" onSelect={exportGraph}>
       Export graph
-    </a>
-    <a href="#" onClick={importGraph} style={{ marginLeft: '50px' }}>
-      Upload graph
-    </a>
-    <a href="#" onClick={download} style={{ marginLeft: '50px' }}>
-      Downloads as PNG
-    </a>
-    <a href onClick={download} style={{ marginLeft: '50px' }}>
-      Download as PNG
-    </a>
-  </div>
+    </MenuItem>
+    <MenuItem eventKey="3" onSelect={importGraph}>Import graph</MenuItem>
+    <MenuItem eventKey="4" onSelect={exportPicture}>
+      Export as image
+    </MenuItem>
+  </DropdownButton>
 ));

--- a/frog/imports/ui/GraphEditor/TopPanel/index.js
+++ b/frog/imports/ui/GraphEditor/TopPanel/index.js
@@ -4,12 +4,15 @@ import React from 'react';
 
 import GraphList from './GraphList';
 import GraphConfigPanel from './GraphConfigPanel';
-import Settings from './Settings';
+import { UndoButton, ConfigMenu } from './Settings';
 
 export default () => (
   <div id="topPanel">
-    <GraphList />
+    <div>
+      <ConfigMenu />
+      <GraphList />
+    </div>
     <GraphConfigPanel />
-    <Settings />
+    <UndoButton />
   </div>
 );

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -59,7 +59,6 @@ export default class Store {
   @observable history = [];
   @observable readOnly: Boolean;
 
-  @observable _graphDuration: number = 120;
   @observable graphDuration: number = 120;
 
   set state(newState: StateT) {
@@ -83,7 +82,6 @@ export default class Store {
   };
 
   @action changeDuration = duration => {
-    this._graphDuration = duration;
     if (duration && duration >= 30 && duration <= 1200) {
       const oldPanTime = this.ui.panTime;
       // changes the scale on duration change
@@ -91,12 +89,13 @@ export default class Store {
       this.graphDuration = duration;
       const needPanDelta = timeToPx(oldPanTime - this.ui.panTime, 1);
       this.ui.panDelta(needPanDelta);
+      Graphs.update(this.graphId, { $set: { duration: this.graphDuration } });
     }
   };
 
   @observable overlapAllowed = true;
-  @action updateSettings = (settings: { overlapAllowed: boolean }) =>
-    this.overlapAllowed = settings.overlapAllowed;
+  @action toggleOverlapAllowed = () =>
+    this.overlapAllowed = !this.overlapAllowed;
 
   @action deleteSelected = (): void => {
     if (this.state.mode === 'normal') {
@@ -141,6 +140,7 @@ export default class Store {
         return new Connection(source, target, x._id);
       });
 
+    this.ui.selected = null;
     this.history = [];
     this.addHistory();
     this.state = { mode: 'normal' };

--- a/frog/imports/ui/GraphEditor/utils/TextInput.js
+++ b/frog/imports/ui/GraphEditor/utils/TextInput.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react';
 
 export default class TextInput extends Component {
-  constructor(props: { value: string, onChange: Function }) {
+  constructor(props: { value: string, onChange: Function, style?: string }) {
     super(props);
     this.state = { val: this.props.value || '' };
   }
@@ -35,19 +35,23 @@ export default class TextInput extends Component {
     if (e.keyCode === 27) {
       this.props.onCancel();
     }
+    if (e.keyCode === 13) {
+      this.props.onSubmit(this.state.val);
+    }
   };
 
   render() {
     return (
-      <form onSubmit={this.onSubmit} onBlur={this.onSubmit}>
-        <input
-          type="text"
-          onChange={this.onChange}
-          onKeyDown={this.handleKey}
-          value={this.state.val}
-          ref={input => this.textInput = input}
-        />
-      </form>
+      <input
+        type="text"
+        onChange={this.onChange}
+        onKeyDown={this.handleKey}
+        value={this.state.val}
+        ref={input => this.textInput = input}
+        onSubmit={this.onSubmit}
+        onBlur={this.onSubmit}
+        style={this.props.style}
+      />
     );
   }
 }

--- a/frog/imports/ui/GraphEditor/utils/export.js
+++ b/frog/imports/ui/GraphEditor/utils/export.js
@@ -20,9 +20,8 @@ const graphToString = graphId =>
     connections: Connections.find({ graphId }).fetch().map(x => clean(x))
   });
 
-export const exportGraph = (e, graphId) => {
-  e.preventDefault();
-  const blob = new Blob([graphToString(graphId)], {
+export const exportGraph = () => {
+  const blob = new Blob([graphToString(store.graphId)], {
     type: 'text/plain;charset=utf-8'
   });
   FileSaver.saveAs(blob, 'graph.json', true);
@@ -47,8 +46,7 @@ const doImportGraph = graphStr => {
   store.setId(graphId);
 };
 
-export const importGraph = e => {
-  e.preventDefault();
+export const importGraph = () => {
   fileDialog().then(file => {
     const fr = new FileReader();
     fr.onloadend = doImportGraph;

--- a/frog/imports/ui/GraphEditor/utils/exportPicture.js
+++ b/frog/imports/ui/GraphEditor/utils/exportPicture.js
@@ -1,0 +1,30 @@
+// @flow
+import React from 'react';
+import { render } from 'react-dom';
+import { Provider } from 'mobx-react';
+import { saveSvgAsPng } from 'save-svg-as-png';
+
+import { store } from '../store';
+import { timeToPx } from '../utils';
+import Graph from '../Graph';
+
+export default () => {
+  const canvas = document.createElement('canvas');
+
+  const oldScale = store.ui.scale;
+  store.ui.setScaleValue(store.graphDuration / 30);
+  store.ui.setGraphWidth(1768);
+  render(
+    <Provider store={store}>
+      <Graph viewBox={[0, 0, 1, 1].join(' ')} isSvg scaled hasTimescale />
+    </Provider>,
+    canvas
+  );
+  const pictureWidth = timeToPx(store.graphDuration, store.graphDuration / 30);
+  saveSvgAsPng(store.ui.svgRef, 'graph.png', {
+    width: pictureWidth,
+    height: 600
+  });
+  store.ui.setScaleValue(oldScale);
+  store.ui.updateGraphWidth();
+};


### PR DESCRIPTION
I tried cleaning up the menu bar in the graph editor a bit, which had grown by us gradually adding options with no clear design :) I made another dropdown with most of the options and operations, and made the title and time similar to the rename in sidebar - click to edit. This also means we avoid issues about graph length jumping around while we're typing. (Also, you had forgotten to write graphLength to the database :))...

The code is pretty ugly, and could probably use a refactoring, but everything should work - except duplicateGraph - it doesn't look like this was working in your version either? Did we have a function for this at some point which disappeared?

We should think a bit about consistent approach to theming... right now we have both a main.css, bootstrap, react-bootstrap component, styled-components, and inline styles :)... 

Also, the reason links were going to the homepage is because of the addition of a URL router, so if you have an a href you need to do preventDefault, otherwise the url will go to /#, which will update the router. We could create an A component which automatically prevents default.