### PR TITLE
Removing navigation bar for students, and chrome for single activities

### DIFF
--- a/frog/imports/ui/App/Navigation.jsx
+++ b/frog/imports/ui/App/Navigation.jsx
@@ -1,11 +1,22 @@
 // @flow
 
 import React from 'react';
+import Meteor from 'meteor/meteor';
 import { Nav, NavItem } from 'react-bootstrap';
 
-export default ({ apps, currentApp }: { apps: Object, currentApp: string }) =>
+export default ({
+  apps,
+  currentApp,
+  username
+}: {
+  apps: Object,
+  currentApp: string,
+  username: string
+}) =>
   <Nav bsStyle="pills" activeKey={currentApp}>
     {Object.keys(apps).map(app =>
-      <NavItem key={app} eventKey={app} href={'/#/' + app}>{apps[app]}</NavItem>
+      <NavItem key={app} eventKey={app} href={'/#/' + username + '/' + app}>
+        {apps[app]}
+      </NavItem>
     )}
   </Nav>;

--- a/frog/imports/ui/App/Navigation.jsx
+++ b/frog/imports/ui/App/Navigation.jsx
@@ -1,7 +1,6 @@
 // @flow
 
 import React from 'react';
-import Meteor from 'meteor/meteor';
 import { Nav, NavItem } from 'react-bootstrap';
 
 export default ({

--- a/frog/imports/ui/App/index.js
+++ b/frog/imports/ui/App/index.js
@@ -28,16 +28,16 @@ window.connection = connection;
 
 // App component - represents the whole app
 export default class App extends Component {
-  state: { app: string };
+  state: { app: string, username: string };
 
   constructor() {
     super();
-    this.state = { app: 'home' };
+    this.state = { app: 'home', username: '' };
     Meteor.subscribe('userData', { onReady: this.handleNewHash });
   }
 
   handleNewHash = () => {
-    const [, location, username] = window.location.hash.split('/');
+    const [, username, location] = window.location.hash.split('/');
     if (username) {
       if (!Meteor.users.findOne({ username })) {
         Accounts.createUser({ username, password: DEFAULT_PASSWORD }, () =>
@@ -47,7 +47,10 @@ export default class App extends Component {
         connectWithDefaultPwd(username);
       }
     }
-    if (location && apps[location]) {
+    this.setState({ username });
+    if (username !== 'teacher') {
+      this.setState({ app: 'student' });
+    } else if (location && apps[location]) {
       this.setState({ app: location });
     }
   };
@@ -59,10 +62,14 @@ export default class App extends Component {
   render() {
     return (
       <div id="app">
-        <div id="header">
-          <AccountsUIWrapper />
-          <Navigation apps={apps} currentApp={this.state.app} />
-        </div>
+        {this.state.username === 'teacher' &&
+          <div id="header">
+            <Navigation
+              username={this.state.username}
+              apps={apps}
+              currentApp={this.state.app}
+            />
+          </div>}
         <div id="body">
           <Body app={this.state.app} />
         </div>

--- a/frog/imports/ui/App/index.js
+++ b/frog/imports/ui/App/index.js
@@ -7,7 +7,6 @@ import sharedbClient from 'sharedb/lib/client';
 import ReconnectingWebSocket from 'reconnectingwebsocket';
 
 import Body from './Body.jsx';
-import AccountsUIWrapper from './AccountsUIWrapper.jsx';
 import Navigation from './Navigation';
 
 const DEFAULT_PASSWORD = '123456';

--- a/frog/imports/ui/GraphEditor/utils/export.js
+++ b/frog/imports/ui/GraphEditor/utils/export.js
@@ -60,6 +60,7 @@ const doImportGraph = graphStr => {
     });
     store.setId(graphId);
   } catch (e) {
+    // eslint-ignore-next-line no-alert
     window.alert('File has error, unable to import graph');
   }
 };

--- a/frog/imports/ui/StudentView/Runner.jsx
+++ b/frog/imports/ui/StudentView/Runner.jsx
@@ -14,7 +14,7 @@ import { Activities } from '../../api/activities';
 import doGetInstances from '../../api/doGetInstances';
 import ReactiveHOC from './ReactiveHOC';
 
-const Runner = ({ activity, object }) => {
+const Runner = ({ activity, object, single }) => {
   if (!activity) {
     return <p>NULL ACTIVITY</p>;
   }
@@ -64,21 +64,29 @@ const Runner = ({ activity, object }) => {
       object.socialStructure
     );
 
-    return (
-      <MosaicWindow title={activity.title + ' ' + title}>
-        <ActivityToRun
-          activityData={activityData}
-          userInfo={{ name: Meteor.user().username, id: Meteor.userId() }}
-          logger={logger}
-        />
-      </MosaicWindow>
+    const activity = (
+      <ActivityToRun
+        activityData={activityData}
+        userInfo={{ name: Meteor.user().username, id: Meteor.userId() }}
+        logger={logger}
+      />
     );
+
+    if (single) {
+      return activity;
+    } else {
+      return (
+        <MosaicWindow title={activity.title + ' ' + title}>
+          {activity}
+        </MosaicWindow>
+      );
+    }
   }
   return null;
 };
 
-export default createContainer(({ activityId }) => {
+export default createContainer(({ activityId, single }) => {
   const object = Objects.findOne(activityId) || {};
   const activity = Activities.findOne(activityId);
-  return { activity, object };
+  return { activity, object, single };
 }, Runner);

--- a/frog/imports/ui/StudentView/Runner.jsx
+++ b/frog/imports/ui/StudentView/Runner.jsx
@@ -26,63 +26,63 @@ const Runner = ({ activity, object, single }) => {
     user: Meteor.userId()
   });
 
-  if (object) {
-    const socStructure = focusStudent(object.socialStructure);
-    const studentSoc = socStructure[Meteor.userId()];
-
-    let groupingValue;
-    if (studentSoc && activity.groupingKey) {
-      groupingValue = studentSoc[activity.groupingKey];
-    } else if (activity.plane === 3) {
-      groupingValue = 'all';
-    } else {
-      groupingValue = Meteor.userId();
-    }
-    const reactiveId = activity._id + '/' + groupingValue;
-
-    const RunComp = activityType.ActivityRunner;
-    RunComp.displayName = activity.activityType;
-    const ActivityToRun = ReactiveHOC(
-      cloneDeep(activityType.dataStructure),
-      reactiveId
-    )(RunComp);
-
-    const groupingStr = activity.groupingKey ? activity.groupingKey + '/' : '';
-    let title = '(' + groupingStr + groupingValue + ')';
-    if (activity.plane === 1) {
-      title = `(individual/${Meteor.user().username})`;
-    }
-
-    const config = activity.data;
-    const activityStructure = doGetInstances(activity, object).structure;
-
-    const activityData = getMergedExtractedUnit(
-      config,
-      object.activityData,
-      activityStructure,
-      groupingValue,
-      object.socialStructure
-    );
-
-    const activity = (
-      <ActivityToRun
-        activityData={activityData}
-        userInfo={{ name: Meteor.user().username, id: Meteor.userId() }}
-        logger={logger}
-      />
-    );
-
-    if (single) {
-      return activity;
-    } else {
-      return (
-        <MosaicWindow title={activity.title + ' ' + title}>
-          {activity}
-        </MosaicWindow>
-      );
-    }
+  if (!object) {
+    return null;
   }
-  return null;
+  const socStructure = focusStudent(object.socialStructure);
+  const studentSoc = socStructure[Meteor.userId()];
+
+  let groupingValue;
+  if (studentSoc && activity.groupingKey) {
+    groupingValue = studentSoc[activity.groupingKey];
+  } else if (activity.plane === 3) {
+    groupingValue = 'all';
+  } else {
+    groupingValue = Meteor.userId();
+  }
+  const reactiveId = activity._id + '/' + groupingValue;
+
+  const RunComp = activityType.ActivityRunner;
+  RunComp.displayName = activity.activityType;
+  const ActivityToRun = ReactiveHOC(
+    cloneDeep(activityType.dataStructure),
+    reactiveId
+  )(RunComp);
+
+  const groupingStr = activity.groupingKey ? activity.groupingKey + '/' : '';
+  let title = '(' + groupingStr + groupingValue + ')';
+  if (activity.plane === 1) {
+    title = `(individual/${Meteor.user().username})`;
+  }
+
+  const config = activity.data;
+  const activityStructure = doGetInstances(activity, object).structure;
+
+  const activityData = getMergedExtractedUnit(
+    config,
+    object.activityData,
+    activityStructure,
+    groupingValue,
+    object.socialStructure
+  );
+
+  const Torun = (
+    <ActivityToRun
+      activityData={activityData}
+      userInfo={{ name: Meteor.user().username, id: Meteor.userId() }}
+      logger={logger}
+    />
+  );
+
+  if (single) {
+    return Torun;
+  } else {
+    return (
+      <MosaicWindow title={activity.title + ' ' + title}>
+        {Torun}
+      </MosaicWindow>
+    );
+  }
 };
 
 export default createContainer(({ activityId, single }) => {

--- a/frog/imports/ui/StudentView/SessionBody.jsx
+++ b/frog/imports/ui/StudentView/SessionBody.jsx
@@ -16,12 +16,21 @@ const getInitialState = (activities, d = 1) => {
       };
 };
 
-const SessionBody = ({ session }: { session: Object }) =>
-  session.openActivities && session.openActivities.length > 0
-    ? <Mosaic
+const SessionBody = ({ session }: { session: Object }) => {
+  if (!session.openActivities) {
+    return <h1>NO ACTIVITY</h1>;
+  }
+  if (session.openActivities.length === 1) {
+    console.log(session.openActivities);
+    return <Runner activityId={session.openActivities[0]} single />;
+  } else {
+    return (
+      <Mosaic
         renderTile={activityId => <Runner activityId={activityId} />}
         initialValue={getInitialState(session.openActivities)}
       />
-    : <h1>NO ACTIVITY</h1>;
+    );
+  }
+};
 
 export default SessionBody;

--- a/frog/imports/ui/StudentView/SessionBody.jsx
+++ b/frog/imports/ui/StudentView/SessionBody.jsx
@@ -21,7 +21,6 @@ const SessionBody = ({ session }: { session: Object }) => {
     return <h1>NO ACTIVITY</h1>;
   }
   if (session.openActivities.length === 1) {
-    console.log(session.openActivities);
     return <Runner activityId={session.openActivities[0]} single />;
   } else {
     return (


### PR DESCRIPTION
Ref #302. This makes URLs the only way to log in, and reverses the order (username, then app). Teacher status is set by username === 'teacher' (for now). Teacher sees navigation bar, and the apps in the URL bar are taken into account. Other users go directly to student view, and do not see the navigation bar.

It also removes the layout chrome for single activities in Runner... Not sure if this is desirable - you loose the title and the grouping info which is useful for debug, but you have more flexibility for custom layout etc.