### PR TITLE
Adding conditional fields in forms

### DIFF
--- a/frog-utils/package.json
+++ b/frog-utils/package.json
@@ -12,8 +12,10 @@
   "license": "ISC",
   "dependencies": {
     "cuid": "^1.3.8",
+    "lodash": "^4.17.4",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
+    "react-jsonschema-form": "^0.49.0",
     "recompose": "^0.24.0"
   },
   "devDependencies": {

--- a/frog-utils/src/EnhancedForm.js
+++ b/frog-utils/src/EnhancedForm.js
@@ -1,0 +1,41 @@
+import React, { Component } from 'react';
+import Form from 'react-jsonschema-form';
+import { cloneDeep } from 'lodash';
+
+const calculateSchema = (formData, schema, UISchema) => {
+  console.log(formData, schema, UISchema);
+  const hide = [];
+  if (UISchema) {
+    Object.keys(UISchema).forEach(x => {
+      const cond = UISchema[x].conditional;
+      if (cond) {
+        if (typeof cond === 'string') {
+          console.log(cond, formData[cond]);
+          if (!formData[cond]) {
+            hide.push(x);
+            console.log(hide);
+          }
+        } else {
+          try {
+            if (!cond(formData)) {
+              hide.push(x);
+            }
+          } catch (e) {
+            hide.push(x);
+          }
+        }
+      }
+    });
+  }
+
+  const newSchema = cloneDeep(schema);
+  hide.forEach(x => delete newSchema.properties[x]);
+  console.log(hide);
+  return newSchema;
+};
+
+export default props => {
+  const schema = calculateSchema(props.formData, props.schema, props.UISchema);
+
+  return <Form {...props} schema={schema} />;
+};

--- a/frog-utils/src/index.js
+++ b/frog-utils/src/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { compose, withHandlers, withState } from 'recompose';
 
+export { default as EnhancedForm } from './EnhancedForm';
 export { generateReactiveFn, inMemoryReactive } from './generateReactiveFn';
 export { Highlight } from './highlightSubstring';
 export { default as uuid } from 'cuid';

--- a/frog-utils/yarn.lock
+++ b/frog-utils/yarn.lock
@@ -91,6 +91,18 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
+jsonschema@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.1.1.tgz#3cede8e3e411d377872eefbc9fdf26383cbc3ed9"
+
+lodash.topath@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.topath/-/lodash.topath-4.5.2.tgz#3616351f3bba61994a0931989660bd03254fd009"
+
+lodash@^4.17.4:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
@@ -126,7 +138,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10:
+prop-types@^15.5.10, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -141,6 +153,15 @@ react-dom@^15.6.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.10"
+
+react-jsonschema-form@^0.49.0:
+  version "0.49.0"
+  resolved "https://registry.yarnpkg.com/react-jsonschema-form/-/react-jsonschema-form-0.49.0.tgz#58bf691eae2d016d5c23cb59512f2e74f54ac324"
+  dependencies:
+    jsonschema "^1.0.2"
+    lodash.topath "^4.5.2"
+    prop-types "^15.5.8"
+    setimmediate "^1.0.5"
 
 react@^15.6.1:
   version "15.6.1"

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel.js
@@ -1,9 +1,11 @@
 // @flow
 import React, { Component } from 'react';
 import { createContainer } from 'meteor/react-meteor-data';
-import Form from 'react-jsonschema-form';
-import { ChangeableText } from 'frog-utils';
-import type { ActivityPackageT } from 'frog-utils';
+import {
+  EnhancedForm,
+  ChangeableText,
+  type ActivityPackageT
+} from 'frog-utils';
 
 import { Activities, addActivity } from '/imports/api/activities';
 import { activityTypes, activityTypesObj } from '/imports/activityTypes';
@@ -145,8 +147,9 @@ const EditClass = props => {
           </div>}
         <hr />
       </div>
-      <Form
+      <EnhancedForm
         schema={activityTypesObj[activity.activityType].config}
+        UISchema={activityTypesObj[activity.activityType].configUI}
         onChange={data => {
           addActivity(
             activity.activityType,
@@ -160,7 +163,7 @@ const EditClass = props => {
         liveValidate
       >
         <div />
-      </Form>
+      </EnhancedForm>
       <FileForm />
     </div>
   );

--- a/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel.js
@@ -1,9 +1,11 @@
 // @flow
 import React, { Component } from 'react';
 import { createContainer } from 'meteor/react-meteor-data';
-import Form from 'react-jsonschema-form';
-import { ChangeableText } from 'frog-utils';
-import type { operatorPackageT } from 'frog-utils';
+import {
+  type operatorPackageT,
+  ChangeableText,
+  EnhancedForm
+} from 'frog-utils';
 
 import { Operators, addOperator } from '/imports/api/activities';
 import { operatorTypes, operatorTypesObj } from '/imports/operatorTypes';
@@ -112,8 +114,9 @@ const EditClass = ({ store: { operatorStore: { all } }, operator }) => {
         </font>
         <hr />
       </div>
-      <Form
+      <EnhancedForm
         schema={operatorTypesObj[operator.operatorType].config}
+        UISchema={operatorTypesObj[operator.operatorType].configUI}
         onChange={data =>
           addOperator(
             operator.operatorType,
@@ -125,7 +128,7 @@ const EditClass = ({ store: { operatorStore: { all } }, operator }) => {
         liveValidate
       >
         <div />
-      </Form>
+      </EnhancedForm>
     </div>
   );
 };

--- a/op/op-distribute/src/index.js
+++ b/op/op-distribute/src/index.js
@@ -16,7 +16,7 @@ const config = {
   properties: {
     individual: {
       type: 'boolean',
-      title: 'Distribute to each student (or fill out grouping attribute below)'
+      title: 'Distribute to each student'
     },
     grouping: {
       type: 'string',
@@ -31,6 +31,10 @@ const config = {
       title: 'Allow multiple groups receiving the same item?'
     }
   }
+};
+
+const configUI = {
+  grouping: { conditional: formData => !formData.individual }
 };
 
 const operator = (configData, object) => {
@@ -88,5 +92,6 @@ export default ({
   id: 'op-distribute',
   operator,
   config,
-  meta
+  meta,
+  configUI
 }: productOperatorT);


### PR DESCRIPTION
This PR adds a wrapper around react-jsonschema-form, EnhancedForm in frog-utils. The wrapper recognizes a conditional field, either as a string (if the other field is true), or as a function, taking formData as input. Example:

```js
UISchema: {
  username: { 
    conditional: 'hasUsername'
  }
  seniorDiscount: { 
    conditional: formdata => formdata.age > 67 
  }
}
```

Currently, both operator and activity sidepanels use this enhanced form. For now, I'm using activity/operatorType.configUI to store the UISchema, to avoid rewriting every ac/op. In the future, we might change config to have schema, and UISchema, or something like that.

Currently, data is still stored and kept whether a field is visible or not. Not sure if making a field invisible should remove the data from the invisible field.

All other props are passed to RJF, so this should support all the functionality of RJF, but more actual usage is required to verify this.
  