### PR TITLE
Adding highlighting of erroneous ac/op

### DIFF
--- a/frog/imports/api/__tests__/validGraphFnTest.js
+++ b/frog/imports/api/__tests__/validGraphFnTest.js
@@ -37,6 +37,10 @@ test("Test activityType desn't exist => unvalid", () => {
   expect(resultToIds(g8)).toEqual(['cj5azthci000d3k6o919vps5d']);
 });
 
+test('Test operator does not have outgoing connections', () => {
+  expect(resultToIds(g9)).toEqual(['cj5szsc93000b3k6o3suw338f']);
+});
+
 const g1 = {
   graph: {
     _id: 'cj5aziuo400003k6om24tozbn',
@@ -94,7 +98,13 @@ const g3 = {
       type: 'social'
     }
   ],
-  connections: []
+  connections: [
+    {
+      _id: 'cj5azrxuo000a3k6oo1j2ek0k',
+      source: { type: 'operator', id: 'cj5azl3d600033k6og3gtozas' },
+      target: { type: 'activity', id: 'cj5azm5kf00063k6o7vwz37pt' }
+    }
+  ]
 };
 
 const g4 = {
@@ -114,7 +124,13 @@ const g4 = {
       operatorType: 'op-group-identical'
     }
   ],
-  connections: []
+  connections: [
+    {
+      _id: 'cj5azrxuo000a3k6oo1j2ek0k',
+      source: { type: 'operator', id: 'cj5azuchn000e3k6oidbdvsfq' },
+      target: { type: 'activity', id: 'cj5azm5kf00063k6o7vwz37pt' }
+    }
+  ]
 };
 
 const g5 = {
@@ -230,5 +246,26 @@ const g8 = {
     }
   ],
   operators: [],
+  connections: []
+};
+
+const g9 = {
+  graph: {
+    _id: 'cj5aziuo400003k6om24tozbn',
+    name: 'TestNTA',
+    createdAt: '2017-07-19T12:29:17.381Z',
+    duration: 120
+  },
+  activities: [],
+  operators: [
+    {
+      _id: 'cj5szsc93000b3k6o3suw338f',
+      time: 1.9014084507042253,
+      y: 340,
+      type: 'product',
+      operatorType: 'op-jigsaw',
+      data: { roles: 'chief' }
+    }
+  ],
   connections: []
 };

--- a/frog/imports/ui/GraphEditor/Activities.js
+++ b/frog/imports/ui/GraphEditor/Activities.js
@@ -5,16 +5,28 @@ import { connect, type StoreProp, store } from './store';
 import Activity from './store/activity';
 import { getClickHandler } from './utils';
 
-const Box = ({ x, y, width, selected, color }) =>
-  <rect
-    x={x}
-    y={y}
-    width={width}
-    stroke={selected ? '#ff9900' : 'grey'}
-    fill={color}
-    rx={10}
-    height={30}
-  />;
+const Box = ({ x, y, width, selected, strokeColor, color }) =>
+  <g>
+    <rect
+      x={x}
+      y={y}
+      width={width}
+      fill={color}
+      stroke={strokeColor}
+      rx={10}
+      height={30}
+    />;
+    {selected &&
+      <rect
+        x={x - 2}
+        y={y - 2}
+        width={width + 2}
+        stroke="#ff9900"
+        fill="transparent"
+        rx={10}
+        height={34}
+      />}
+  </g>;
 
 class ActivityComponent extends Component {
   clickHandler: ?Function;
@@ -58,6 +70,7 @@ class ActivityComponent extends Component {
           highlighted={activity.color}
           selected={activity.selected}
           color={activity.color}
+          strokeColor={activity.strokeColor}
         />
         {width > 21 &&
           <g>

--- a/frog/imports/ui/GraphEditor/Operator.js
+++ b/frog/imports/ui/GraphEditor/Operator.js
@@ -10,11 +10,12 @@ export default ({
   selected,
   type,
   color,
+  strokeColor,
   startDragging,
   onDrag,
   onStop
 }) => {
-  const stroke = selected ? '#ff9900' : 'grey';
+  const stroke = selected ? '#ff9900' : 'transparent';
   let icon;
   switch (type) {
     case 'social':
@@ -37,15 +38,20 @@ export default ({
       y={`${y}px`}
       width="60px"
       height="60px"
-      viewBox="0 0 800 800"
+      viewBox="0 0 900 900"
       xmlSpace="preserve"
+      overflow="visibile"
     >
       <g onMouseUp={onClick}>
         <circle
           cx={300}
           cy={300}
-          r={300}
-          style={{ fill: color || 'white', stroke, strokeWidth: 60 }}
+          r={290}
+          style={{
+            fill: color || 'white',
+            stroke: strokeColor,
+            strokeWidth: 30
+          }}
           transform="translate(30,30)"
         />
         {icon}
@@ -53,8 +59,8 @@ export default ({
           <circle
             cx={300}
             cy={300}
-            r={350}
-            style={{ fill: 'transparent', stroke: 'transparent' }}
+            r={320}
+            style={{ fill: 'transparent', stroke, strokeWidth: 25 }}
             transform="translate(30,30)"
             onMouseOver={onOver}
             onMouseLeave={onLeave}

--- a/frog/imports/ui/GraphEditor/Operators.js
+++ b/frog/imports/ui/GraphEditor/Operators.js
@@ -29,6 +29,7 @@ export default connect(
           onDrag={op.onDrag}
           onStop={op.stopDragging}
           type={op.type}
+          strokeColor={op.strokeColor}
         />
       );
     });

--- a/frog/imports/ui/GraphEditor/store/elemClass.js
+++ b/frog/imports/ui/GraphEditor/store/elemClass.js
@@ -9,6 +9,7 @@ export default class Elem {
   id: string;
   state: ?string;
   color: string;
+  strokeColor: string;
 
   @action
   select = (): void => {
@@ -67,5 +68,17 @@ export default class Elem {
       store.state.draggingFrom !== this &&
       store.state.mode === 'dragging'
     );
+  }
+
+  @computed
+  get strokeColor(): boolean {
+    const errors = store.graphErrors.filter(x => x.id === this.id);
+    if (errors.length === 0) {
+      return 'grey';
+    }
+    if (errors.find(x => x.type === 'missingType')) {
+      return '#e6e8fc';
+    }
+    return '#C72616';
   }
 }


### PR DESCRIPTION
- I added a type to each error, and also checking whether operators have at least one outgoing connection.

- I changed the border drawing of AC/OP. Rather than switching between normal color and highlight, the highlight is now drawn outside the basic color, giving us more choice with the basic color.
  - I distinguish between an ac/op not yet specified, by fading the color. This makes it visually clear that the ac/op has not been specified, without screaming error (as the designer is still in the process). Once the ac/op has been specified, it changes color to either a solid dark, if correct, or red, if there is one or more errors attached to that object. 