### PR TITLE
Adding warning/error distinction

### DIFF
--- a/frog/imports/ui/GraphEditor/Validator.js
+++ b/frog/imports/ui/GraphEditor/Validator.js
@@ -9,8 +9,13 @@ const ListError = ({ errors }) =>
     {errors.map((x, i) => {
       const k = i * 2;
       return (
-        <text x="90" y={40 + 20 * i} key={x.id + k}>
-          {' '}{'• ' + x.err}{' '}
+        <text
+          x="90"
+          y={40 + 20 * i}
+          key={x.id + k}
+          fill={x.severity === 'error' ? 'red' : 'orange'}
+        >
+          {'• ' + x.err}
         </text>
       );
     })}
@@ -41,14 +46,14 @@ export const ErrorList = connect(
 );
 
 export const ValidButton = connect(
-  ({ store: { graphErrors, ui: { setShowErrors } } }) =>
+  ({ store: { ui: { graphErrorColor, setShowErrors } } }) =>
     <svg width="34px" height="34px" style={{ overflow: 'visible' }}>
       <circle
         cx="17"
         cy="17"
         r="12"
         stroke="transparent"
-        fill={graphErrors.length > 0 ? 'red' : 'green'}
+        fill={graphErrorColor}
         onMouseOver={() => setShowErrors(true)}
         onMouseOut={() => setShowErrors(false)}
       />

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -1,5 +1,5 @@
 // @flow
-import { isEqual } from 'lodash';
+import { isEqual, sortBy } from 'lodash';
 import { computed, action, observable } from 'mobx';
 import Stringify from 'json-stable-stringify';
 
@@ -191,10 +191,13 @@ export default class Store {
       mergeGraph(this.objects);
     }
 
-    this.graphErrors = valid(
-      Activities.find({ graphId: this.graphId }).fetch(),
-      Operators.find({ graphId: this.graphId }).fetch(),
-      Connections.find({ graphId: this.graphId }).fetch()
+    this.graphErrors = sortBy(
+      valid(
+        Activities.find({ graphId: this.graphId }).fetch(),
+        Operators.find({ graphId: this.graphId }).fetch(),
+        Connections.find({ graphId: this.graphId }).fetch()
+      ),
+      'severity'
     );
 
     Graphs.update(this.graphId, {

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -196,6 +196,12 @@ export default class Store {
       Operators.find({ graphId: this.graphId }).fetch(),
       Connections.find({ graphId: this.graphId }).fetch()
     );
+
+    Graphs.update(this.graphId, {
+      $set: {
+        broken: this.graphErrors.filter(x => x.severity === 'error').length > 0
+      }
+    });
   };
 
   @computed

--- a/frog/imports/ui/GraphEditor/store/uiStore.js
+++ b/frog/imports/ui/GraphEditor/store/uiStore.js
@@ -29,6 +29,19 @@ export default class uiStore {
   @observable showInfo: ?{ klass: 'activity' | 'operator', id: string };
   @observable showErrors: boolean = false;
 
+  @computed
+  get graphErrorColor(): string {
+    const error = store.graphErrors.filter(x => x.severity === 'error');
+    const warning = store.graphErrors.filter(x => x.severity === 'warning');
+    if (error.length > 0) {
+      return 'red';
+    }
+    if (warning.length > 0) {
+      return 'yellow';
+    }
+    return 'green';
+  }
+
   @action
   setShowErrors = (toSet: boolean) => {
     this.showErrors = toSet;

--- a/frog/imports/ui/TeacherView/index.js
+++ b/frog/imports/ui/TeacherView/index.js
@@ -119,7 +119,7 @@ export default createContainer(
     return {
       sessions: Sessions.find().fetch(),
       session,
-      graphs: Graphs.find({ broken: false }).fetch(),
+      graphs: Graphs.find({ broken: { $ne: true } }).fetch(),
       activities,
       students,
       logs,

--- a/frog/imports/ui/TeacherView/index.js
+++ b/frog/imports/ui/TeacherView/index.js
@@ -119,7 +119,7 @@ export default createContainer(
     return {
       sessions: Sessions.find().fetch(),
       session,
-      graphs: Graphs.find().fetch(),
+      graphs: Graphs.find({ broken: false }).fetch(),
       activities,
       students,
       logs,


### PR DESCRIPTION
This PR adds a distinction in severity. Conditions which will cause engine errors are 'error', things that will not cause errors, but are superfluous or possible mistakes are 'warning'. Currently, the only errors marked warning are related to operators with no connections - this does not cause an error, and whether they are fully configured or not, is irrelevant. However, it's most likely a mistake, which is why we're highlighting it.

The circle is red if there are any errors, and yellow if only warnings. I also ensure that you cannot initiate a graph in the engine if it has any errors (warnings are OK).