### PR TITLE
Re-include hidden files in initial_setup

### DIFF
--- a/initial_setup_wo_meteor.sh
+++ b/initial_setup_wo_meteor.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+shopt -s dotglob
+
 FROG=`pwd`
 YARN=yarn
 which yarn | grep -qw yarn || npm install yarn@0.24.6


### PR DESCRIPTION
I had trouble installing FROG on both my macbook and Ubuntu desktop because of this line that was removed. It makes the bash commands include hidden files.