### PR TITLE
Validate config

### DIFF
--- a/ac/ac-form/src/config.js
+++ b/ac/ac-form/src/config.js
@@ -1,7 +1,8 @@
 // @flow
 
-export default {
+export const config = {
   type: 'object',
+  required: ['title', 'questions'],
   properties: {
     title: {
       type: 'string',
@@ -17,3 +18,10 @@ export default {
     }
   }
 };
+
+export const validateConfig = [
+  (data: Object): null | { field: string, err: string } =>
+    data.questions.split(',').length > 5
+      ? { field: 'questions', err: 'You cannot have more than 5 questions' }
+      : null
+];

--- a/ac/ac-form/src/index.js
+++ b/ac/ac-form/src/index.js
@@ -5,7 +5,7 @@ import Form from 'react-jsonschema-form';
 
 import type { ActivityRunnerT, ActivityPackageT } from 'frog-utils';
 
-import config from './config';
+import { config, validateConfig } from './config';
 
 const meta = {
   name: 'Simple form',
@@ -92,5 +92,6 @@ export default ({
   type: 'react-component',
   meta,
   config,
+  validateConfig,
   ActivityRunner
 }: ActivityPackageT);

--- a/frog-utils/src/EnhancedForm.js
+++ b/frog-utils/src/EnhancedForm.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Form from 'react-jsonschema-form';
 import { cloneDeep } from 'lodash';
 
-const calculateSchema = (formData = {}, schema, UISchema) => {
+const calculateHides = (formData = {}, schema, UISchema) => {
   const hide = [];
   if (UISchema) {
     Object.keys(UISchema).forEach(x => {
@@ -24,7 +24,11 @@ const calculateSchema = (formData = {}, schema, UISchema) => {
       }
     });
   }
+  return hide;
+};
 
+const calculateSchema = (formData = {}, schema, UISchema) => {
+  const hide = calculateHides(formData, schema, UISchema);
   const newSchema = cloneDeep(schema);
   hide.forEach(x => delete newSchema.properties[x]);
   return newSchema;
@@ -37,3 +41,19 @@ const EnhancedForm = props => {
 };
 
 export default EnhancedForm;
+
+export const hideConditional = (
+  formData = {},
+  schema: Object,
+  UISchema: object
+): Object => {
+  if (UISchema) {
+    const hides = calculateHides(formData, schema, UISchema);
+
+    const newFormData = cloneDeep(formData);
+    hides.forEach(hide => delete newFormData[hide]);
+    return newFormData;
+  } else {
+    return formData;
+  }
+};

--- a/frog-utils/src/index.js
+++ b/frog-utils/src/index.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { compose, withHandlers, withState } from 'recompose';
 
-export { default as EnhancedForm } from './EnhancedForm';
+export { default as EnhancedForm, hideConditional } from './EnhancedForm';
 export { generateReactiveFn, inMemoryReactive } from './generateReactiveFn';
 export { Highlight } from './highlightSubstring';
 export { default as uuid } from 'cuid';

--- a/frog-utils/src/types.js
+++ b/frog-utils/src/types.js
@@ -50,6 +50,8 @@ export type ActivityRunnerT = {
   userInfo: { id: string, name: string }
 };
 
+export type validateConfigFnT = Object => null | { field: string, err: string };
+
 export type ActivityPackageT = {
   id: string,
   type: 'react-component',
@@ -60,6 +62,7 @@ export type ActivityPackageT = {
     exampleData: Array<any>
   },
   config: Object,
+  validateConfig?: validateConfigFnT[],
   mergeFunction?: (dataUnitStructT, Object) => void,
   ActivityRunner: (x: ActivityRunnerT) => React$Component<*> | React$Element<*>
 };
@@ -73,6 +76,7 @@ export type productOperatorT = {
     description: string
   },
   config: Object,
+  validateConfig?: validateConfigFnT[],
   operator: (configData: Object, object: ObjectT) => activityDataT
 };
 
@@ -85,6 +89,7 @@ export type socialOperatorT = {
     description: string
   },
   outputDefinition: string[] | ((config: Object) => string[]),
+  validateConfig?: validateConfigFnT[],
   config: Object,
   operator: (configData: Object, object: ObjectT) => socialStructureT
 };

--- a/frog/imports/api/__tests__/validGraphFnTest.js
+++ b/frog/imports/api/__tests__/validGraphFnTest.js
@@ -4,7 +4,7 @@ import valid from '../validGraphFn';
 
 const resultToIds = graph => {
   const res = valid(graph.activities, graph.operators, graph.connections);
-  return res.errors.map(x => x.id);
+  return res.errors.filter(x => x.type !== 'missingConfig').map(x => x.id);
 };
 
 test('Test activity with no type defined => unvalid', () => {

--- a/frog/imports/api/__tests__/validSocial.js
+++ b/frog/imports/api/__tests__/validSocial.js
@@ -4,7 +4,9 @@ import valid from '../validGraphFn';
 
 const getErrs = (a, o, c) => {
   const f = valid(a, o, c);
-  return f.errors.map(x => [x.id, x.type]);
+  return f.errors
+    .filter(x => x.type !== 'missingRequiredConfigField')
+    .map(x => [x.id, x.type]);
 };
 
 const activities = [

--- a/frog/imports/api/__tests__/validateConfig.js
+++ b/frog/imports/api/__tests__/validateConfig.js
@@ -103,3 +103,7 @@ test('test datafns', () => {
     }
   ]);
 });
+
+test('test empty requirement', () => {
+  expect(valid('1', {}, { type: 'object', properties: {} })).toEqual([]);
+});

--- a/frog/imports/api/__tests__/validateConfig.js
+++ b/frog/imports/api/__tests__/validateConfig.js
@@ -1,4 +1,6 @@
-import valid from '../validateConfig';
+import v from '../validateConfig';
+const valid = (id, obj, config, validfn) =>
+  v('activity', id, obj, config, validfn);
 
 const config = {
   type: 'object',
@@ -31,6 +33,7 @@ test('test correct validator, number/string', () => {
     {
       err: "Field 'Desired group size' is not of a type(s) number",
       field: 'groupsize',
+      nodeType: 'activity',
       id: '1',
       severity: 'error',
       type: 'invalidConfigField'
@@ -43,6 +46,7 @@ test('test obligatory field', () => {
     {
       err: "Field 'Desired group size' is not of a type(s) number",
       field: 'groupsize',
+      nodeType: 'activity',
       id: '1',
       severity: 'error',
       type: 'invalidConfigField'
@@ -75,6 +79,7 @@ test('test obligatory field', () => {
     {
       err: "Field 'Group formation strategy' required",
       field: 'strategy',
+      nodeType: 'activity',
       id: '1',
       severity: 'error',
       type: 'missingRequiredConfigField'
@@ -98,6 +103,7 @@ test('test datafns', () => {
       field: 'strategy',
       id: '1',
       msg: 'Strategy field cannot be longer than 2 characters',
+      nodeType: 'activity',
       severity: 'error',
       type: 'configValidateFn'
     }

--- a/frog/imports/api/__tests__/validateConfig.js
+++ b/frog/imports/api/__tests__/validateConfig.js
@@ -1,0 +1,105 @@
+import valid from '../validateConfig';
+
+const config = {
+  type: 'object',
+  properties: {
+    groupsize: {
+      type: 'number',
+      title: 'Desired group size'
+    },
+    strategy: {
+      type: 'string',
+      title:
+        'Group formation strategy, optimize for at least this number of students in each group (minimum) or no more than this number of students per group (maximum)?',
+      enum: ['minimum', 'maximum']
+    },
+    grouping: {
+      type: 'string',
+      title: "Name of social attribute (default 'group')"
+    }
+  }
+};
+const obj = { groupsize: 3, strategy: 'minimum', grouping: 'group' };
+
+test('test correct validator', () => {
+  expect(valid('1', obj, config)).toEqual([]);
+});
+const obj1 = { groupsize: '3', strategy: 'minimum', grouping: 'group' };
+
+test('test correct validator, number/string', () => {
+  expect(valid('1', obj1, config)).toEqual([
+    {
+      err: "Field 'Desired group size' is not of a type(s) number",
+      field: 'groupsize',
+      id: '1',
+      severity: 'error',
+      type: 'invalidConfigField'
+    }
+  ]);
+});
+
+test('test obligatory field', () => {
+  expect(valid('1', obj1, config)).toEqual([
+    {
+      err: "Field 'Desired group size' is not of a type(s) number",
+      field: 'groupsize',
+      id: '1',
+      severity: 'error',
+      type: 'invalidConfigField'
+    }
+  ]);
+});
+
+const config1 = {
+  type: 'object',
+  required: ['strategy'],
+  properties: {
+    groupsize: {
+      type: 'number',
+      title: 'Desired group size'
+    },
+    strategy: {
+      type: 'string',
+      title: 'Group formation strategy',
+      enum: ['minimum', 'maximum']
+    },
+    grouping: {
+      type: 'string',
+      title: "Name of social attribute (default 'group')"
+    }
+  }
+};
+
+test('test obligatory field', () => {
+  expect(valid('1', {}, config1)).toEqual([
+    {
+      err: "Field 'Group formation strategy' required",
+      field: 'strategy',
+      id: '1',
+      severity: 'error',
+      type: 'missingRequiredConfigField'
+    }
+  ]);
+});
+
+const validfns = [
+  data =>
+    data.strategy.length > 2
+      ? {
+          field: 'strategy',
+          msg: 'Strategy field cannot be longer than 2 characters'
+        }
+      : null
+];
+
+test('test datafns', () => {
+  expect(valid('1', obj, config1, validfns)).toEqual([
+    {
+      field: 'strategy',
+      id: '1',
+      msg: 'Strategy field cannot be longer than 2 characters',
+      severity: 'error',
+      type: 'configValidateFn'
+    }
+  ]);
+});

--- a/frog/imports/api/checkSocial.js
+++ b/frog/imports/api/checkSocial.js
@@ -28,7 +28,8 @@ export default (
           if (!social[node._id] || !social[node._id].includes(node.data[x])) {
             errors.push({
               id: node._id,
-              err: `The config of ${nodeType} ${node.title} requires the social attribute '${x}', which is not provided by any connected social operator`,
+              nodeType,
+              err: `Config requires the social attribute '${x}', which is not provided by any connected social operator`,
               type: 'missingSocialAttribute',
               severity: 'error'
             });
@@ -43,7 +44,8 @@ export default (
         if (socialFieldValues.includes(node.groupingKey)) {
           errors.push({
             id: node._id,
-            err: `The ${nodeType} ${node.title} uses the same social attribute in the grouping field, and in the configuration`,
+            nodeType,
+            err: `Cannot use the same social attribute in the grouping field, and in the configuration`,
             type: 'groupingKeyInConfig',
             severity: 'error'
           });
@@ -54,7 +56,8 @@ export default (
       if (!soc.includes(node.groupingKey)) {
         errors.push({
           id: node._id,
-          err: `The ${nodeType} ${node.title} requires the grouping attribute '${node.groupingKey}', which is not provided by any connected social operator`,
+          nodeType,
+          err: `Requires the grouping attribute '${node.groupingKey}', which is not provided by any connected social operator`,
           type: 'groupingKeyNotProvided',
           severity: 'error'
         });

--- a/frog/imports/api/traceSocial.js
+++ b/frog/imports/api/traceSocial.js
@@ -49,10 +49,11 @@ export default (
     if (socAttribs.length > 0) {
       const dup = duplicates(socAttribs);
       if (dup.length > 0) {
-        const type = x.plane ? 'activity' : 'operator';
+        const nodeType = x.plane ? 'activity' : 'operator';
         errors.push({
           id: x._id,
-          err: `The ${type} ${x.title} receives the social attribute(s) ${dup
+          nodeType,
+          err: `Receives the social attribute(s) ${dup
             .map(y => `'${y}'`)
             .join(', ')} from more than one social operator.`,
           type: 'overlappingSocialAttributes',

--- a/frog/imports/api/validGraphFn.js
+++ b/frog/imports/api/validGraphFn.js
@@ -28,7 +28,8 @@ export const checkComponent = (
         ...acc,
         {
           id: x._id,
-          err: 'Type of the ' + nodeType + ' ' + x.title + ' is not defined',
+          nodeType,
+          err: 'Type is not defined',
           type: 'missingType',
           severity
         }
@@ -43,7 +44,8 @@ export const checkComponent = (
         ...acc,
         {
           id: x._id,
-          err: `The ${nodeType}Package ${type} required by ${nodeType} ${x.title} is not installed`,
+          nodeType,
+          err: `The ${nodeType}Package ${type} is not installed`,
           type: 'missingPackage',
           severity: 'error'
         }
@@ -73,10 +75,8 @@ const checkConnection = (
           ...acc,
           {
             id: act._id,
-            err:
-              'The group activity ' +
-              act.title +
-              ' needs to be connected to a social operator',
+            nodeType: 'activity',
+            err: 'A group activity needs to be connected to a social operator',
             type: 'needsSocialOp',
             severity: 'error'
           }
@@ -92,7 +92,8 @@ const checkConnection = (
         ...acc,
         {
           id: op._id,
-          err: `The operator ${op.title} does not have any outgoing connections`,
+          nodeType: 'operator',
+          err: `Does not have any outgoing connections`,
           type: 'noOutgoing',
           severity: 'warning'
         }
@@ -110,6 +111,7 @@ const checkConfigs = (operators, activities) => {
         x.operatorType &&
         operatorTypesObj[x.operatorType] &&
         validateConfig(
+          'operator',
           x._id,
           hideConditional(
             x.data,
@@ -128,6 +130,7 @@ const checkConfigs = (operators, activities) => {
         x.activityType &&
         activityTypesObj[x.activityType] &&
         validateConfig(
+          'activity',
           x._id,
           hideConditional(
             x.data,

--- a/frog/imports/api/validGraphFn.js
+++ b/frog/imports/api/validGraphFn.js
@@ -1,5 +1,6 @@
 // @flow
 import { compact, flatMap } from 'lodash';
+import { hideConditional } from 'frog-utils';
 
 import { activityTypes, activityTypesObj } from '../activityTypes';
 import { operatorTypes, operatorTypesObj } from '../operatorTypes';
@@ -44,19 +45,6 @@ export const checkComponent = (
           id: x._id,
           err: `The ${nodeType}Package ${type} required by ${nodeType} ${x.title} is not installed`,
           type: 'missingPackage',
-          severity: 'error'
-        }
-      ];
-    }
-
-    if (x.err) {
-      return [
-        ...acc,
-        {
-          id: x._id,
-          err:
-            'Error(s) in the configuration of the ' + nodeType + ' ' + x.title,
-          type: 'configError',
           severity: 'error'
         }
       ];
@@ -123,7 +111,11 @@ const checkConfigs = (operators, activities) => {
         operatorTypesObj[x.operatorType] &&
         validateConfig(
           x._id,
-          x.data,
+          hideConditional(
+            x.data,
+            operatorTypesObj[x.operatorType].config,
+            operatorTypesObj[x.operatorType].configUI
+          ),
           operatorTypesObj[x.operatorType].config,
           operatorTypesObj[x.operatorType].validateConfig
         )
@@ -137,7 +129,11 @@ const checkConfigs = (operators, activities) => {
         activityTypesObj[x.activityType] &&
         validateConfig(
           x._id,
-          x.data,
+          hideConditional(
+            x.data,
+            activityTypesObj[x.activityType].config,
+            activityTypesObj[x.activityType].configUI
+          ),
           activityTypesObj[x.activityType].config,
           activityTypesObj[x.activityType].validateConfig
         )

--- a/frog/imports/api/validateConfig.js
+++ b/frog/imports/api/validateConfig.js
@@ -16,10 +16,11 @@ const runFn = (id, fn, obj) => {
   }
 };
 
-export default (id, obj, schema, datafns) => {
+export default (nodeType, id, obj, schema, datafns) => {
   if (schema && schema.properties !== {} && (obj === {} || !obj)) {
     return {
       id,
+      nodeType,
       type: 'missingConfig',
       severity: 'error',
       err: 'No config available'
@@ -33,6 +34,7 @@ export default (id, obj, schema, datafns) => {
       if (x.name === 'type') {
         return {
           field,
+          nodeType,
           err: `Field '${x.schema.title}' ${x.message}`,
           id,
           severity: 'error',
@@ -41,6 +43,7 @@ export default (id, obj, schema, datafns) => {
       } else if (x.name === 'required') {
         return {
           field: x.argument,
+          nodeType,
           err: `Field '${result.schema.properties[x.argument].title}' required`,
           type: 'missingRequiredConfigField',
           severity: 'error',
@@ -63,6 +66,7 @@ export default (id, obj, schema, datafns) => {
   return dataerrors.map(x => ({
     ...x,
     id,
+    nodeType,
     type: 'configValidateFn',
     severity: 'error'
   }));

--- a/frog/imports/api/validateConfig.js
+++ b/frog/imports/api/validateConfig.js
@@ -1,0 +1,69 @@
+import { compact } from 'lodash';
+import { Validator } from 'jsonschema';
+
+const v = new Validator();
+
+const runFn = (id, fn, obj) => {
+  try {
+    return fn(obj);
+  } catch (e) {
+    return {
+      id,
+      type: 'validConfigCrashed',
+      severity: 'error',
+      err: 'The config validator crashed'
+    };
+  }
+};
+
+export default (id, obj, schema, datafns) => {
+  if (schema && schema.properties !== {} && (obj === {} || !obj)) {
+    return {
+      id,
+      type: 'missingConfig',
+      severity: 'error',
+      err: 'No config available'
+    };
+  }
+
+  const result = v.validate(obj, schema);
+  const validResult = compact(
+    result.errors.map(x => {
+      const field = x.property.slice(9);
+      if (x.name === 'type') {
+        return {
+          field,
+          err: `Field '${x.schema.title}' ${x.message}`,
+          id,
+          severity: 'error',
+          type: 'invalidConfigField'
+        };
+      } else if (x.name === 'required') {
+        return {
+          field: x.argument,
+          err: `Field '${result.schema.properties[x.argument].title}' required`,
+          type: 'missingRequiredConfigField',
+          severity: 'error',
+          id
+        };
+      } else {
+        console.error('missing validator error', result.err);
+      }
+      return null;
+    })
+  );
+
+  if (validResult.length > 0) {
+    return validResult;
+  }
+
+  const dataerrors =
+    datafns && obj ? compact(datafns.map(fn => runFn(id, fn, obj))) : [];
+
+  return dataerrors.map(x => ({
+    ...x,
+    id,
+    type: 'configValidateFn',
+    severity: 'error'
+  }));
+};

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
@@ -100,7 +100,6 @@ const EditActivity = props => {
           props.store.refreshValidate();
         }}
         formData={activity.data}
-        liveValidate
       >
         <div />
       </EnhancedForm>

--- a/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel.js
@@ -160,7 +160,6 @@ const EditClass = ({
           refreshValidate();
         }}
         formData={operator.data}
-        liveValidate
       >
         <div />
       </EnhancedForm>

--- a/frog/imports/ui/GraphEditor/Validator.js
+++ b/frog/imports/ui/GraphEditor/Validator.js
@@ -41,18 +41,40 @@ const ListError = ({ errors, maxLength }) => {
 };
 
 export const ErrorList = connect(
-  ({ store: { graphErrors, ui: { showErrors } }, activityId }) => {
+  ({
+    store: {
+      graphErrors,
+      ui: { showErrors },
+      activityStore: { all: activities },
+      operatorStore: { all: operators }
+    },
+    activityId
+  }) => {
+    // component not open
     if (showErrors !== true && showErrors !== activityId) {
       return null;
     }
 
+    // being called from the wrong place
     if (activityId && showErrors === true) {
       return null;
     }
-    const errors =
-      showErrors === true
-        ? graphErrors
-        : graphErrors.filter(x => x.id === activityId);
+
+    let errors;
+    if (showErrors === true) {
+      errors = graphErrors.map(x => {
+        const nodeName =
+          x.nodeType === 'activity'
+            ? activities.find(y => y.id === x.id).title
+            : operators.find(y => y.id === x.id).title;
+        return {
+          ...x,
+          err: `${x.nodeType} ${nodeName || 'unnamed'}: ${x.err}`
+        };
+      });
+    } else {
+      errors = graphErrors.filter(x => x.id === activityId);
+    }
     if (errors.length === 0) {
       return null;
     }

--- a/frog/package.json
+++ b/frog/package.json
@@ -25,6 +25,7 @@
     "http": "0.0.0",
     "json-stable-stringify": "^1.0.1",
     "json-stringify-pretty-compact": "^1.0.3",
+    "jsonschema": "^1.1.1",
     "lodash": "^4.17.4",
     "meteor-node-stubs": "^0.2.3",
     "mobx": "^3.0.2",

--- a/frog/yarn.lock
+++ b/frog/yarn.lock
@@ -1112,7 +1112,7 @@ jsonpath-plus@^0.16.0:
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-0.16.0.tgz#fe441b23f03ec6979a5603513988cd3edb7db5dc"
 
-jsonschema@^1.0.2:
+jsonschema@^1.0.2, jsonschema@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.1.1.tgz#3cede8e3e411d377872eefbc9fdf26383cbc3ed9"
 

--- a/op/op-hypothesis/src/index.js
+++ b/op/op-hypothesis/src/index.js
@@ -17,6 +17,7 @@ export const meta = {
 
 export const config = {
   type: 'object',
+  required: ['tag', 'url'],
   properties: {
     tag: {
       type: 'string',


### PR DESCRIPTION
This adds config validation to both operators and activities, using jsonschema, and a custom validateConfig function. It also changes the formatting of error messages to insert nodeType and name globally, which means that we can hide this in the sidepanel error list.