### PR TITLE
Fixing CK-Board, and giving config to mergeFunction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .tern-port
 /tmp/
 **/.babelrc
+**/npm-debug.log*

--- a/ac/ac-ck-board/package.json
+++ b/ac/ac-ck-board/package.json
@@ -17,6 +17,7 @@
     "react-draggable": "github:houshuang/react-draggable",
     "react-dropzone": "^3.13.2",
     "react-icons": "^2.2.5",
-    "react-tap-event-plugin": "2.0.1"
+    "react-tap-event-plugin": "2.0.1",
+    "styled-components": "^2.0.1"
   }
 }

--- a/ac/ac-ck-board/package.json
+++ b/ac/ac-ck-board/package.json
@@ -8,9 +8,6 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "json-stable-stringify": "^1.0.1",
-    "jsxstyle": "1.0.2",
-    "lodash": "^4.17.2",
     "material-ui": "^0.18.1",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",

--- a/ac/ac-ck-board/src/__tests__/mergeFunction.js
+++ b/ac/ac-ck-board/src/__tests__/mergeFunction.js
@@ -1,0 +1,52 @@
+import { inMemoryReactive } from 'frog-utils';
+
+import pkg from '..';
+
+Math.random = jest.fn(() => 0.5);
+
+const emptyData = { data: [], config: {} };
+const boxes = [
+  { title: 'hello', content: 'hi', id: 'a' },
+  { title: 'Howdy', content: 'wassap', id: 'b' }
+];
+const contentData = { data: boxes, config: {} };
+
+test('Merge data with no input is OK', () =>
+  inMemoryReactive(pkg.dataStructure || {}).then(({ data, dataFn }) => {
+    pkg.mergeFunction(emptyData, dataFn);
+    expect(data.data).toEqual([]);
+  }));
+
+test('Merge data with two boxes is OK', () =>
+  inMemoryReactive(pkg.dataStructure || {}).then(({ data, dataFn }) => {
+    pkg.mergeFunction(contentData, dataFn);
+    expect(data.data).toEqual([
+      { content: 'hi', id: 'a', title: 'hello', x: 200, y: 200 },
+      { content: 'wassap', id: 'b', title: 'Howdy', x: 200, y: 200 }
+    ]);
+  }));
+
+const configData = { config: { boxes }, data: [] };
+
+test('Merge no data with boxes in config', () =>
+  inMemoryReactive(pkg.dataStructure || {}).then(({ data, dataFn }) => {
+    pkg.mergeFunction(configData, dataFn);
+    expect(data.data).toEqual([
+      { content: 'hi', id: 'a', title: 'hello', x: 200, y: 200 },
+      { content: 'wassap', id: 'b', title: 'Howdy', x: 200, y: 200 }
+    ]);
+  }));
+
+const bothData = {
+  config: { boxes },
+  data: [{ content: 'leman', title: 'geneve', id: 'd' }]
+};
+test('Merge data with boxes in config', () =>
+  inMemoryReactive(pkg.dataStructure || {}).then(({ data, dataFn }) => {
+    pkg.mergeFunction(bothData, dataFn);
+    expect(data.data).toEqual([
+      { content: 'hi', id: 'a', title: 'hello', x: 200, y: 200 },
+      { content: 'wassap', id: 'b', title: 'Howdy', x: 200, y: 200 },
+      { content: 'leman', id: 'd', title: 'geneve', x: 200, y: 200 }
+    ]);
+  }));

--- a/ac/ac-ck-board/src/board.js
+++ b/ac/ac-ck-board/src/board.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
-import Stringify from 'json-stable-stringify';
 import styled from 'styled-components';
 
 import ObservationContainer from './obs_container';

--- a/ac/ac-ck-board/src/board.js
+++ b/ac/ac-ck-board/src/board.js
@@ -13,8 +13,8 @@ class Cluster extends Component {
   }
 
   render() {
-    const { config, dataFn } = this.props.activityData;
-    const { data } = this.props;
+    const { config } = this.props.activityData;
+    const { data, dataFn } = this.props;
     const List = data.map((y, i) => {
       const openInfoFn = () => this.setState({ info: y });
       const setXY = (_, draggable) => {
@@ -29,20 +29,20 @@ class Cluster extends Component {
       return (
         <Container>
           {config.quadrants
-            ? <div>
+            ? [
                 <Item group="a">
                   {config.quadrant1}
-                </Item>
+                </Item>,
                 <Item group="b">
                   {config.quadrant2}
-                </Item>
+                </Item>,
                 <Item group="c">
                   {config.quadrant3}
-                </Item>
+                </Item>,
                 <Item group="d">
                   {config.quadrant4}
                 </Item>
-              </div>
+              ]
             : null}
           <ObservationContainer
             key={i}

--- a/ac/ac-ck-board/src/board.js
+++ b/ac/ac-ck-board/src/board.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import Stringify from 'json-stable-stringify';
+import styled from 'styled-components';
 
 import ObservationContainer from './obs_container';
 import ObservationDetail from './obs_detail';
@@ -11,7 +13,9 @@ class Cluster extends Component {
   }
 
   render() {
-    const List = this.props.data.map((y, i) => {
+    const { config, dataFn } = this.props.activityData;
+    const { data } = this.props;
+    const List = data.map((y, i) => {
       const openInfoFn = () => this.setState({ info: y });
       const setXY = (_, draggable) => {
         const newObj = {
@@ -19,16 +23,34 @@ class Cluster extends Component {
           x: y.x + draggable.position.left || 1,
           y: y.y + draggable.position.top || 1
         };
-        this.props.dataFn.listReplace(y, newObj, i);
+        dataFn.listReplace(y, newObj, i);
       };
 
       return (
-        <ObservationContainer
-          key={y.id}
-          setXY={setXY}
-          openInfoFn={openInfoFn}
-          observation={y}
-        />
+        <Container>
+          {config.quadrants
+            ? <div>
+                <Item group="a">
+                  {config.quadrant1}
+                </Item>
+                <Item group="b">
+                  {config.quadrant2}
+                </Item>
+                <Item group="c">
+                  {config.quadrant3}
+                </Item>
+                <Item group="d">
+                  {config.quadrant4}
+                </Item>
+              </div>
+            : null}
+          <ObservationContainer
+            key={i}
+            setXY={setXY}
+            openInfoFn={openInfoFn}
+            observation={y}
+          />
+        </Container>
       );
     });
 
@@ -51,3 +73,21 @@ class Cluster extends Component {
 }
 
 export default Cluster;
+
+const Container = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  height: 100vh;
+`;
+
+const colors = {
+  a: '#e7ffac',
+  b: '#fbe4ff',
+  c: '#dcd3ff',
+  d: '#ffccf9'
+};
+
+const Item = styled.div`
+  width: 50%;
+  background: ${props => colors[props.group]}
+`;

--- a/ac/ac-ck-board/src/board.js
+++ b/ac/ac-ck-board/src/board.js
@@ -45,7 +45,7 @@ class Cluster extends Component {
               ]
             : null}
           <ObservationContainer
-            key={i}
+            key={y.id}
             setXY={setXY}
             openInfoFn={openInfoFn}
             observation={y}

--- a/ac/ac-ck-board/src/index.js
+++ b/ac/ac-ck-board/src/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { type ActivityPackageT } from 'frog-utils';
+import { type ActivityPackageT, uuid } from 'frog-utils';
 
 import Board from './board';
 
@@ -57,13 +57,16 @@ const config = {
 const dataStructure = [];
 
 const mergeFunction = (object, dataFn) => {
-  [...(object.config.boxes || []), ...object.data].forEach(box =>
-    dataFn.listAppend({
+  [...(object.config.boxes || []), ...object.data].forEach(box => {
+    if (!box.id) {
+      box.id = uuid();
+    }
+    return dataFn.listAppend({
       ...box,
       x: Math.random() * 400,
       y: Math.random() * 400
-    })
-  );
+    });
+  });
 };
 
 export default ({

--- a/ac/ac-ck-board/src/index.js
+++ b/ac/ac-ck-board/src/index.js
@@ -13,8 +13,28 @@ const meta = {
 const config = {
   type: 'object',
   properties: {
+    quadrants: {
+      title: 'Draw four quadrants, named as below',
+      type: 'boolean'
+    },
+    quadrant1: {
+      title: 'Quadrant 1 title',
+      type: 'string'
+    },
+    quadrant2: {
+      title: 'Quadrant 2 title',
+      type: 'string'
+    },
+    quadrant3: {
+      title: 'Quadrant 3 title',
+      type: 'string'
+    },
+    quadrant4: {
+      title: 'Quadrant 4 title',
+      type: 'string'
+    },
     boxes: {
-      title: 'Boxes',
+      title: 'Initial boxes',
       type: 'array',
       items: {
         type: 'object',
@@ -37,11 +57,11 @@ const config = {
 const dataStructure = [];
 
 const mergeFunction = (object, dataFn) => {
-  object.data.forEach(box =>
+  [...(object.config.boxes || []), ...object.data].forEach(box =>
     dataFn.listAppend({
       ...box,
-      x: Math.random() * 800,
-      y: Math.random() * 800
+      x: Math.random() * 400,
+      y: Math.random() * 400
     })
   );
 };

--- a/ac/ac-ck-board/src/obs_container.js
+++ b/ac/ac-ck-board/src/obs_container.js
@@ -18,7 +18,7 @@ export default ({ setXY, openInfoFn, observation }) => {
       <div
         style={{
           position: 'absolute',
-          fontSize: '20px',
+          fontSize: '10px',
           textOverflow: 'ellipsis',
           overflow: 'hidden',
           top: observation.y,
@@ -34,10 +34,10 @@ export default ({ setXY, openInfoFn, observation }) => {
           </div>
           <div
             style={{
-              fontSize: '15px',
+              fontSize: '8px',
               float: 'left',
-              marginTop: '15px',
-              marginLeft: '5px'
+              marginTop: '5px',
+              marginLeft: '2px'
             }}
           >
             {shorten(observation.content, 100)}

--- a/ac/ac-ck-board/yarn.lock
+++ b/ac/ac-ck-board/yarn.lock
@@ -21,6 +21,10 @@ babel-runtime@^6.20.0, babel-runtime@^6.23.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+base64-js@^1.0.2:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
+
 big.js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
@@ -28,6 +32,13 @@ big.js@^3.1.3:
 bowser@^1.6.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.6.1.tgz#9157e9498f456e937173a2918f3b2161e5353eb3"
+
+buffer@^5.0.3:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.6.tgz#2ea669f7eec0b6eda05b08f8b5ff661b28573588"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
 
 chain-function@^1.0.0:
   version "1.0.0"
@@ -49,11 +60,23 @@ core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+
 css-in-js-utils@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-1.0.3.tgz#9ac7e02f763cf85d94017666565ed68a5b5f3215"
   dependencies:
     hyphenate-style-name "^1.0.2"
+
+css-to-react-native@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.0.4.tgz#cf4cc407558b3474d4ba8be1a2cd3b6ce713101b"
+  dependencies:
+    css-color-keywords "^1.0.0"
+    fbjs "^0.8.5"
+    postcss-value-parser "^3.3.0"
 
 dom-helpers@^3.2.0:
   version "3.2.1"
@@ -73,7 +96,7 @@ esprima@~3.1.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
-fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.6, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.6, fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
@@ -85,7 +108,11 @@ fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.6, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-hoist-non-react-statics@^1.0.0:
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+
+hoist-non-react-statics@^1.0.0, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
@@ -96,6 +123,10 @@ hyphenate-style-name@^1.0.2:
 iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
+
+ieee754@^1.1.4:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
 inline-style-prefixer@^3.0.2:
   version "3.0.2"
@@ -110,9 +141,23 @@ invariant@^2.2.1:
   dependencies:
     loose-envify "^1.0.0"
 
+is-function@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
+
+is-plain-object@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.3.tgz#c15bf3e4b66b62d72efaf2925848663ecbc619b6"
+  dependencies:
+    isobject "^3.0.0"
+
 is-stream@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+isobject@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.0.tgz#39565217f3661789e8a0a0c080d5f7e6bc46e1a0"
 
 isomorphic-fetch@^2.1.1:
   version "2.2.1"
@@ -215,6 +260,10 @@ node-fetch@^1.0.1:
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+postcss-value-parser@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
 
 private@~0.1.5:
   version "0.1.7"
@@ -350,6 +399,30 @@ style-loader@^0.13.1:
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.13.2.tgz#74533384cf698c7104c7951150b49717adc2f3bb"
   dependencies:
     loader-utils "^1.0.2"
+
+styled-components@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-2.1.0.tgz#425805fca7efa5880aad2171f986bfd8a2f0808f"
+  dependencies:
+    buffer "^5.0.3"
+    css-to-react-native "^2.0.3"
+    fbjs "^0.8.9"
+    hoist-non-react-statics "^1.2.0"
+    is-function "^1.0.1"
+    is-plain-object "^2.0.1"
+    prop-types "^15.5.4"
+    stylis "^3.0.19"
+    supports-color "^3.2.3"
+
+stylis@^3.0.19:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.1.9.tgz#638370451f980437f57c59e58d2e296be29fafb7"
+
+supports-color@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
+  dependencies:
+    has-flag "^1.0.0"
 
 symbol-observable@^1.0.4:
   version "1.0.4"

--- a/frog-utils/package.json
+++ b/frog-utils/package.json
@@ -15,5 +15,8 @@
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "recompose": "^0.23.5"
+  },
+  "devDependencies": {
+    "sharedb": "^1.0.0-beta.7"
   }
 }

--- a/frog-utils/src/__tests__/generateReactiveFn.js
+++ b/frog-utils/src/__tests__/generateReactiveFn.js
@@ -1,6 +1,6 @@
 import ShareDB from 'sharedb';
 import { uuid } from 'frog-utils';
-import generateReactiveFn from '../generateReactiveFn';
+import { generateReactiveFn } from '../generateReactiveFn';
 
 const share = new ShareDB();
 const connection = share.connect();

--- a/frog-utils/src/generateReactiveFn.js
+++ b/frog-utils/src/generateReactiveFn.js
@@ -99,7 +99,7 @@ export const generateReactiveFn = (doc: any): Object => {
 
 export const inMemoryReactive = (
   initial: any
-): Promise<{ data: any, datafn: Doc }> => {
+): Promise<{ data: any, dataFn: Doc }> => {
   const share = new ShareDB();
   const connection = share.connect();
 

--- a/frog-utils/src/generateReactiveFn.js
+++ b/frog-utils/src/generateReactiveFn.js
@@ -1,7 +1,6 @@
 // @flow
-
-import { uuid } from './index';
 import ShareDB from 'sharedb';
+import { uuid } from './index';
 
 type rawPathT = string | string[];
 

--- a/frog-utils/src/index.js
+++ b/frog-utils/src/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { compose, withHandlers, withState } from 'recompose';
 
+export { generateReactiveFn, inMemoryReactive } from './generateReactiveFn';
 export { default as uuid } from 'cuid';
 export { default as colorRange } from './colorRange';
 export { default as unrollProducts } from './unrollProducts';

--- a/frog-utils/yarn.lock
+++ b/frog-utils/yarn.lock
@@ -2,9 +2,17 @@
 # yarn lockfile v1
 
 
+arraydiff@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/arraydiff/-/arraydiff-0.1.3.tgz#86a5436d7b72f1bdda5fd6d74e8724e42f83ce4d"
+
 asap@~2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
+
+async@^1.4.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
 browser-fingerprint@0.0.1:
   version "0.0.1"
@@ -26,6 +34,10 @@ cuid@^1.3.8:
     core-js "^1.1.1"
     node-fingerprint "0.0.2"
 
+deep-is@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
 encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
@@ -43,6 +55,10 @@ fbjs@^0.8.1, fbjs@^0.8.9:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
+
+hat@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/hat/-/hat-0.0.3.tgz#bb014a9e64b3788aed8005917413d4ff3d502d8a"
 
 hoist-non-react-statics@^1.0.0:
   version "1.2.0"
@@ -73,6 +89,10 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   dependencies:
     js-tokens "^3.0.0"
 
+make-error@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.0.tgz#52ad3a339ccf10ce62b4040b708fe707244b8b96"
+
 node-fetch@^1.0.1:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
@@ -87,6 +107,10 @@ node-fingerprint@0.0.2:
 object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+ot-json0@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ot-json0/-/ot-json0-1.0.1.tgz#3edfe7b73bd1f192c0737d332050e23515be354a"
 
 promise@^7.1.1:
   version "7.1.1"
@@ -131,6 +155,17 @@ recompose@^0.23.5:
 setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
+sharedb@^1.0.0-beta.7:
+  version "1.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/sharedb/-/sharedb-1.0.0-beta.7.tgz#82118293db29dd3d781692ae3a39cfdef297b698"
+  dependencies:
+    arraydiff "^0.1.1"
+    async "^1.4.2"
+    deep-is "^0.1.3"
+    hat "0.0.3"
+    make-error "^1.1.1"
+    ot-json0 "^1.0.1"
 
 symbol-observable@^1.0.4:
   version "1.0.4"

--- a/frog/imports/ui/StudentView/ReactiveHOC.jsx
+++ b/frog/imports/ui/StudentView/ReactiveHOC.jsx
@@ -1,8 +1,9 @@
 // @flow
 
 import React, { Component } from 'react';
+import { generateReactiveFn } from 'frog-utils';
+
 import { connection } from '../App/index';
-import generateReactiveFn from '../../api/generateReactiveFn';
 
 const getDisplayName = (WrappedComponent: any): string => {
   if (typeof WrappedComponent.displayName === 'string') {

--- a/frog/imports/ui/StudentView/ReactiveHOC.jsx
+++ b/frog/imports/ui/StudentView/ReactiveHOC.jsx
@@ -19,7 +19,7 @@ const ReactiveHOC = (dataStructure: any, docId: string) => (
   WrappedComponent: Class<Component<*, *, *>>
 ) => {
   class ReactiveComp extends Component {
-    state: { data: any, dataFn: Object };
+    state: { data: any, dataFn: ?Object };
     doc: any;
     timeout: ?number;
     unmounted: boolean;
@@ -28,7 +28,7 @@ const ReactiveHOC = (dataStructure: any, docId: string) => (
       super(props);
       this.state = {
         data: dataStructure,
-        dataFn: {}
+        dataFn: null
       };
     }
 

--- a/frog/imports/ui/StudentView/Runner.jsx
+++ b/frog/imports/ui/StudentView/Runner.jsx
@@ -40,10 +40,9 @@ const Runner = ({ activity, object }) => {
 
     const RunComp = activityType.ActivityRunner;
     RunComp.displayName = activity.activityType;
-    const ActivityToRun = ReactiveHOC(
-      { ...activityType.dataStructure },
-      reactiveId
-    )(RunComp);
+    const ActivityToRun = ReactiveHOC(activityType.dataStructure, reactiveId)(
+      RunComp
+    );
 
     const groupingStr = activity.groupingKey ? activity.groupingKey + '/' : '';
     let title = '(' + groupingStr + groupingValue + ')';

--- a/frog/server/mergeData.js
+++ b/frog/server/mergeData.js
@@ -1,12 +1,11 @@
 // @flow
 
 import { Meteor } from 'meteor/meteor';
-import { extractUnit, type ObjectT } from 'frog-utils';
+import { generateReactiveFn, extractUnit, type ObjectT } from 'frog-utils';
 import { Activities, getInstances } from '../imports/api/activities';
 
 import { serverConnection } from './share-db-manager';
 import { activityTypesObj } from '../imports/activityTypes';
-import generateReactiveFn from '../imports/api/generateReactiveFn';
 
 export default (activityId: string, object: ObjectT) => {
   const { activityData } = object;

--- a/frog/server/mergeData.js
+++ b/frog/server/mergeData.js
@@ -1,7 +1,11 @@
 // @flow
 
 import { Meteor } from 'meteor/meteor';
-import { generateReactiveFn, extractUnit, type ObjectT } from 'frog-utils';
+import {
+  generateReactiveFn,
+  getMergedExtractedUnit,
+  type ObjectT
+} from 'frog-utils';
 import { Activities, getInstances } from '../imports/api/activities';
 
 import { serverConnection } from './share-db-manager';
@@ -38,10 +42,12 @@ export default (activityId: string, object: ObjectT) => {
         if (mergeFunction) {
           const dataFn = generateReactiveFn(doc);
           // merging in config with incoming product
-          const instanceActivityData = extractUnit(
+          const instanceActivityData = getMergedExtractedUnit(
+            activity.data,
             activityData,
             structure,
-            grouping
+            grouping,
+            object.socialStructure
           );
           if (instanceActivityData) {
             mergeFunction(instanceActivityData, dataFn);

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
   },
   "license": "ISC",
   "dependencies": {
-    "assert": "^1.4.1"
+    "assert": "^1.4.1",
+    "enzyme": "^2.8.2",
+    "react-test-renderer": "^15.6.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -158,6 +158,10 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
+asap@~2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
+
 asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
@@ -989,6 +993,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -1103,6 +1111,27 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
 charenc@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+
+cheerio@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.22.0.tgz#a9baa860a3f9b595a6b81b1a86873121ed3a269e"
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash.assignin "^4.0.9"
+    lodash.bind "^4.1.4"
+    lodash.defaults "^4.0.1"
+    lodash.filter "^4.4.0"
+    lodash.flatten "^4.2.0"
+    lodash.foreach "^4.3.0"
+    lodash.map "^4.4.0"
+    lodash.merge "^4.4.0"
+    lodash.pick "^4.2.1"
+    lodash.reduce "^4.4.0"
+    lodash.reject "^4.4.0"
+    lodash.some "^4.4.0"
 
 chokidar@^1.6.1:
   version "1.6.1"
@@ -1231,6 +1260,10 @@ convert-source-map@^1.1.0, convert-source-map@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+
 core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
@@ -1248,6 +1281,19 @@ cryptiles@2.x.x:
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
   dependencies:
     boom "2.x.x"
+
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
+css-what@2.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
@@ -1374,6 +1420,34 @@ doctrine@^2.0.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
+dom-serializer@0, dom-serializer@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+  dependencies:
+    domelementtype "~1.1.1"
+    entities "~1.1.1"
+
+domelementtype@1, domelementtype@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+
+domelementtype@~1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
+
+domhandler@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
+  dependencies:
+    domelementtype "1"
+
+domutils@1.5.1, domutils@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
 double-ended-queue@^2.1.0-0:
   version "2.1.0-0"
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
@@ -1414,11 +1488,36 @@ emoji-regex@^6.1.0:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.4.2.tgz#a30b6fee353d406d96cfb9fa765bdc82897eff6e"
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
+
 enqueue@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/enqueue/-/enqueue-1.0.2.tgz#9014e9bce570ee93ca96e6c8e63ad54c192b6bc8"
   dependencies:
     sliced "0.0.5"
+
+entities@^1.1.1, entities@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+enzyme@^2.8.2:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-2.8.2.tgz#6c8bcb05012abc4aa4bc3213fb23780b9b5b1714"
+  dependencies:
+    cheerio "^0.22.0"
+    function.prototype.name "^1.0.0"
+    is-subset "^0.1.1"
+    lodash "^4.17.2"
+    object-is "^1.0.1"
+    object.assign "^4.0.4"
+    object.entries "^1.0.3"
+    object.values "^1.0.3"
+    prop-types "^15.5.4"
+    uuid "^2.0.3"
 
 "errno@>=0.1.1 <0.2.0-0":
   version "0.1.4"
@@ -1432,7 +1531,7 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.7.0:
+es-abstract@^1.6.1, es-abstract@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
   dependencies:
@@ -1776,6 +1875,18 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 fd-slicer@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
@@ -1982,6 +2093,14 @@ function-source@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/function-source/-/function-source-0.1.0.tgz#d9104bf3e46788b55468c02bf1b2fabcf8fc19af"
 
+function.prototype.name@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.0.0.tgz#5f523ca64e491a5f95aba80cc1e391080a14482e"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.0"
+    is-callable "^1.1.2"
+
 gauge@~2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.3.tgz#1c23855f962f17b3ad3d0dc7443f304542edfe09"
@@ -2161,6 +2280,17 @@ html-encoding-sniffer@^1.0.1:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+htmlparser2@^3.9.1:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -2169,7 +2299,7 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.13:
+iconv-lite@0.4.13, iconv-lite@~0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
@@ -2258,7 +2388,7 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-callable@^1.1.1, is-callable@^1.1.3:
+is-callable@^1.1.1, is-callable@^1.1.2, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
 
@@ -2371,6 +2501,14 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
+is-stream@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-subset@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
+
 is-symbol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
@@ -2400,6 +2538,13 @@ isobject@^2.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
     isarray "1.0.0"
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -2856,15 +3001,63 @@ lodash.assign@^4.0.3, lodash.assign@^4.0.6:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
+lodash.assignin@^4.0.9:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
+
+lodash.bind@^4.1.4:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
+
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
+
+lodash.defaults@^4.0.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+
+lodash.filter@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
+
+lodash.flatten@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+
+lodash.foreach@^4.3.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+
+lodash.map@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
+
+lodash.merge@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
+
+lodash.pick@^4.2.1:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
+lodash.reduce@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
+
+lodash.reject@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
+
+lodash.some@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
 
 lodash@3.0.x:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.0.1.tgz#14d49028a38bc740241d11e2ecd57ec06d73c19a"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2872,7 +3065,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -3043,6 +3236,13 @@ nightmare@^2.10.0:
     sliced "1.0.1"
     split2 "^2.0.1"
 
+node-fetch@^1.0.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.1.tgz#899cb3d0a3c92f952c47f1b876f4c8aeabd400d5"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -3118,6 +3318,12 @@ nps@^5.3.2:
     type-detect "^4.0.0"
     yargs "^6.6.0"
 
+nth-check@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
+  dependencies:
+    boolbase "~1.0.0"
+
 nugget@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/nugget/-/nugget-2.0.1.tgz#201095a487e1ad36081b3432fa3cada4f8d071b0"
@@ -3146,7 +3352,11 @@ object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
-object-keys@^1.0.8:
+object-is@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
+
+object-keys@^1.0.10, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
@@ -3154,12 +3364,38 @@ object-keys@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
 
+object.assign@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.0.4.tgz#b1c9cc044ef1b9fe63606fc141abbb32e14730cc"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.0"
+    object-keys "^1.0.10"
+
+object.entries@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
+
 object.omit@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
+
+object.values@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.0.4.tgz#e524da09b4f66ff05df457546ec72ac99f13069a"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
@@ -3381,6 +3617,19 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  dependencies:
+    asap "~2.0.3"
+
+prop-types@^15.5.4:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -3423,6 +3672,13 @@ rc@^1.1.2, rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-test-renderer@^15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.1.tgz#026f4a5bb5552661fd2cc4bbcd0d4bc8a35ebf7e"
+  dependencies:
+    fbjs "^0.8.9"
+    object-assign "^4.1.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -3694,7 +3950,7 @@ set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
-"setimmediate@>= 1.0.1 < 2", "setimmediate@>= 1.0.2 < 2":
+"setimmediate@>= 1.0.1 < 2", "setimmediate@>= 1.0.2 < 2", setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
@@ -4058,6 +4314,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+ua-parser-js@^0.7.9:
+  version "0.7.13"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.13.tgz#cd9dd2f86493b3f44dbeeef3780fda74c5ee14be"
+
 uglify-js@^2.6:
   version "2.8.28"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.28.tgz#e335032df9bb20dcb918f164589d5af47f38834a"
@@ -4105,6 +4365,10 @@ util@0.10.3:
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   dependencies:
     inherits "2.0.1"
+
+uuid@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
 uuid@^3.0.0:
   version "3.0.1"
@@ -4159,6 +4423,10 @@ whatwg-encoding@^1.0.1:
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz#3c6c451a198ee7aec55b1ec61d0920c67801a5f4"
   dependencies:
     iconv-lite "0.4.13"
+
+whatwg-fetch@>=0.10.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
 whatwg-url@^4.3.0:
   version "4.8.0"


### PR DESCRIPTION
This PR updates CK-board to work properly. It makes sure that the mergeFunction receives both the config data and the activity data, and merges the two in the mergeFunction. I add ways of testing the mergeFunction, but having an easy way to create an in-memory reactiveDataFn / doc. 

I also added the option of having the four quadrants, with titles configurable. (I don't think there's an easy way of hiding the four titles, if people click "no", so that's a bit confusing).

I've tested this manually data straight from op-hypothesis, op-hypothesis + config data, or just config data.

I only tested in the all configuration, I didn't test manually if it also works in p1/p2, but it should.

Because I needed access to the generateReactiveData from an operator, I moved it to frog-utils.