### PR TITLE
Fix reactive data (second attempt)

### DIFF
--- a/frog/imports/ui/GraphEditor/Preview.js
+++ b/frog/imports/ui/GraphEditor/Preview.js
@@ -1,15 +1,16 @@
 // @flow
-//
+
 import React from 'react';
 import { cloneDeep, uniqBy } from 'lodash';
 import Stringify from 'json-stable-stringify';
-import { A } from 'frog-utils';
+import { A, generateReactiveFn, uuid } from 'frog-utils';
 import Modal from 'react-modal';
 import { Nav, NavItem } from 'react-bootstrap';
 import { withState, compose } from 'recompose';
 import { Inspector } from 'react-inspector';
 import { Meteor } from 'meteor/meteor';
 import { Link } from 'react-router-dom';
+import ShareDB from 'sharedb';
 
 import { activityTypesObj } from '../../activityTypes';
 import ReactiveHOC from '../StudentView/ReactiveHOC';
@@ -30,85 +31,123 @@ const ShowInfo = ({ activityData, data }) =>
     </div>
   </div>;
 
-export const StatelessPreview = ({
-  activityTypeId,
-  example,
-  setExample,
-  showData,
-  setShowData,
-  dismiss,
-  config,
-  isSeparatePage = false
-}: {
-  activityTypeId: string,
-  example: number,
-  setExample: Function,
-  showData: boolean,
-  setShowData: Function,
-  dismiss?: Function,
-  config?: Object,
-  isSeparatePage: boolean
-}) => {
-  const activityType = activityTypesObj[activityTypeId];
+const backend = new ShareDB();
+const connection = backend.connect();
+const Collections = {};
 
-  const RunComp = activityType.ActivityRunner;
-  RunComp.displayName = activityType.id;
+export const StatelessPreview = withState(
+  'reload',
+  'setReload',
+  ''
+)(
+  ({
+    activityTypeId,
+    example,
+    setExample,
+    showData,
+    setShowData,
+    dismiss,
+    config,
+    isSeparatePage = false,
+    setReload
+  }: {
+    activityTypeId: string,
+    example: number,
+    setExample: Function,
+    showData: boolean,
+    setShowData: Function,
+    dismiss?: Function,
+    config?: Object,
+    isSeparatePage: boolean,
+    setReload: string => void
+  }) => {
+    const activityType = activityTypesObj[activityTypeId];
+    const RunComp = activityType.ActivityRunner;
+    RunComp.displayName = activityType.id;
 
-  const examples = config
-    ? uniqBy(activityType.meta.exampleData, x => Stringify(x.data))
-    : activityType.meta.exampleData;
+    const examples = config
+      ? uniqBy(activityType.meta.exampleData, x => Stringify(x.data))
+      : activityType.meta.exampleData;
 
-  const activityData = cloneDeep(examples[example]);
-  if (config) {
-    activityData.config = config;
+    const activityData = cloneDeep(examples[example]);
+    if (config) {
+      activityData.config = config;
+    }
+
+    if (!Collections[`demo-${activityType.id}-${example}`]) {
+      Collections[`demo-${activityType.id}-${example}`] = uuid();
+    }
+
+    const doc = connection.get(
+      'rz',
+      Collections[`demo-${activityType.id}-${example}`]
+    );
+    doc.subscribe();
+    doc.on('load', () => {
+      doc.create(cloneDeep(activityType.dataStructure) || {});
+      const mergeFunction = activityType.mergeFunction;
+      if (mergeFunction && activityType.meta.exampleData[example]) {
+        const dataFn = generateReactiveFn(doc);
+        mergeFunction(
+          cloneDeep(activityType.meta.exampleData[example]),
+          dataFn
+        );
+      }
+    });
+
+    const ActivityToRun = ReactiveHOC(
+      'demo/' + activityType.id + '/' + example,
+      doc
+    )(showData ? ShowInfo : RunComp);
+
+    return (
+      <Modal
+        contentLabel={'Preview of ' + activityType.id}
+        isOpen
+        onRequestClose={dismiss}
+      >
+        <div className="modal-header">
+          <button type="button" className="close" onClick={dismiss}>
+            X
+          </button>
+          <h4 className="modal-title">
+            Preview of {activityType.meta.name} ({activityType.id}){' '}
+            <A onClick={() => setShowData(!showData)}>
+              (show {showData ? 'activity' : 'underlying data'})
+            </A>
+            {!isSeparatePage &&
+              <Link to={`/preview/${activityTypeId}/${example}`}>
+                (Open in separate window) +{' '}
+              </Link>}
+          </h4>
+          <Nav bsStyle="pills" activeKey={example}>
+            {examples.map((x, i) =>
+              // eslint-disable-next-line react/no-array-index-key
+              <NavItem key={i} eventKey={i} onClick={() => setExample(i)}>
+                {x.title}
+              </NavItem>
+            )}
+          </Nav>{' '}
+          <A
+            onClick={() => {
+              Collections[`demo-${activityType.id}-${example}`] = uuid();
+              setReload(uuid());
+            }}
+          >
+            (Reset data)
+          </A>
+        </div>
+        <div style={{ position: 'absolute', width: '100%', height: '100%' }}>
+          <ActivityToRun
+            activityData={activityData}
+            userInfo={{ name: Meteor.user().username, id: Meteor.userId() }}
+            logger={() => {}}
+          />
+        </div>
+      </Modal>
+    );
   }
-  const ActivityToRun = ReactiveHOC(
-    cloneDeep(activityType.dataStructure || {}),
-    'demo/' + activityType.id + '/' + example,
-    activityType,
-    activityData
-  )(showData ? ShowInfo : RunComp);
-
-  return (
-    <Modal
-      contentLabel={'Preview of ' + activityType.id}
-      isOpen
-      onRequestClose={dismiss || (() => null)}
-    >
-      <div className="modal-header">
-        <button type="button" className="close" onClick={dismiss}>
-          X
-        </button>
-
-        <h4 className="modal-title">
-          Preview of {activityType.meta.name} ({activityType.id}){' '}
-          <A onClick={() => setShowData(!showData)}>
-            (show {showData ? 'activity' : 'underlying data'})
-          </A>{' '}
-          {!isSeparatePage &&
-            <Link to={`/preview/${activityTypeId}/${example}`}>
-              (Open in separate window)
-            </Link>}
-        </h4>
-        <Nav bsStyle="pills" activeKey={example}>
-          {examples.map((x, i) =>
-            // eslint-disable-next-line react/no-array-index-key
-            <NavItem key={i} eventKey={i} onClick={() => setExample(i)}>
-              {x.title}
-            </NavItem>
-          )}
-        </Nav>
-      </div>
-      <div style={{ position: 'absolute', width: '100%', height: '100%' }}>
-        <ActivityToRun
-          activityData={activityData}
-          userInfo={{ name: Meteor.user().username, id: Meteor.userId() }}
-          logger={() => {}}
-        />
-      </div>
-    </Modal>
-  );
-};
+);
 
 const StatefulPreview = compose(
   withState('example', 'setExample', 0),

--- a/frog/imports/ui/StudentView/ReactiveHOC.jsx
+++ b/frog/imports/ui/StudentView/ReactiveHOC.jsx
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component } from 'react';
 import { generateReactiveFn, type ReactComponent } from 'frog-utils';
-import { cloneDeep } from 'lodash';
 
 import { uploadFile } from '../../api/openUploads';
 import { connection } from '../App/index';
@@ -16,12 +15,9 @@ const getDisplayName = (WrappedComponent: any): string => {
   }
 };
 
-const ReactiveHOC = (
-  dataStructure: any,
-  docId: string,
-  previewActivity: any = false,
-  previewActivityData: any = null
-) => (WrappedComponent: ReactComponent<any>) => {
+const ReactiveHOC = (docId: string, doc?: any) => (
+  WrappedComponent: ReactComponent<any>
+) => {
   class ReactiveComp extends Component {
     state: { data: any, dataFn: ?Object };
     doc: any;
@@ -37,22 +33,11 @@ const ReactiveHOC = (
     }
 
     componentDidMount = () => {
-      this.doc = connection.get('rz', docId);
-      this.doc.subscribe();
-      if (previewActivity !== false) {
-        this.doc.on('load', () => {
-          if (!this.doc.type) {
-            this.doc.create(previewActivity.dataStructure || {});
-            if (previewActivity.mergeFunction) {
-              const dataFn = generateReactiveFn(this.doc);
-              previewActivity.mergeFunction(
-                cloneDeep(previewActivityData),
-                dataFn
-              );
-            }
-            this.waitForDoc();
-          }
-        });
+      if (!doc) {
+        this.doc = connection.get('rz', docId);
+        this.doc.subscribe();
+      } else {
+        this.doc = doc;
       }
       this.doc.on('ready', this.update);
       this.doc.on('op', this.update);

--- a/frog/imports/ui/StudentView/Runner.jsx
+++ b/frog/imports/ui/StudentView/Runner.jsx
@@ -5,7 +5,6 @@ import { Meteor } from 'meteor/meteor';
 import { createContainer } from 'meteor/react-meteor-data';
 import { MosaicWindow } from 'react-mosaic-component';
 import { focusStudent, getMergedExtractedUnit } from 'frog-utils';
-import { cloneDeep } from 'lodash';
 
 import { activityTypesObj } from '../../activityTypes';
 import { createLogger } from '../../api/logs';

--- a/frog/imports/ui/StudentView/Runner.jsx
+++ b/frog/imports/ui/StudentView/Runner.jsx
@@ -44,10 +44,7 @@ const Runner = ({ activity, object, single }) => {
 
   const RunComp = activityType.ActivityRunner;
   RunComp.displayName = activity.activityType;
-  const ActivityToRun = ReactiveHOC(
-    cloneDeep(activityType.dataStructure),
-    reactiveId
-  )(RunComp);
+  const ActivityToRun = ReactiveHOC(reactiveId)(RunComp);
 
   const groupingStr = activity.groupingKey ? activity.groupingKey + '/' : '';
   let title = '(' + groupingStr + groupingValue + ')';


### PR DESCRIPTION
This makes the Preview reactive data structure live in memory, and adds a button to reset the data. Since it's in memory, it's automatically reset on reload as well, of course.

Closes #382