### PR TITLE
Fixing op-create-groups

### DIFF
--- a/op/op-create-groups/src/__tests__/index.js
+++ b/op/op-create-groups/src/__tests__/index.js
@@ -7,10 +7,16 @@ const operator = pkg.operator;
 lodash.shuffle = jest.fn(x => [...x].sort());
 
 const obj = { globalStructure: { studentIds: ['1', '2', '3', '4', '5'] } };
+const obj4 = { globalStructure: { studentIds: ['1', '2', '3', '4'] } };
 
 test('Create groups minimum', () =>
   expect(operator({ strategy: 'minimum', groupsize: 2 }, obj)).toEqual({
     group: { '1': ['1', '2', '5'], '2': ['3', '4'] }
+  }));
+
+test('Create groups minimum, 4', () =>
+  expect(operator({ strategy: 'minimum', groupsize: 2 }, obj4)).toEqual({
+    group: { '1': ['1', '2'], '2': ['3', '4'] }
   }));
 
 test('Create groups maximum', () =>

--- a/op/op-create-groups/src/index.js
+++ b/op/op-create-groups/src/index.js
@@ -33,7 +33,7 @@ const operator = (configData, object) => {
 
   const ids = shuffle(globalStructure.studentIds);
   const struct = chunk(ids, configData.groupsize);
-  const last = struct.slice(-1);
+  const last = struct.slice(-1)[0];
   if (last.length < configData.groupsize && configData.strategy === 'minimum') {
     const leftover = struct.pop();
     while (leftover.length > 0) {


### PR DESCRIPTION
There was a bug that led to settings: size 2, strategy: min to generate one group of 4. Fixed, and added test.