### PR TITLE
Better ac/op list

### DIFF
--- a/ac/ac-brainstorm/src/index.js
+++ b/ac/ac-brainstorm/src/index.js
@@ -9,8 +9,10 @@ import Dashboard from './Dashboard';
 const meta = {
   name: 'Brainstorm',
   type: 'react-component',
-  shortDesc: 'sharing ideas',
-  description: 'Students can submit ideas associated with the given guideline'
+  shortDesc:
+    'Display text items, and vote up/down. Optionally students can add new items',
+  description:
+    'This activity features a list of items with title and content. Items have a score attached, and are ordered by score. Students can vote up or down, and optionally add new items.'
 };
 
 const dataStructure = {};

--- a/ac/ac-chat/src/index.js
+++ b/ac/ac-chat/src/index.js
@@ -8,8 +8,8 @@ import Dashboard from './Dashboard';
 const meta = {
   name: 'Chat',
   type: 'react-component',
-  shortDesc: 'chat between students',
-  description: 'Opens a chat between the students of the considered group'
+  shortDesc: 'Chat component',
+  description: 'Persistent text chat'
 };
 
 const dataStructure = [];

--- a/ac/ac-ck-board/src/index.js
+++ b/ac/ac-ck-board/src/index.js
@@ -8,9 +8,9 @@ const meta = {
   name: 'Common Knowledge board',
   type: 'react-component',
   mode: 'collab',
-  shortDesc: 'associating ideas with concepts',
+  shortDesc: '2D board for placing items',
   description:
-    'Students have to place boxes containing ideas in the part of the frame that corresponds to its concept'
+    'All imported items are placed on a 2D space. Optionally, teacher can designate four named quadrants. Students can drag boxes to organize or group ideas. Incoming items have title and content.'
 };
 
 const config = {

--- a/ac/ac-form/src/index.js
+++ b/ac/ac-form/src/index.js
@@ -10,8 +10,9 @@ import config from './config';
 const meta = {
   name: 'Simple form',
   type: 'react-component',
-  shortDesc: 'question-answer form',
-  description: 'Creates a form with divers specified fields'
+  shortDesc: 'Form with text fields',
+  description:
+    'Creates a form with specified text fields, optionally allow students to submit multiple forms.'
 };
 
 const modifyForm = (questions, title) => {

--- a/ac/ac-iframe/src/index.js
+++ b/ac/ac-iframe/src/index.js
@@ -6,8 +6,9 @@ import type { ActivityRunnerT } from 'frog-utils';
 export const meta = {
   name: 'Embedded website',
   type: 'react-component',
-  shortDesc: 'reading a website',
-  description: 'Display a frame containing a website'
+  shortDesc: 'Embedding an external website in an iFrame',
+  description:
+    'Takes a URL and displays the corresponding website embedded in an iFrame. Not all websites allow embedding.'
 };
 
 export const config = {

--- a/ac/ac-induction/src/index.js
+++ b/ac/ac-induction/src/index.js
@@ -8,9 +8,9 @@ import config from './config';
 const meta = {
   name: 'Induction',
   type: 'react-component',
-  shortDesc: 'reasoning by induction',
+  shortDesc: 'Reasoning by induction',
   description:
-    "The student has an image that corresponds to the concept he needs to define an one that doens't and he has to cehck the rules that fit the concept"
+    "The student has an image that corresponds to the concept he needs to define an one that doens't and he has to check the rules that fit the concept."
 };
 
 export default ({

--- a/ac/ac-quiz/src/index.js
+++ b/ac/ac-quiz/src/index.js
@@ -8,8 +8,8 @@ import ActivityRunner from './ActivityRunner';
 export const meta = {
   name: 'Multiple-Choice Questions',
   type: 'react-component',
-  shortDesc: 'filling a MCQ form',
-  description: 'Display a multiple-choice questions form'
+  shortDesc: 'Filling a MCQ form',
+  description: 'Display a multiple-choice questions form.'
 };
 
 export default ({

--- a/ac/ac-text/src/index.js
+++ b/ac/ac-text/src/index.js
@@ -7,8 +7,9 @@ import type { ActivityRunnerT, ActivityPackageT } from 'frog-utils';
 export const meta = {
   name: 'Text Component',
   type: 'react-component',
-  shortDesc: 'reading a text',
-  description: 'Display a given text'
+  shortDesc: 'Reading a text',
+  description:
+    'Display a given text, can be taken from config, or operators, or both.'
 };
 
 export const config = {

--- a/ac/ac-video/src/index.js
+++ b/ac/ac-video/src/index.js
@@ -9,8 +9,9 @@ import Dashboard from './dashboard';
 export const meta = {
   name: 'Video player',
   type: 'react-component',
-  shortDesc: 'watching a video',
-  description: 'Plays a video'
+  shortDesc: 'Video player',
+  description:
+    'Video player configurable with URL, and some settings (autoplay etc).'
 };
 
 export const config = {

--- a/frog/imports/api/sessions.js
+++ b/frog/imports/api/sessions.js
@@ -47,7 +47,7 @@ const addSessionItem = (type, graphId, params) => {
 };
 
 export const addSession = (graphId: string) => {
-  const result = Meteor.call('add.session', graphId, (err, result) => {
+  Meteor.call('add.session', graphId, (err, result) => {
     if (result === 'invalidGraph') {
       window.alert(
         'Cannot create session from invalid graph. Please open graph in graph editor and correct errors.'

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { createContainer } from 'meteor/react-meteor-data';
 import Form from 'react-jsonschema-form';
 import { ChangeableText } from 'frog-utils';
+import { withState } from 'recompose';
 
 import { Activities, addActivity } from '/imports/api/activities';
 import { activityTypes, activityTypesObj } from '/imports/activityTypes';
@@ -11,26 +12,36 @@ import { connect } from '../store';
 import FileForm from './fileUploader';
 import ListComponent from './ListComponent';
 
-const ChooseActivityTypeComp = ({ activity, store: { addHistory } }) => {
-  const select = ev => {
-    const e = ev.target.getAttribute('value');
-    if (activityTypesObj[e]) {
-      Activities.update(activity._id, { $set: { activityType: e } });
-      addHistory();
-    }
+const ChooseActivityTypeComp = withState(
+  'expanded',
+  'setExpand',
+  null
+)(({ activity, store: { addHistory }, expanded, setExpand }) => {
+  const select = (activityType, e) => {
+    Activities.update(activity._id, {
+      $set: { activityType: activityType.id }
+    });
+    addHistory();
   };
 
   return (
     <div>
       <h4>Please select activity type</h4>
-      <div className="list-group" role="button" tabIndex={0} onClick={select}>
+      <div className="list-group">
         {activityTypes.map(x =>
-          <ListComponent key={x.id} object={x} eventKey={x.id} />
+          <ListComponent
+            onSelect={e => select(x)}
+            showExpanded={expanded === x.id}
+            expand={() => setExpand(x.id)}
+            key={x.id}
+            object={x}
+            eventKey={x.id}
+          />
         )}
       </div>
     </div>
   );
-};
+});
 
 const EditClass = props => {
   const activity = props.activity;

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel.js
@@ -17,7 +17,7 @@ const ChooseActivityTypeComp = withState(
   'setExpand',
   null
 )(({ activity, store: { addHistory }, expanded, setExpand }) => {
-  const select = (activityType, e) => {
+  const select = activityType => {
     Activities.update(activity._id, {
       $set: { activityType: activityType.id }
     });
@@ -30,7 +30,7 @@ const ChooseActivityTypeComp = withState(
       <div className="list-group">
         {activityTypes.map(x =>
           <ListComponent
-            onSelect={e => select(x)}
+            onSelect={() => select(x)}
             showExpanded={expanded === x.id}
             expand={() => setExpand(x.id)}
             key={x.id}

--- a/frog/imports/ui/GraphEditor/SidePanel/ListComponent.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/ListComponent.jsx
@@ -1,66 +1,44 @@
 // @flow
 
 import React, { Component } from 'react';
+import { Button } from 'react-bootstrap';
 
-class ListComponent extends Component {
-  state: { longDesc: boolean, over1: boolean, over2: boolean };
-  constructor(props: any) {
-    super(props);
-    this.state = {
-      longDesc: false,
-      over1: false,
-      over2: false
-    };
-  }
-
-  render() {
-    const obj = this.props.object;
-
-    const click = () => this.setState({ longDesc: !this.state.longDesc });
-
-    return (
-      <div className="list-group-item">
-        <h5 style={{ fontWeight: 'bold' }}>
-          {obj.meta.name}
-        </h5>
-        <button
-          value={obj.id}
-          style={{
-            position: 'absolute',
-            right: '2px',
-            top: '4px',
-            width: '13%',
-            height: '35px'
-          }}
-        >
-          {' '}Choose{' '}
-        </button>
-        <button
-          style={{
-            position: 'absolute',
-            right: '2px',
-            top: '38px',
-            width: '13%',
-            height: '35px'
-          }}
-          className={
-            this.state.longDesc
-              ? 'glyphicon glyphicon-minus'
-              : 'glyphicon glyphicon-plus'
-          }
-          onClick={click}
-        />
-        {!this.state.longDesc &&
-          <div style={{ width: '87%' }}>
-            {obj.meta.shortDesc}{' '}
-          </div>}
-        {this.state.longDesc &&
-          <div style={{ width: '87%' }}>
-            {obj.meta.description}{' '}
-          </div>}
-      </div>
-    );
-  }
-}
-
-export default ListComponent;
+export default ({ object, showExpanded, onSelect, expand }) =>
+  <div className="list-group-item">
+    <h5 style={{ fontWeight: 'bold' }}>
+      {object.meta.name}
+    </h5>
+    <Button
+      value={object.id}
+      className="glyphicon glyphicon-ok"
+      style={{
+        position: 'absolute',
+        right: '2px',
+        top: '4px',
+        width: '9%',
+        height: '34px'
+      }}
+      onClick={onSelect}
+    />
+    {!showExpanded &&
+      <Button
+        style={{
+          position: 'absolute',
+          right: '2px',
+          top: '39px',
+          width: '9%',
+          height: '35px'
+        }}
+        className="glyphicon glyphicon-menu-down"
+        onClick={expand}
+      />}
+    <div style={{ width: '87%' }}>
+      {object.meta.shortDesc}
+    </div>
+    {showExpanded &&
+      <div style={{ width: '87%' }}>
+        <i>
+          {object.meta.description}
+        </i>
+      </div>}
+  </div>;

--- a/frog/imports/ui/GraphEditor/SidePanel/ListComponent.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/ListComponent.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Component } from 'react';
+import React from 'react';
 import { Button } from 'react-bootstrap';
 
 export default ({ object, showExpanded, onSelect, expand }) =>

--- a/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel.js
@@ -27,7 +27,7 @@ const ChooseOperatorTypeComp = withState(
       <div className="list-group">
         {operatorTypes.map(x =>
           <ListComponent
-            onSelect={e => select(x)}
+            onSelect={() => select(x)}
             showExpanded={expanded === x.id}
             expand={() => setExpand(x.id)}
             key={x.id}

--- a/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel.js
@@ -3,32 +3,42 @@ import React from 'react';
 import { createContainer } from 'meteor/react-meteor-data';
 import Form from 'react-jsonschema-form';
 import { ChangeableText } from 'frog-utils';
+import { withState } from 'recompose';
 
 import { Operators, addOperator } from '/imports/api/activities';
 import { operatorTypes, operatorTypesObj } from '/imports/operatorTypes';
 import { connect } from '../store';
 import ListComponent from './ListComponent';
 
-const ChooseOperatorTypeComp = ({ operator, store: { addHistory } }) => {
-  const select = ev => {
-    const e = ev.target.getAttribute('value');
-    if (operatorTypesObj[e]) {
-      Operators.update(operator._id, { $set: { operatorType: e } });
-      addHistory();
-    }
+const ChooseOperatorTypeComp = withState(
+  'expanded',
+  'setExpand',
+  null
+)(({ operator, store: { addHistory }, expanded, setExpand }) => {
+  const select = operatorType => {
+    Operators.update(operator._id, {
+      $set: { operatorType: operatorType.id }
+    });
+    addHistory();
   };
-
   return (
     <div>
       <h4>Please select operator type</h4>
-      <div className="list-group" role="button" tabIndex={0} onClick={select}>
+      <div className="list-group">
         {operatorTypes.map(x =>
-          <ListComponent key={x.id} object={x} eventKey={x.id} />
+          <ListComponent
+            onSelect={e => select(x)}
+            showExpanded={expanded === x.id}
+            expand={() => setExpand(x.id)}
+            key={x.id}
+            object={x}
+            eventKey={x.id}
+          />
         )}
       </div>
     </div>
   );
-};
+});
 
 const EditClass = ({ store: { operatorStore: { all } }, operator }) => {
   const graphOperator = all.find(act => act.id === operator._id);

--- a/op/op-argue/src/index.js
+++ b/op/op-argue/src/index.js
@@ -6,8 +6,8 @@ import type { socialOperatorT } from 'frog-utils';
 const meta = {
   name: 'Argue',
   type: 'social',
-  shortDesc: 'group students to argue',
-  description: 'Group students with as many different answers as possible'
+  shortDesc: 'Group students to argue',
+  description: 'Group students with as many similar answers as possible.'
 };
 
 const config = {

--- a/op/op-create-groups/src/index.js
+++ b/op/op-create-groups/src/index.js
@@ -6,8 +6,9 @@ import { type socialOperatorT } from 'frog-utils';
 const meta = {
   name: 'Create groups',
   type: 'social',
-  shortDesc: 'group students randomly',
-  description: 'Create radom groups of a given amount of students'
+  shortDesc: 'Group students randomly',
+  description:
+    'Create random groups of students, configurable group size and strategy (at least n students, or maximum n students per group).'
 };
 
 const config = {

--- a/op/op-distribute/src/index.js
+++ b/op/op-distribute/src/index.js
@@ -6,8 +6,9 @@ import { type productOperatorT } from 'frog-utils';
 const meta = {
   name: 'Distribute content',
   type: 'product',
-  shortDesc: 'distribute data',
-  description: 'Distribute data to all members of a group'
+  shortDesc: 'Distribute list items',
+  description:
+    'Distribute list items to groups or individual students, with configurable numbers of items per group, overlap allowed or not, etc.'
 };
 
 const config = {

--- a/op/op-group-identical/src/index.js
+++ b/op/op-group-identical/src/index.js
@@ -7,7 +7,7 @@ import type { socialOperatorT } from 'frog-utils';
 const meta = {
   name: 'Group based on identical student data',
   type: 'social',
-  shortDesc: 'group identical students together',
+  shortDesc: 'Group identical students together',
   description: 'Group students with as many similar answers as possible'
 };
 

--- a/op/op-hypothesis/src/index.js
+++ b/op/op-hypothesis/src/index.js
@@ -12,9 +12,8 @@ import {
 export const meta = {
   name: 'Get ideas from Hypothesis',
   type: 'product',
-  shortDesc: 'collect ideas',
-  description:
-    'Collect ideas from an hypothesis and feed them as data to an activity'
+  shortDesc: 'Get ideas from Hypothesis API',
+  description: 'Collect ideas from an Hypothesis API by hashtag or document id.'
 };
 
 export const config = {

--- a/op/op-jigsaw/src/index.js
+++ b/op/op-jigsaw/src/index.js
@@ -6,8 +6,9 @@ import { focusRole, type socialOperatorT } from 'frog-utils';
 const meta = {
   name: 'Jigsaw',
   type: 'social',
-  shortDesc: 'gives roles to students',
-  description: 'Attribute roles to every students of a group'
+  shortDesc: 'Assign students to groups and roles',
+  description:
+    'Given a list of roles, students are assigned to groups and roles, where each role only appears once in each group.'
 };
 
 const config = {


### PR DESCRIPTION
This PR

- improves the look of the list a bit, by using bootstrap Button instead of button, etc.
- now, you can only expand items, expanding an item collapses all other items

Still not perfect, but seems cleaner to me.

Note the use of recompose to add state to a stateless component. I just don't like classes :) We use this a few other places, including the withVisibility function from frog-utils :)

Also updated/expanded on the descriptions in all ac/op packages.