### PR TITLE
Enabling ac/op packages to export multiple op/ac

### DIFF
--- a/frog-utils/src/__tests__/index.js
+++ b/frog-utils/src/__tests__/index.js
@@ -1,0 +1,7 @@
+import { flattenOne } from '..';
+
+test('flattenOne', () => {
+  expect(flattenOne([1, 2, 3])).toEqual([1, 2, 3]);
+  expect(flattenOne([1, [2, 3], 4])).toEqual([1, 2, 3, 4]);
+  expect(flattenOne([1, [2, [3, 9]], 4])).toEqual([1, 2, [3, 9], 4]);
+});

--- a/frog-utils/src/index.js
+++ b/frog-utils/src/index.js
@@ -90,3 +90,9 @@ export const withVisibility = compose(
     toggleVisibility: ({ setVisibility }) => () => setVisibility(n => !n)
   })
 );
+
+export const flattenOne = (ary: any[]): any[] =>
+  ary.reduce(
+    (acc: any[], x: any) => (Array.isArray(x) ? [...acc, ...x] : [...acc, x]),
+    []
+  );

--- a/frog/imports/activityTypes.js
+++ b/frog/imports/activityTypes.js
@@ -10,11 +10,11 @@ import acForm from 'ac-form';
 import acQuiz from 'ac-quiz';
 import acCKBoard from 'ac-ck-board';
 
-import type { ActivityPackageT } from 'frog-utils';
+import { type ActivityPackageT, flattenOne } from 'frog-utils';
 
 import { keyBy } from 'lodash';
 
-export const activityTypes: Array<ActivityPackageT> = [
+export const activityTypes: ActivityPackageT[] = flattenOne([
   acInduction,
   acBrainstorm,
   acChat,
@@ -24,7 +24,7 @@ export const activityTypes: Array<ActivityPackageT> = [
   acForm,
   acCKBoard,
   acQuiz
-].map(x => Object.freeze(x));
+]).map(x => Object.freeze(x));
 
 // see explanation of `any` in operatorTypes.js
 export const activityTypesObj: { [actId: string]: ActivityPackageT } = (keyBy(

--- a/frog/imports/operatorTypes.js
+++ b/frog/imports/operatorTypes.js
@@ -7,18 +7,18 @@ import opHypothesis from 'op-hypothesis';
 import opCreateGroups from 'op-create-groups';
 import opDistribute from 'op-distribute';
 
-import type { operatorPackageT } from 'frog-utils';
+import { type operatorPackageT, flattenOne } from 'frog-utils';
 
 import { keyBy } from 'lodash';
 
-export const operatorTypes: Array<operatorPackageT> = [
+export const operatorTypes: operatorPackageT[] = flattenOne([
   opGroupIdentical,
   opJigsaw,
   opArgue,
   opHypothesis,
   opCreateGroups,
   opDistribute
-].map(x => Object.freeze(x));
+]).map(x => Object.freeze(x));
 
 // somehow lodash.keyBy has the type {[id]: ??}, which means that the object can be null
 // this means it will not fit in the type we want, and give us flow errors whenever


### PR DESCRIPTION
This will make it easier to have a package with many short operator functions for example, and also speed up development (adding a new operator is caught automatically, without adding lot's of links and directories etc).