### PR TITLE
Default incoming data -> null

### DIFF
--- a/ac/ac-chat/src/index.js
+++ b/ac/ac-chat/src/index.js
@@ -48,7 +48,9 @@ const config = {
 };
 
 const mergeFunction = (obj, dataFn) => {
-  obj.data.forEach(x => dataFn.listAppend(x));
+  if (obj.data) {
+    obj.data.forEach(x => dataFn.listAppend(x));
+  }
 };
 
 export default ({

--- a/frog-utils/src/dataStructureTools.js
+++ b/frog-utils/src/dataStructureTools.js
@@ -23,7 +23,7 @@ const mergeConfig = (
 // takes a single dataUnit, config object, or both, for all students, and wraps them in a proper
 // activityDataT structure
 export const wrapUnitAll = (
-  data: dataUnitT = {},
+  data: dataUnitT = null,
   config: Object = {}
 ): activityDataT => ({
   structure: 'all',
@@ -37,7 +37,7 @@ export const extractUnit = (
   socialStructure?: socialStructureT
 ): dataUnitStructT => {
   if (!data) {
-    return { data: {}, config: {} };
+    return { data: null, config: {} };
   } else if (data.structure === 'all') {
     return data.payload.all;
   } else if (data.structure === 'individual') {

--- a/frog/server/runDataflow.js
+++ b/frog/server/runDataflow.js
@@ -80,7 +80,7 @@ const runDataflow = (
       ? prod.activityData
       : {
           structure: 'all',
-          payload: { all: { data: {}, config: {} } }
+          payload: { all: { data: null, config: {} } }
         };
 
   // More data needed by the operators. Will need to be completed, documented and typed if possible


### PR DESCRIPTION
I think the cleanest approach is to make incoming empty data explicitly null, and have activities explicitly check for null. This only needs to happen in mergeFunction, because the reactive data is initialized with the default dataStructure ([] or {} or something else), so the actual ActivityRunner can map, etc without worry. 

Needs more testing with the other activities/operators. 

Closes #400 
Closes #309