### PR TITLE
Preview based on custom config

### DIFF
--- a/ac/ac-ck-board/src/index.js
+++ b/ac/ac-ck-board/src/index.js
@@ -82,6 +82,13 @@ const config = {
   }
 };
 
+const configUI = {
+  quadrant1: { conditional: 'quadrants' },
+  quadrant2: { conditional: 'quadrants' },
+  quadrant3: { conditional: 'quadrants' },
+  quadrant4: { conditional: 'quadrants' }
+};
+
 const dataStructure = [];
 
 const mergeFunction = (object, dataFn) => {
@@ -102,6 +109,7 @@ export default ({
   type: 'react-component',
   meta,
   config,
+  configUI,
   ActivityRunner: Board,
   Dashboard: null,
   dataStructure,

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
@@ -4,8 +4,11 @@ import { EnhancedForm, ChangeableText } from 'frog-utils';
 import { addActivity } from '/imports/api/activities';
 import { activityTypesObj } from '/imports/activityTypes';
 import FlexView from 'react-flexview';
+import { withState } from 'recompose';
+import { Button } from 'react-bootstrap';
 
 import { connect } from '../../store';
+import Preview from '../../Preview';
 import { ErrorList, ValidButton } from '../../Validator';
 import { RenameField } from '../../Rename';
 import FileForm from '../fileUploader';
@@ -63,6 +66,19 @@ const EditActivity = props => {
             </h3>
           </div>
           <FlexView marginLeft="auto">
+            {errorColor === 'green' &&
+              <Button
+                className="glyphicon glyphicon-eye-open"
+                style={{
+                  position: 'absolute',
+                  right: '2px',
+                  top: '39px',
+                  width: '9%',
+                  height: '34px'
+                }}
+                onClick={() => props.setShowInfo(true)}
+              />}
+
             <ValidButton activityId={activity._id} errorColor={errorColor} />
           </FlexView>
         </FlexView>
@@ -104,8 +120,16 @@ const EditActivity = props => {
         <div />
       </EnhancedForm>
       <FileForm />
+      {props.showInfo &&
+        <Preview
+          activityTypeId={activity.activityType}
+          config={activity.data}
+          dismiss={() => props.setShowInfo(false)}
+        />}
     </div>
   );
 };
 
-export default connect(EditActivity);
+export default withState('showInfo', 'setShowInfo', false)(
+  connect(EditActivity)
+);

--- a/frog/imports/ui/StudentView/ReactiveHOC.jsx
+++ b/frog/imports/ui/StudentView/ReactiveHOC.jsx
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 import { generateReactiveFn } from 'frog-utils';
-import { deepClone } from 'lodash';
+import { cloneDeep } from 'lodash';
 
 import { connection } from '../App/index';
 
@@ -46,7 +46,7 @@ const ReactiveHOC = (
             if (previewActivity.mergeFunction) {
               const dataFn = generateReactiveFn(this.doc);
               previewActivity.mergeFunction(
-                deepClone(previewActivityData),
+                cloneDeep(previewActivityData),
                 dataFn
               );
             }


### PR DESCRIPTION
This PR adds the ability to show a preview of an activity, given user inputted custom config. This option is only valid when there are no errors for a given activity. It chooses all exampleData configs where the activityData portion is different, and merges the config into the activityData object.

Future note:
Currently the example data mix config and activity data. This makes it messy when we try to provide different example data in activity-specific preview... One option is to disentangle, provide one list of activityData, and one list of config... Makes preview UI a bit more complex, and also - do all configs go with all example data? So far, I think so?