### PR TITLE
Preview on separate permanent URL

### DIFF
--- a/frog-utils/src/index.js
+++ b/frog-utils/src/index.js
@@ -40,7 +40,8 @@ export type {
   ActivityPackageT,
   productOperatorT,
   socialOperatorT,
-  operatorPackageT
+  operatorPackageT,
+  ReactComponent
 } from './types';
 
 export const A = ({ onClick, children, ...rest }: any): any =>

--- a/frog-utils/src/types.js
+++ b/frog-utils/src/types.js
@@ -53,6 +53,10 @@ export type ActivityRunnerT = {
 
 export type validateConfigFnT = Object => null | { field: string, err: string };
 
+export type ReactComponent<Props> =
+  | Class<React$Component<*, Props, *>>
+  | (Props => React$Element<any>);
+
 export type ActivityPackageT = {
   id: string,
   type: 'react-component',
@@ -63,9 +67,10 @@ export type ActivityPackageT = {
     exampleData: Array<any>
   },
   config: Object,
+  dataStructure?: any,
   validateConfig?: validateConfigFnT[],
   mergeFunction?: (dataUnitStructT, Object) => void,
-  ActivityRunner: (x: ActivityRunnerT) => React$Component<*> | React$Element<*>
+  ActivityRunner: ReactComponent<ActivityRunnerT>
 };
 
 export type productOperatorT = {

--- a/frog/imports/ui/App/FROGRouter.js
+++ b/frog/imports/ui/App/FROGRouter.js
@@ -9,6 +9,7 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 import StudentView from './../StudentView';
 import TeacherView from './../TeacherView';
 import GraphEditor from './../GraphEditor';
+import Preview from './../Preview';
 import Admin from './../Admin';
 import TopBar from './TopBar';
 import NotLoggedIn from './NotLoggedIn';
@@ -44,6 +45,9 @@ const Page = ({ isNotLoggedIn, isRedirect, isStudent, path, ready }) => {
         <Route path="/teacher" component={TeacherView} />
         <Route path="/student" component={StudentView} />
         <Route path="/admin" component={Admin} />
+        <Route path="/preview/:activityTypeId/:example" component={Preview} />
+        <Route path="/preview/:activityTypeId" component={Preview} />
+        <Route path="/preview" component={Preview} />
         <Route component={FourOhFour} />
       </Switch>
     </div>

--- a/frog/imports/ui/App/TopBar.js
+++ b/frog/imports/ui/App/TopBar.js
@@ -17,6 +17,7 @@ const TopBar = () =>
   <ul className="nav nav-pills">
     <Link to="/admin">Admin</Link>
     <Link to="/graph">Graph Editor</Link>
+    <Link to="/preview">Preview</Link>
     <Link to="/teacher">Teacher View</Link>
     <Link to="/student">Student View</Link>
   </ul>;

--- a/frog/imports/ui/GraphEditor/Preview.js
+++ b/frog/imports/ui/GraphEditor/Preview.js
@@ -1,3 +1,5 @@
+// @flow
+//
 import React from 'react';
 import { cloneDeep, uniqBy } from 'lodash';
 import Stringify from 'json-stable-stringify';
@@ -7,6 +9,7 @@ import { Nav, NavItem } from 'react-bootstrap';
 import { withState, compose } from 'recompose';
 import { Inspector } from 'react-inspector';
 import { Meteor } from 'meteor/meteor';
+import { Link } from 'react-router-dom';
 
 import { activityTypesObj } from '../../activityTypes';
 import ReactiveHOC from '../StudentView/ReactiveHOC';
@@ -27,73 +30,90 @@ const ShowInfo = ({ activityData, data }) =>
     </div>
   </div>;
 
-export default compose(
+export const StatelessPreview = ({
+  activityTypeId,
+  example,
+  setExample,
+  showData,
+  setShowData,
+  dismiss,
+  config,
+  isSeparatePage = false
+}: {
+  activityTypeId: string,
+  example: number,
+  setExample: Function,
+  showData: boolean,
+  setShowData: Function,
+  dismiss?: Function,
+  config?: Object,
+  isSeparatePage: boolean
+}) => {
+  const activityType = activityTypesObj[activityTypeId];
+
+  const RunComp = activityType.ActivityRunner;
+  RunComp.displayName = activityType.id;
+
+  const examples = config
+    ? uniqBy(activityType.meta.exampleData, x => Stringify(x.data))
+    : activityType.meta.exampleData;
+
+  const activityData = cloneDeep(examples[example]);
+  if (config) {
+    activityData.config = config;
+  }
+  const ActivityToRun = ReactiveHOC(
+    cloneDeep(activityType.dataStructure || {}),
+    'demo/' + activityType.id + '/' + example,
+    activityType,
+    activityData
+  )(showData ? ShowInfo : RunComp);
+
+  return (
+    <Modal
+      contentLabel={'Preview of ' + activityType.id}
+      isOpen
+      onRequestClose={dismiss || (() => null)}
+    >
+      <div className="modal-header">
+        <button type="button" className="close" onClick={dismiss}>
+          X
+        </button>
+
+        <h4 className="modal-title">
+          Preview of {activityType.meta.name} ({activityType.id}){' '}
+          <A onClick={() => setShowData(!showData)}>
+            (show {showData ? 'activity' : 'underlying data'})
+          </A>{' '}
+          {!isSeparatePage &&
+            <Link to={`/preview/${activityTypeId}/${example}`}>
+              (Open in separate window)
+            </Link>}
+        </h4>
+        <Nav bsStyle="pills" activeKey={example}>
+          {examples.map((x, i) =>
+            // eslint-disable-next-line react/no-array-index-key
+            <NavItem key={i} eventKey={i} onClick={() => setExample(i)}>
+              {x.title}
+            </NavItem>
+          )}
+        </Nav>
+      </div>
+      <div style={{ position: 'absolute', width: '100%', height: '100%' }}>
+        <ActivityToRun
+          activityData={activityData}
+          userInfo={{ name: Meteor.user().username, id: Meteor.userId() }}
+          logger={() => {}}
+        />
+      </div>
+    </Modal>
+  );
+};
+
+const StatefulPreview = compose(
   withState('example', 'setExample', 0),
   withState('showData', 'setShowData', false)
-)(
-  ({
-    activityTypeId,
-    example,
-    setExample,
-    showData,
-    setShowData,
-    dismiss,
-    config
-  }) => {
-    const activityType = activityTypesObj[activityTypeId];
+)(StatelessPreview);
 
-    const RunComp = activityType.ActivityRunner;
-    RunComp.displayName = activityType;
-
-    const examples = config
-      ? uniqBy(activityType.meta.exampleData, x => Stringify(x.data))
-      : activityType.meta.exampleData;
-
-    const activityData = cloneDeep(examples[example]);
-    if (config) {
-      activityData.config = config;
-    }
-    const ActivityToRun = ReactiveHOC(
-      cloneDeep(activityType.dataStructure),
-      'demo/' + activityType.id + '/' + example,
-      activityType,
-      activityData
-    )(showData ? ShowInfo : RunComp);
-
-    return (
-      <Modal
-        contentLabel={'Preview of ' + activityType.id}
-        isOpen
-        onRequestClose={dismiss}
-      >
-        <div className="modal-header">
-          <button type="button" className="close" onClick={dismiss}>
-            X
-          </button>
-
-          <h4 className="modal-title">
-            Preview of {activityType.meta.name} ({activityType.id}){' '}
-            <A onClick={() => setShowData(!showData)}>
-              (show {showData ? 'activity' : 'underlying data'})
-            </A>
-          </h4>
-          <Nav bsStyle="pills" activeKey={example}>
-            {examples.map((x, i) =>
-              // eslint-disable-next-line react/no-array-index-key
-              <NavItem key={i} eventKey={i} onClick={() => setExample(i)}>
-                {x.title}
-              </NavItem>
-            )}
-          </Nav>
-        </div>
-        <div style={{ position: 'absolute', width: '100%', height: '100%' }}>
-          <ActivityToRun
-            activityData={activityData}
-            userInfo={{ name: Meteor.user().username, id: Meteor.userId() }}
-            logger={() => {}}
-          />
-        </div>
-      </Modal>
-    );
-  }
-);
+StatefulPreview.displayName = 'StatefulPreview';
+export default StatefulPreview;

--- a/frog/imports/ui/Preview/index.js
+++ b/frog/imports/ui/Preview/index.js
@@ -1,0 +1,51 @@
+// @flow
+import React from 'react';
+import { toObject as queryToObject } from 'query-parse';
+import { withRouter } from 'react-router';
+import { A } from 'frog-utils';
+
+import { StatelessPreview } from '../GraphEditor/Preview';
+import { activityTypes } from '../../activityTypes';
+
+const ActivityList = ({ history }) =>
+  <div>
+    <h2>Choose activity to preview</h2>
+    <ul>
+      {activityTypes.map(act =>
+        <li>
+          <A onClick={() => history.push(`/preview/${act.id}`)}>
+            {act.id}
+          </A>
+        </li>
+      )}
+    </ul>
+  </div>;
+
+const PreviewPage = ({
+  match: { params: { activityTypeId = null, example = 0 } },
+  location: { search },
+  history
+}) => {
+  const showData = queryToObject(search.slice(1)).showData === 'true';
+  const setExample = ex =>
+    history.push(`/preview/${activityTypeId || ''}/${ex}`);
+  const setShowData = ex =>
+    history.push(`/preview/${activityTypeId || ''}/${example}?showData=${ex}`);
+  const dismiss = () => history.push(`/preview`);
+  return activityTypeId
+    ? <StatelessPreview
+        {...{
+          activityTypeId,
+          example,
+          setExample,
+          showData,
+          setShowData,
+          dismiss,
+          isSeparatePage: true
+        }}
+      />
+    : <ActivityList history={history} />;
+};
+
+PreviewPage.displayName = 'PreviewPage';
+export default withRouter(PreviewPage);

--- a/frog/imports/ui/Preview/index.js
+++ b/frog/imports/ui/Preview/index.js
@@ -12,7 +12,7 @@ const ActivityList = ({ history }) =>
     <h2>Choose activity to preview</h2>
     <ul>
       {activityTypes.map(act =>
-        <li>
+        <li key={act.id}>
           <A onClick={() => history.push(`/preview/${act.id}`)}>
             {act.id}
           </A>

--- a/frog/imports/ui/StudentView/ReactiveHOC.jsx
+++ b/frog/imports/ui/StudentView/ReactiveHOC.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { generateReactiveFn } from 'frog-utils';
+import { generateReactiveFn, type ReactComponent } from 'frog-utils';
 import { cloneDeep } from 'lodash';
 
 import { uploadFile } from '../../api/openUploads';
@@ -21,7 +21,7 @@ const ReactiveHOC = (
   docId: string,
   previewActivity: any = false,
   previewActivityData: any = null
-) => (WrappedComponent: Class<Component<*, *, *>>) => {
+) => (WrappedComponent: ReactComponent<any>) => {
   class ReactiveComp extends Component {
     state: { data: any, dataFn: ?Object };
     doc: any;


### PR DESCRIPTION
This enables previewing activities outside of the context of the graph editor, with a permanent URL that survives reloads. 

- you can directly type /preview/{activity-id} optionally followed by {example-id}. It also keeps track of whether showing data with ?showData=true
- you can click on preview in the top menubar (or just type /preview) to see a list of all activity types. This list is also shown if you close an activity preview
- when previewing an activity in the graph editor, there is a link to open the preview with a permanent URL (note, you cannot get back to the graph view from here)

This seems to work quite well with minimal code change. In the future, I could imagine adding the possibility of custom configurations, as well as the ability to see an activity inside a multi-window view with n number of panes.

Closes #383