### PR TITLE
175

### DIFF
--- a/frog/imports/ui/GraphEditor/components/ScrollFields.js
+++ b/frog/imports/ui/GraphEditor/components/ScrollFields.js
@@ -5,7 +5,7 @@ import { connect, store, type StoreProp } from './../store';
 const scrollInterval = direction => {
   if (!store.scrollIntervalID) {
     store.ui.storeInterval(
-      window.setInterval(() => store.ui.panDelta(1 * direction), 20)
+      window.setInterval(() => store.ui.panDelta(3 * direction), 20)
     );
   }
 };

--- a/frog/imports/ui/GraphEditor/store/uiStore.js
+++ b/frog/imports/ui/GraphEditor/store/uiStore.js
@@ -122,8 +122,7 @@ export default class uiStore {
     this.scrollIntervalID = undefined;
   };
 
-  @action panDelta = (rawX: number): void => {
-    const deltaX = rawX * 2;
+  @action panDelta = (deltaX: number): void => {
     const oldpan = this.panx;
     const rightBoundary = this.graphWidth - this.panBoxSize;
 


### PR DESCRIPTION
#175 

The input of panDelta was multiplied by 2 without any reason. Removing it fixed the speed of scroll by dragging the panBox, but made scroll by bringing ac/op/con on an edge very slow, so I also sped that up. 