### PR TITLE
Fix empty object bug in Runner

### DIFF
--- a/frog/imports/ui/StudentView/Runner.jsx
+++ b/frog/imports/ui/StudentView/Runner.jsx
@@ -86,7 +86,7 @@ const Runner = ({ activity, object, single }) => {
 };
 
 export default createContainer(({ activityId, single }) => {
-  const object = Objects.findOne(activityId) || {};
+  const object = Objects.findOne(activityId);
   const activity = Activities.findOne(activityId);
   return { activity, object, single };
 }, Runner);

--- a/frog/imports/ui/StudentView/SessionBody.jsx
+++ b/frog/imports/ui/StudentView/SessionBody.jsx
@@ -17,7 +17,7 @@ const getInitialState = (activities, d = 1) => {
 };
 
 const SessionBody = ({ session }: { session: Object }) => {
-  if (!session.openActivities) {
+  if (!session.openActivities || session.openActivities.length === 0) {
     return <h1>NO ACTIVITY</h1>;
   }
   if (session.openActivities.length === 1) {


### PR DESCRIPTION
## Previous behavior
- When starting with an activity on individual plane, studentView was not updated automatically when teacher clicked start. It was actually crashing with `cannot access studentIds of undefined at doGetInstances`

## Reasons
`if(!object){...}` was doing `...` even when `object = {}`. Indeed ` !{} === false`

## Other
small fix about the no activity state when `session.openActivities` is not undefined but an empty list (again `![] === false` )
