### PR TITLE
Making sure imported graphs work properly

### DIFF
--- a/frog/imports/ui/GraphEditor/utils/export.js
+++ b/frog/imports/ui/GraphEditor/utils/export.js
@@ -1,6 +1,7 @@
 import Stringify from 'json-stringify-pretty-compact';
 import fileDialog from 'file-dialog';
 import FileSaver from 'file-saver';
+import { uuid } from 'frog-utils';
 
 import { Activities, Operators, Connections } from '../../../api/activities';
 import { Graphs, addGraph, uploadGraph } from '../../../api/graphs';
@@ -34,10 +35,11 @@ const doImportGraph = graphStr => {
   const graphObj = JSON.parse(graphStr.target.result);
   const importNo = getGlobalSetting('importNo') || 0;
   setGlobalSetting('importNo', importNo + 1);
-  const graphId = addGraph(
-    graphObj.graph.name + ' ' + importNo,
-    graphObj.graph
-  );
+  const graphId = addGraph(graphObj.graph.name + ' ' + importNo, {
+    ...graphObj.graph,
+    _id: uuid(),
+    sessionId: null
+  });
   const fixId = id => importNo + '-' + id;
   const specify = obj => ({ ...obj, _id: fixId(obj._id), graphId });
   uploadGraph({


### PR DESCRIPTION
This assigns new IDs, and clears the sessionId field. I had a case where a graph had been exported as a session, and when importing it, I was not able to start a new session based on it. 

(In the future, we will have true "export session" stuff, and we also want to make it easier to move between "graph" and "session", but for now, this is what we'd expect when importing a graph)