### PR TITLE
Moving types to top-level in ac/op

### DIFF
--- a/ac/ac-brainstorm/src/index.js
+++ b/ac/ac-brainstorm/src/index.js
@@ -14,7 +14,6 @@ const listItems = [
 
 const meta = {
   name: 'Brainstorm',
-  type: 'react-component',
   shortDesc:
     'Display text items, and vote up/down. Optionally students can add new items',
   description:
@@ -58,6 +57,7 @@ const mergeFunction = (obj: dataUnitStructT, dataFn: Object) => {
 
 export default ({
   id: 'ac-brainstorm',
+  type: 'react-component',
   ActivityRunner,
   Dashboard,
   config,

--- a/ac/ac-chat/src/index.js
+++ b/ac/ac-chat/src/index.js
@@ -7,7 +7,6 @@ import Dashboard from './Dashboard';
 
 const meta = {
   name: 'Chat',
-  type: 'react-component',
   shortDesc: 'Chat component',
   description: 'Persistent text chat',
   exampleData: [
@@ -54,6 +53,7 @@ const mergeFunction = (obj, dataFn) => {
 
 export default ({
   id: 'ac-chat',
+  type: 'react-component',
   ActivityRunner,
   config,
   meta,

--- a/ac/ac-ck-board/src/index.js
+++ b/ac/ac-ck-board/src/index.js
@@ -6,7 +6,6 @@ import Board from './board';
 
 const meta = {
   name: 'Common Knowledge board',
-  type: 'react-component',
   mode: 'collab',
   shortDesc: '2D board for placing items',
   description:
@@ -100,6 +99,7 @@ const mergeFunction = (object, dataFn) => {
 
 export default ({
   id: 'ac-ck-board',
+  type: 'react-component',
   meta,
   config,
   ActivityRunner: Board,

--- a/ac/ac-form/src/index.js
+++ b/ac/ac-form/src/index.js
@@ -9,7 +9,6 @@ import config from './config';
 
 const meta = {
   name: 'Simple form',
-  type: 'react-component',
   shortDesc: 'Form with text fields',
   description:
     'Creates a form with specified text fields, optionally allow students to submit multiple forms.',
@@ -90,6 +89,7 @@ const ActivityRunner = ({ activityData, data, dataFn }: ActivityRunnerT) => {
 
 export default ({
   id: 'ac-form',
+  type: 'react-component',
   meta,
   config,
   ActivityRunner

--- a/ac/ac-iframe/src/index.js
+++ b/ac/ac-iframe/src/index.js
@@ -5,7 +5,6 @@ import type { ActivityRunnerT } from 'frog-utils';
 
 export const meta = {
   name: 'Embedded website',
-  type: 'react-component',
   shortDesc: 'Embedding an external website in an iFrame',
   description:
     'Takes a URL and displays the corresponding website embedded in an iFrame. Not all websites allow embedding.',
@@ -39,6 +38,7 @@ export const ActivityRunner = ({ activityData }: ActivityRunnerT) =>
 
 export default {
   id: 'ac-iframe',
+  type: 'react-component',
   ActivityRunner,
   config,
   meta

--- a/ac/ac-induction/src/index.js
+++ b/ac/ac-induction/src/index.js
@@ -7,7 +7,6 @@ import config from './config';
 
 const meta = {
   name: 'Induction',
-  type: 'react-component',
   shortDesc: 'Reasoning by induction',
   description:
     "The student has an image that corresponds to the concept he needs to define an one that doens't and he has to check the rules that fit the concept.",
@@ -46,6 +45,7 @@ const meta = {
 
 export default ({
   id: 'ac-induction',
+  type: 'react-component',
   meta,
   config,
   ActivityRunner,

--- a/ac/ac-quiz/src/index.js
+++ b/ac/ac-quiz/src/index.js
@@ -48,7 +48,6 @@ const exampleConfig = {
 
 export const meta = {
   name: 'Multiple-Choice Questions',
-  type: 'react-component',
   shortDesc: 'Filling a MCQ form',
   description: 'Display a multiple-choice questions form.',
   exampleData: [
@@ -62,6 +61,7 @@ export const meta = {
 
 export default ({
   id: 'ac-quiz',
+  type: 'react-component',
   meta,
   config,
   ActivityRunner

--- a/ac/ac-text/src/index.js
+++ b/ac/ac-text/src/index.js
@@ -6,7 +6,6 @@ import type { ActivityRunnerT, ActivityPackageT } from 'frog-utils';
 
 export const meta = {
   name: 'Text Component',
-  type: 'react-component',
   shortDesc: 'Reading a text',
   description:
     'Display a given text, can be taken from config, or operators, or both.',
@@ -46,8 +45,10 @@ export const ActivityRunner = ({ activityData }: ActivityRunnerT) =>
       {activityData.config ? activityData.config.text : 'NO TEXT'}
     </p>
   </div>;
+
 export default ({
   id: 'ac-text',
+  type: 'react-component',
   ActivityRunner,
   config,
   meta

--- a/ac/ac-video/src/index.js
+++ b/ac/ac-video/src/index.js
@@ -8,7 +8,6 @@ import Dashboard from './dashboard';
 
 export const meta = {
   name: 'Video player',
-  type: 'react-component',
   shortDesc: 'Video player',
   description:
     'Video player configurable with URL, and some settings (autoplay etc).',
@@ -62,6 +61,7 @@ export const ActivityRunner = ({ activityData, logger }: ActivityRunnerT) =>
 
 export default {
   id: 'ac-video',
+  type: 'react-component',
   ActivityRunner,
   config,
   meta,

--- a/frog-utils/src/types.js
+++ b/frog-utils/src/types.js
@@ -52,8 +52,8 @@ export type ActivityRunnerT = {
 
 export type ActivityPackageT = {
   id: string,
+  type: 'react-component',
   meta: {
-    type: string,
     name: string,
     shortDesc: string,
     description: string,
@@ -66,8 +66,8 @@ export type ActivityPackageT = {
 
 export type productOperatorT = {
   id: string,
+  type: 'product',
   meta: {
-    type: string,
     name: string,
     shortDesc: string,
     description: string
@@ -78,8 +78,8 @@ export type productOperatorT = {
 
 export type socialOperatorT = {
   id: string,
+  type: 'social',
   meta: {
-    type: string,
     name: string,
     shortDesc: string,
     description: string

--- a/frog/imports/api/activities.js
+++ b/frog/imports/api/activities.js
@@ -130,7 +130,7 @@ export const addOperator = (
     Operators.insert({
       _id: uuid(),
       operatorType,
-      type: operatorTypesObj[operatorType].meta.type,
+      type: operatorTypesObj[operatorType].type,
       data,
       err,
       createdAt: new Date()

--- a/op/op-argue/src/index.js
+++ b/op/op-argue/src/index.js
@@ -5,7 +5,6 @@ import type { socialOperatorT } from 'frog-utils';
 
 const meta = {
   name: 'Argue',
-  type: 'social',
   shortDesc: 'Group students to argue',
   description: 'Group students with as many similar answers as possible.'
 };
@@ -138,6 +137,7 @@ export const dist = (A: Object, B: Object): Set<string> =>
 
 export default ({
   id: 'op-argue',
+  type: 'social',
   operator,
   config,
   meta

--- a/op/op-create-groups/src/index.js
+++ b/op/op-create-groups/src/index.js
@@ -5,7 +5,6 @@ import { type socialOperatorT } from 'frog-utils';
 
 const meta = {
   name: 'Create groups',
-  type: 'social',
   shortDesc: 'Group students randomly',
   description:
     'Create random groups of students, configurable group size and strategy (at least n students, or maximum n students per group).'
@@ -59,6 +58,7 @@ const operator = (configData, object) => {
 
 export default ({
   id: 'op-create-groups',
+  type: 'social',
   operator,
   config,
   meta

--- a/op/op-distribute/src/index.js
+++ b/op/op-distribute/src/index.js
@@ -5,7 +5,6 @@ import { type productOperatorT } from 'frog-utils';
 
 const meta = {
   name: 'Distribute content',
-  type: 'product',
   shortDesc: 'Distribute list items',
   description:
     'Distribute list items to groups or individual students, with configurable numbers of items per group, overlap allowed or not, etc.'
@@ -90,6 +89,7 @@ const operator = (configData, object) => {
 
 export default ({
   id: 'op-distribute',
+  type: 'product',
   operator,
   config,
   meta,

--- a/op/op-group-identical/src/index.js
+++ b/op/op-group-identical/src/index.js
@@ -6,7 +6,6 @@ import type { socialOperatorT } from 'frog-utils';
 
 const meta = {
   name: 'Group based on identical student data',
-  type: 'social',
   shortDesc: 'Group identical students together',
   description: 'Group students with as many similar answers as possible'
 };
@@ -41,6 +40,7 @@ const operator = (configData, object) => {
 
 export default ({
   id: 'op-group-identical',
+  type: 'social',
   operator,
   config,
   meta

--- a/op/op-hypothesis/src/index.js
+++ b/op/op-hypothesis/src/index.js
@@ -11,7 +11,6 @@ import {
 
 export const meta = {
   name: 'Get ideas from Hypothesis',
-  type: 'product',
   shortDesc: 'Get ideas from Hypothesis API',
   description: 'Collect ideas from an Hypothesis API by hashtag or document id.'
 };
@@ -60,6 +59,7 @@ export const operator = (configData: {
 
 export default ({
   id: 'op-hypothesis',
+  type: 'product',
   operator,
   config,
   meta

--- a/op/op-jigsaw/src/index.js
+++ b/op/op-jigsaw/src/index.js
@@ -5,7 +5,6 @@ import { focusRole, type socialOperatorT } from 'frog-utils';
 
 const meta = {
   name: 'Jigsaw',
-  type: 'social',
   shortDesc: 'Assign students to groups and roles',
   description:
     'Given a list of roles, students are assigned to groups and roles, where each role only appears once in each group.'
@@ -56,6 +55,7 @@ const operator = (configData, object) => {
 
 export default ({
   id: 'op-jigsaw',
+  type: 'social',
   meta,
   config,
   operator


### PR DESCRIPTION
Social operators and product operators have some different values, and  we need Flow to be able to detect this properly. Turns out that currently it can only do so if the variable to check is in the top level of the object, see contrasting examples:

- [Doesn't work](https://flow.org/try/#0PTAEAEDMBsHsHcBQiCmAPADrATgF1LgJ4YqgCCAxrgJYBu1RAIgEYAqoAvKAN6KigB9agBMAXKADOubNQB2AcwA0fUMICGuNeIDyzAFYoqy-vOywArhjnyA0ikLipMhcdAZoa2SnGzzAW2YUbEQAXwBuZBAeUDUtaNMLDHEARkVQM2hvUAByCgALFEhstIpYOGxxbOwUYWzQEOUo-mZmcW5QBMtxACY0jKzs+DUGILqGxCbQCgo29LKBoZHsMfrUTBx8IhJJXHNhFFlcAGVpcypzavYuXn4AbSk9g9wASTEd53kAXVnbjWlqZjmXAoOwOd7Wb7ghSrcKRMDtTpJaLZZLZcS3HKxHKgT5pbLdNGgDHZFp1T71Rpgfj9Wb5QrozFqMlpRbAipEnKkvHTMkUiZUqZlHCzapvbKxFYhNZYPAEYikCSwCjUNTQE7YM67S6cHgqX64f6A4Ggxz-BSQm78Il-GRGlAANVV5iyTghpo+t0+KilsOlGzl23UmgAqrIGFdQLoDFRQAAfGKyQieiJ+2VbUhBtShhjqzUR9qlWSQajyHT6Qy4NKZ8SZ7O4di+9Ayzby96ai4oRiFfMdMyWawmqHyepxnJyYR0ETmVV1ePi6DQbIppv+9NuNSEOBqYQ9-WGoEg+zut2qDRZsPHU5UBvL9Zp1tqKiTphn-MqJzt6ruz+d7uuDAblubwAZusDbqwoS3s2AakFGFZvvwirKqqubnF+khKiqapXlqKCsK4j40PQL6aOIhHPoQjCvq48hwMwKE4R2swPPshyvBIx4KJ6MJQauraUERDCEAASuYsheNgCGgHA8jyEE4gAGJiU+sCyGkUQyfI1hTKq0D0RQADWKjkcRlFnjWZ51qh9auNWCaELZZ4KbIZbRpWKjmBIQTPEWsCzCInFKKAshqH4LpmsOPq8fe2wCRRAAKj4GWoclSQFQ6uGFpG6laMGVNUhEALSlH4WBeIcxQqPwIVhYFriIXkGxdhIMwZVVqgoC1MgYDQql1e16Che4nbmeQ2DYBuAA8niEAAfN6riFsWpaRuWRgqGF2ByUpsgqbIAD84gABS1he1n4atbkAJScLNoC0LAIiuHFpmieJ8mgEdaDiC9QlvRJrA3Rwd3CSghEACQAMKwKVqlPJNABUd3xqDEMAKKZGFhyI-NjZ3i22wYGYwiatoJATbgOBpW8rouBtKDZZa-DppUROwCTVCVblNXhR89WSI1eDNa1tNKO1+xddQPXUH1Q4LSoS0lq5FauLA5MaMKn2K-IVHZXBRigLAa24Mr15A3dJlCbragQXj0FrkhWFk0EGuSTqlrpaLmUM3ETN5TkjszvzPP9blEiC7gwuh1aEsUN1vUuXL-DjPwFi4BgQJdsWF4y4novcfGR1Hdrpu4ObQ6eldi2qctpeq+rlPssXNcltbdeG8bpeA7dGHIdhGpoXhkHICuMWkGrLuN4lhkpXhOqB9AzsU1To5sxzuBL67rApoWUgxDqR1q+IE-L9g0-JalV3iA9Ig97wACQ1CQIfGAAHRZWor9rhwP8B5hM43W4LveYr8ZIv1fmnDOkdChyAYLnG6PpEBAA)
- [Works](https://flow.org/try/#0PTAEAEDMBsHsHcBQiCmAPADrATgF1LgJ4YqgCCAxrgJYBu1RAIgEYAqoAvKAN6KigB9agBMAXKADOubNQB2AcwA0fUMICGuNeIDyzAFYoqy-vOywArhjnyA0ikLipMhcdAZoa2SnGzzAW2YUbEQAXwBuZBAeUDUtaNMLDHEARkVQM2hvUAByCgALFEhstIpYOGxxbOwUYWzQEOUo-mZmcW5QBMtxACY0jKzs+DUGILqGxCbQCgo29LKBoZHsMfrUTBx8IhJJXHNhFFlcAGVpcypzavYuXn4AbSk9g9wASTEd53kAXVnbjWlqZjmXAoOwOd7Wb7ghSrcKRMDtTpJaLZZLZcS3HKxHKgT5pbLdNGgDHZFp1T71Rpgfj9Wb5QrozFqMlpRbAipEnKkvHTMkUiZUqZlHCzapvbKxFYhNZYPAEYikCSwCjUNTQE7YM67S6cHgqX64f6A4Ggxz-BSQm78Il-GRGlAANVV5iyTghpo+t0+KilsOlGzl23UmgAqrIGFdQLoDFRQAAfGKyQieiJ+2VbUhBtShhjqzUR9qlWSQajyHT6Qy4NKZ8SZ7O4di+9Ayzby96ai4oRiFfMdMyWawmqHyepxnJyYR0ETmVV1ePi6DQbIppv+9NuNSEOBqYQ9-WGoEg+zut2qDRZsPHU5UBvL9Zp1tqKiTphn-MqJzt6ruz+d7uuDAblubwAZusDbqwoS3s2AakFGFZvvwirKqqubnF+khKiqapXlqKCsK4j40PQL6aOIhHPoQjCvq48hwMwKE4R2swPPshyvBIx4KJ6MJQauraUERDCEAASuYsheNgCGgHA8jyEE4gAGJiU+sCyGkUQyfI1hTKq0D0RQADWKjkcRlFnjWZ51qh9auNWCaELZZ4KbIZbRpWKjmBIQTPEWsCzCInFKKAshqH4LpmsOPq8fe2wCRRAAKj4GWoclSQFQ6uGFpG6laMGVNUhEALSlH4WBeIcxQqPwIVhYFriIXkGxdhIMwZVVqgoC1MgYDQql1e16Che4nbmeQ2DYBuAA8niEAAfN6riFsWpaRuWRgqGF2ByUpsgqbIAD84gABS1he1n4atbkAJScLNoC0LAIiuHFpmieJ8mgEdaDiC9QlvRJrA3Rwd3CSghEACQAMKwKVqlPJNABUd3xqDEMAKKZGFhyI-NjZ3i22wYGYwiatoJATbgOBpW8rouO16aVETsAk1QlX8FlcSWtVoXhR89WSI1eDNa1tNKO1+xddQPXUH1Q4LSoS0lq5FauLA5MaMKn2K-IVHZXBRigLAa24Mr15A3dJlCbragQXj0FrkhWFk0EGuSTqlrpaL-MMzkjszplKDZVzwU8-1uUSILuDC2HVoSxQ3W9S5cv8OM-AWLgGBAl2xYXjLSei9x8ZHUd2um7g5tDp6V2Lapy1l6r6uU+yJe1yW1v14bxtl4Dt0Ych2EamheGQcgK4xaQasu03iWGSleE6n70DOxTVOjkzLO4MvrusCmhZSDEOpHWr4iTyv2Az8lqVXeID0iL3vAAJDUJAR8YAAdGuHBf77mEzjd3B73mG-GSr837p0zlHQocgGB5xuj6RAQA)

Therefore I'm changing the type definition of ac/op packages to have type in the top level, and not in meta. I also made the allowed values explicit in types.js.

Going forwards, we should rethink entirely the API of ac/op, what should be in meta, do we even need meta, is there other ways of organizing/grouping values, etc.