### PR TITLE
Adding command a to copy existing activity length

### DIFF
--- a/frog/imports/ui/GraphEditor/index.js
+++ b/frog/imports/ui/GraphEditor/index.js
@@ -39,4 +39,7 @@ const bindKeys = () => {
   Mousetrap.bind('p', () => store.operatorStore.place('product'));
   Mousetrap.bind('w', () => store.ui.toggleSidepanelOpen());
   Mousetrap.bind('a', () => store.activityStore.newActivityAbove());
+  Mousetrap.bind('1', () => store.activityStore.newActivityAbove(1));
+  Mousetrap.bind('2', () => store.activityStore.newActivityAbove(2));
+  Mousetrap.bind('3', () => store.activityStore.newActivityAbove(3));
 };

--- a/frog/imports/ui/GraphEditor/index.js
+++ b/frog/imports/ui/GraphEditor/index.js
@@ -38,4 +38,5 @@ const bindKeys = () => {
   Mousetrap.bind('s', () => store.operatorStore.place('social'));
   Mousetrap.bind('p', () => store.operatorStore.place('product'));
   Mousetrap.bind('w', () => store.ui.toggleSidepanelOpen());
+  Mousetrap.bind('a', () => store.activityStore.newActivityAbove());
 };

--- a/frog/imports/ui/GraphEditor/store/activityStore.js
+++ b/frog/imports/ui/GraphEditor/store/activityStore.js
@@ -81,6 +81,17 @@ export default class ActivityStore {
   };
 
   @action
+  newActivityAbove = () => {
+    if (store.ui.selected instanceof Activity) {
+      const toCopy = store.ui.selected;
+      store.activityStore.all.push(
+        new Activity(toCopy.plane, toCopy.startTime, 'Unnamed', toCopy.length)
+      );
+      store.addHistory();
+    }
+  };
+
+  @action
   swapActivities = (left: Activity, right: Activity) => {
     right.startTime = left.startTime;
     left.startTime = right.startTime + right.length;

--- a/frog/imports/ui/GraphEditor/store/activityStore.js
+++ b/frog/imports/ui/GraphEditor/store/activityStore.js
@@ -81,7 +81,7 @@ export default class ActivityStore {
   };
 
   @action
-  newActivityAbove = plane => {
+  newActivityAbove = (plane?: number) => {
     if (store.ui.selected instanceof Activity) {
       const toCopy = store.ui.selected;
       store.activityStore.all.push(

--- a/frog/imports/ui/GraphEditor/store/activityStore.js
+++ b/frog/imports/ui/GraphEditor/store/activityStore.js
@@ -81,11 +81,16 @@ export default class ActivityStore {
   };
 
   @action
-  newActivityAbove = () => {
+  newActivityAbove = plane => {
     if (store.ui.selected instanceof Activity) {
       const toCopy = store.ui.selected;
       store.activityStore.all.push(
-        new Activity(toCopy.plane, toCopy.startTime, 'Unnamed', toCopy.length)
+        new Activity(
+          plane || toCopy.plane,
+          toCopy.startTime,
+          'Unnamed',
+          toCopy.length
+        )
       );
       store.addHistory();
     }


### PR DESCRIPTION
This adds keyboard commands to the graph editor, to quickly create new activities that have the same length as the current activity. Given a currently selected activity, 'a' adds the activity on the same plane, and 1/2/3 adds an activity on the desired plane. This seems to be a common need when designing graphs with multiple concurrent activities. Only start-time and end-time is copied, not title/acType, etc.