### PR TITLE
Ensuring activity startTime is always integer

### DIFF
--- a/frog/imports/ui/GraphEditor/store/activity.js
+++ b/frog/imports/ui/GraphEditor/store/activity.js
@@ -46,20 +46,20 @@ export default class Activity extends Elem {
   @observable startTime: number;
 
   @computed get xScaled(): number {
-    return timeToPx(Math.floor(this.startTime), store.ui.scale);
+    return timeToPx(this.startTime, store.ui.scale);
   }
   @computed get x(): number {
-    return timeToPx(Math.floor(this.startTime), 4);
+    return timeToPx(this.startTime, 4);
   }
   @computed get screenX(): number {
-    return timeToPxScreen(Math.floor(this.startTime), 1);
+    return timeToPxScreen(this.startTime, 1);
   }
 
   @computed get widthScaled(): number {
-    return timeToPx(Math.floor(this.length), store.ui.scale);
+    return timeToPx(this.length, store.ui.scale);
   }
   @computed get width(): number {
-    return timeToPx(Math.floor(this.length), 4);
+    return timeToPx(this.length, 4);
   }
 
   @action update = (newact: $Shape<Activity>) => {

--- a/frog/imports/ui/GraphEditor/store/activityStore.js
+++ b/frog/imports/ui/GraphEditor/store/activityStore.js
@@ -47,20 +47,22 @@ export default class ActivityStore {
   }
 
   @action addActivity = (plane: number, rawX: number): void => {
-    const [x, _] = store.ui.rawMouseToTime(rawX, 0);
+    const [rawTime, _] = store.ui.rawMouseToTime(rawX, 0);
+    const time = Math.round(rawTime);
     let length;
     if (!store.overlapAllowed) {
       const { rightBoundTime } = calculateBounds(
-        { startTime: x, length: 0, id: 0 },
+        { startTime: time, length: 0, id: 0 },
         this.all
       );
-      const maxLength = rightBoundTime - x;
+      const maxLength = rightBoundTime - time;
       length = Math.min(maxLength, 5);
     } else {
       length = 5;
     }
     if (length >= 1) {
-      const newActivity = new Activity(plane, x, 'Unnamed', length);
+      const newActivity = new Activity(plane, time, 'Unnamed', length);
+
       this.all.push(newActivity);
       store.state = { mode: 'rename', currentActivity: newActivity, val: '' };
       store.addHistory();


### PR DESCRIPTION
I think I caught it - amazingly we were not Math.rounding the location of new activities added by double-clicking, but instead we had so many Math.rounds in other places. If this problem ever reappears, please file a bug. :) Fixes #116.