### PR TITLE
Fixing Runner

### DIFF
--- a/frog/imports/ui/StudentView/Runner.jsx
+++ b/frog/imports/ui/StudentView/Runner.jsx
@@ -51,7 +51,7 @@ const Runner = ({ activity, object }) => {
     }
 
     const config = activity.data;
-    const activityStructure = getInstances(activity._id)[1];
+    const activityStructure = getInstances(activity._id).structure;
 
     const activityData = getMergedExtractedUnit(
       config,


### PR DESCRIPTION
This is quite an egregious bug, that harks back to your switching from an array to an Object for doGetInstances. Of course, it would have been better for JS to just complain that you're doing [1] on an object, but instead we just silently get undefined, and the error ends up much later down the stack. I'm actually quite surprised that Flow didn't catch this, the files are all flow-checked.