### PR TITLE
Update the ActivityPackage dashboard API

### DIFF
--- a/ac/ac-imgView/src/ActivityRunner.jsx
+++ b/ac/ac-imgView/src/ActivityRunner.jsx
@@ -69,7 +69,7 @@ class ActivityRunner extends Component {
   }
 
   render() {
-    const { activityData, data, dataFn, uploadFn, userInfo } = this.props;
+    const { activityData, data, dataFn, userInfo, logger } = this.props;
 
     const minVoteT = activityData.config.minVote || 1;
 
@@ -85,22 +85,9 @@ class ActivityRunner extends Component {
       .map(key => ({ ...data[key], key }));
 
     const vote = (key, userId) => {
+      logger('vote');
       const prev = data[key].votes ? data[key].votes[userId] : false;
       dataFn.objInsert(!prev, [key, 'votes', userId]);
-      const countVote = Object.values(data[key].votes).reduce(
-        (n, v) => (v ? n + 1 : n),
-        0
-      );
-      if (prev && countVote < minVoteT)
-        dataFn.objInsert(data[key].categories.filter(x => x !== 'selected'), [
-          key,
-          'categories'
-        ]);
-      else if (!prev && countVote >= minVoteT)
-        dataFn.objInsert(
-          [...data[key].categories, 'selected'],
-          [key, 'categories']
-        );
     };
 
     const setCategory = (c: string) => this.setState({ category: c });
@@ -138,19 +125,9 @@ class ActivityRunner extends Component {
           />}
 
         {activityData.config.canUpload &&
-          <UploadBar
-            data={data}
-            dataFn={dataFn}
-            uploadFn={uploadFn}
-            setWebcam={setWebcam}
-          />}
+          <UploadBar {...{ ...this.props, setWebcam }} />}
         {this.state.webcamOn &&
-          <WebcamInterface
-            data={data}
-            dataFn={dataFn}
-            uploadFn={uploadFn}
-            setWebcam={setWebcam}
-          />}
+          <WebcamInterface {...{ ...this.props, setWebcam }} />}
       </Main>
     );
   }

--- a/ac/ac-imgView/src/Dashboard.jsx
+++ b/ac/ac-imgView/src/Dashboard.jsx
@@ -1,0 +1,23 @@
+// @flow
+
+import React from 'react';
+
+const Viewer = (props: Object) =>
+  <pre>
+    {JSON.stringify(props, null, 2)}
+  </pre>;
+
+const mergeLog = (data: any, dataFn: any, log: any) => {
+  dataFn.numIncr(1, log);
+};
+
+const initData = {
+  vote: 0,
+  upload: 0
+};
+
+export default {
+  Viewer,
+  mergeLog,
+  initData
+};

--- a/ac/ac-imgView/src/components/UploadBar.jsx
+++ b/ac/ac-imgView/src/components/UploadBar.jsx
@@ -5,15 +5,15 @@ import styled from 'styled-components';
 
 import UploadDragDrop from './UploadDragDrop';
 
-const UploadBar = ({ data, dataFn, uploadFn, setWebcam }: Object) =>
+const UploadBar = (props: Object) =>
   <Main>
     <div style={{ width: '100%', height: '1px', backgroundColor: 'black' }} />
     <Container>
-      <UploadDragDrop data={data} dataFn={dataFn} uploadFn={uploadFn} />
+      <UploadDragDrop {...props} />
       <div style={{ width: '50%', display: 'flex', justifyContent: 'center' }}>
         <button
           className="btn btn-secondary"
-          onClick={() => setWebcam(true)}
+          onClick={() => props.setWebcam(true)}
           style={{ width: '50%', minWidth: 'fit-content' }}
         >
           <h3 style={{ margin: 'auto' }}> Open the webcam </h3>

--- a/ac/ac-imgView/src/components/UploadDragDrop.jsx
+++ b/ac/ac-imgView/src/components/UploadDragDrop.jsx
@@ -4,9 +4,10 @@ import React from 'react';
 import Dropzone from 'react-dropzone';
 import styled from 'styled-components';
 
-const UploadDragDrop = ({ data, dataFn, uploadFn }: Object) => {
+const UploadDragDrop = ({ data, dataFn, uploadFn, logger }: Object) => {
   const onDrop = f => {
     uploadFn(f, url => {
+      logger('upload');
       // setTimeout, otherwise HTTP request sends back code 503
       setTimeout(
         () => dataFn.objInsert({ url, votes: {} }, Object.keys(data).length),

--- a/ac/ac-imgView/src/index.js
+++ b/ac/ac-imgView/src/index.js
@@ -1,7 +1,9 @@
 // @flow
 
 import { type ActivityPackageT } from 'frog-utils';
+
 import ActivityRunner from './ActivityRunner';
+import dashboard from './Dashboard';
 
 const meta = {
   name: 'Images viewer',
@@ -120,5 +122,6 @@ export default ({
   configUI,
   dataStructure,
   mergeFunction,
-  ActivityRunner
+  ActivityRunner,
+  dashboard
 }: ActivityPackageT);

--- a/frog-utils/src/types.js
+++ b/frog-utils/src/types.js
@@ -71,7 +71,11 @@ export type ActivityPackageT = {
   validateConfig?: validateConfigFnT[],
   mergeFunction?: (dataUnitStructT, Object) => void,
   ActivityRunner: ReactComponent<ActivityRunnerT>,
-  dashboard?: { Viewer: ReactComponent<any>, mergeLog: Function, initData: any }
+  dashboard?: {
+    Viewer: ReactComponent<any>,
+    mergeLog: (data: any, dataFn: Object, log: any) => void,
+    initData: any
+  }
 };
 
 export type productOperatorT = {

--- a/frog-utils/src/types.js
+++ b/frog-utils/src/types.js
@@ -70,7 +70,8 @@ export type ActivityPackageT = {
   dataStructure?: any,
   validateConfig?: validateConfigFnT[],
   mergeFunction?: (dataUnitStructT, Object) => void,
-  ActivityRunner: ReactComponent<ActivityRunnerT>
+  ActivityRunner: ReactComponent<ActivityRunnerT>,
+  dashboard?: { Viewer: ReactComponent<any>, mergeLog: Function, initData: any }
 };
 
 export type productOperatorT = {

--- a/frog/imports/api/logs.js
+++ b/frog/imports/api/logs.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { Mongo } from 'meteor/mongo';
 import { Meteor } from 'meteor/meteor';
 
@@ -16,7 +18,7 @@ export const Logs = new Mongo.Collection('logs');
 //                             date: 'Thursday 22...'}
 // TODO: Should perhaps accept an object to log, instead of a message, for more flexibility
 
-export const engineLogger = (sessionId, params) =>
+export const engineLogger = (sessionId: string, params: Object) =>
   Logs.insert({
     ...params,
     sessionId,
@@ -24,14 +26,18 @@ export const engineLogger = (sessionId, params) =>
     _id: uuid()
   });
 
-export const createLogger = merge => {
-  const username = Meteor.users.findOne(Meteor.userId()).username;
-  const logger = x => {
+export const createLogger = (activity: Object) => {
+  const merge = {
+    activityId: activity._id,
+    username: Meteor.user().username
+  };
+  const logger = (x: Object) => {
     Logs.update(
       Stringify(merge),
-      { $set: { ...merge, ...x, username, updatedAt: Date() } },
+      { $set: { ...merge, ...x, updatedAt: Date() } },
       { upsert: true }
     );
+    Meteor.call('merge.log', x, activity);
   };
   return logger;
 };

--- a/frog/imports/api/logs.js
+++ b/frog/imports/api/logs.js
@@ -18,26 +18,26 @@ export const Logs = new Mongo.Collection('logs');
 //                             date: 'Thursday 22...'}
 // TODO: Should perhaps accept an object to log, instead of a message, for more flexibility
 
-export const engineLogger = (sessionId: string, params: Object) =>
+export const engineLogger = (sessionId: string, log: Object) =>
   Logs.insert({
-    ...params,
+    payload: log,
+    userId: 'teacher',
     sessionId,
     createdAt: new Date(),
     _id: uuid()
   });
 
-export const createLogger = (activity: Object) => {
-  const merge = {
-    activityId: activity._id,
-    username: Meteor.user().username
-  };
-  const logger = (x: Object) => {
-    Logs.update(
-      Stringify(merge),
-      { $set: { ...merge, ...x, updatedAt: Date() } },
-      { upsert: true }
-    );
-    Meteor.call('merge.log', x, activity);
+export const createLogger = (sessionId: string, activity: Object) => {
+  const logger = (log: Object) => {
+    Logs.insert({
+      userId: Meteor.userId(),
+      sessionId,
+      activityId: activity._id,
+      activityType: activity.activityType,
+      payload: log,
+      updatedAt: Date()
+    });
+    Meteor.call('merge.log', log, activity);
   };
   return logger;
 };

--- a/frog/imports/api/logs.js
+++ b/frog/imports/api/logs.js
@@ -3,7 +3,6 @@
 import { Mongo } from 'meteor/mongo';
 import { Meteor } from 'meteor/meteor';
 
-import Stringify from 'json-stable-stringify';
 import { uuid } from 'frog-utils';
 
 export const Logs = new Mongo.Collection('logs');

--- a/frog/imports/ui/StudentView/Runner.jsx
+++ b/frog/imports/ui/StudentView/Runner.jsx
@@ -20,11 +20,7 @@ const Runner = ({ activity, object, single }) => {
   }
   const activityType = activityTypesObj[activity.activityType];
 
-  const logger = createLogger({
-    activity: activity._id,
-    activityType: activity.activityType,
-    user: Meteor.userId()
-  });
+  const logger = createLogger(activity);
 
   if (!object) {
     return null;

--- a/frog/imports/ui/StudentView/Runner.jsx
+++ b/frog/imports/ui/StudentView/Runner.jsx
@@ -13,13 +13,13 @@ import { Activities } from '../../api/activities';
 import doGetInstances from '../../api/doGetInstances';
 import ReactiveHOC from './ReactiveHOC';
 
-const Runner = ({ activity, object, single }) => {
+const Runner = ({ activity, sessionId, object, single }) => {
   if (!activity) {
     return <p>NULL ACTIVITY</p>;
   }
   const activityType = activityTypesObj[activity.activityType];
 
-  const logger = createLogger(activity);
+  const logger = createLogger(sessionId, activity);
 
   if (!object) {
     return null;

--- a/frog/imports/ui/StudentView/SessionBody.jsx
+++ b/frog/imports/ui/StudentView/SessionBody.jsx
@@ -56,7 +56,11 @@ const SessionBody = ({
     return (
       <div style={{ height: '100%' }}>
         <Countdown session={session} currentTime={currentTime} />
-        <Runner activityId={session.openActivities[0]} sessionId={session._id} single />
+        <Runner
+          activityId={session.openActivities[0]}
+          sessionId={session._id}
+          single
+        />
       </div>
     );
   } else {
@@ -64,7 +68,8 @@ const SessionBody = ({
       <div style={{ height: '100%' }}>
         <Countdown session={session} currentTime={currentTime} />
         <Mosaic
-          renderTile={activityId => <Runner activityId={activityId} sessionId={session._id} />}
+          renderTile={activityId =>
+            <Runner activityId={activityId} sessionId={session._id} />}
           initialValue={getInitialState(session.openActivities)}
         />
       </div>

--- a/frog/imports/ui/StudentView/SessionBody.jsx
+++ b/frog/imports/ui/StudentView/SessionBody.jsx
@@ -56,7 +56,7 @@ const SessionBody = ({
     return (
       <div style={{ height: '100%' }}>
         <Countdown session={session} currentTime={currentTime} />
-        <Runner activityId={session.openActivities[0]} single />
+        <Runner activityId={session.openActivities[0]} sessionId={session._id} single />
       </div>
     );
   } else {
@@ -64,7 +64,7 @@ const SessionBody = ({
       <div style={{ height: '100%' }}>
         <Countdown session={session} currentTime={currentTime} />
         <Mosaic
-          renderTile={activityId => <Runner activityId={activityId} />}
+          renderTile={activityId => <Runner activityId={activityId} sessionId={session._id} />}
           initialValue={getInitialState(session.openActivities)}
         />
       </div>

--- a/frog/imports/ui/TeacherView/Dashboard.jsx
+++ b/frog/imports/ui/TeacherView/Dashboard.jsx
@@ -1,0 +1,104 @@
+// @flow
+
+import React, { Component } from 'react';
+import { createContainer } from 'meteor/react-meteor-data';
+
+import { withState } from 'recompose';
+import { Nav, NavItem } from 'react-bootstrap';
+import styled from 'styled-components';
+
+import { Activities } from '../../api/activities';
+import { activityTypesObj } from '../../activityTypes';
+import { connection } from '../App/index';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+class Dashboard extends Component {
+  state: { data: any };
+  doc: any;
+  timeout: ?number;
+  unmounted: boolean;
+
+  constructor(props: Object) {
+    super(props);
+    this.state = { data: null };
+  }
+
+  componentWillReceiveProps(nextProps: Object) {
+    if (this.props.activity._id !== nextProps.activity._id || !this.doc) {
+      if (this.doc) {
+        this.doc.destroy();
+      }
+      this.doc = connection.get('rz', nextProps.activity._id + '//DASHBOARD');
+      this.doc.subscribe();
+      this.doc.on('ready', this.update);
+      this.doc.on('op', this.update);
+      this.waitForDoc();
+    }
+  }
+
+  waitForDoc = () => {
+    if (this.doc.type) {
+      this.timeout = undefined;
+      this.update();
+    } else {
+      this.timeout = window.setTimeout(this.waitForDoc, 100);
+    }
+  };
+
+  update = () => {
+    if (!this.timeout && !this.unmounted) {
+      this.setState({ data: this.doc.data });
+    }
+  };
+
+  componentWillUnmount = () => {
+    this.doc.destroy();
+    if (this.timeout) {
+      window.clearTimeout(this.timeout);
+    }
+    this.unmounted = true;
+  };
+
+  render() {
+    const aT = activityTypesObj[this.props.activity.activityType];
+    return aT.dashboard && aT.dashboard.Viewer
+      ? <aT.dashboard.Viewer data={this.state.data} />
+      : <p>The selected activity does not provide a dashboard</p>;
+  }
+}
+
+const DashboardNav = ({ activityId, setActivity, openActivities }) => {
+  const aId = activityId || openActivities[0]._id;
+  return (
+    <div>
+      <h1>Dashboards</h1>
+      <Container>
+        <Nav
+          bsStyle="pills"
+          stacked
+          activeKey={aId}
+          onSelect={a => setActivity(a)}
+          style={{ width: '150px' }}
+        >
+          {openActivities.map(a =>
+            <NavItem eventKey={a._id} key={a._id} href="#">
+              {a.title}
+            </NavItem>
+          )}
+        </Nav>
+        <Dashboard activity={openActivities.find(a => a._id === aId)} />
+      </Container>
+    </div>
+  );
+};
+
+export default createContainer(
+  ({ openActivities }) => ({
+    openActivities: Activities.find({ _id: { $in: openActivities } }).fetch()
+  }),
+  withState('activityId', 'setActivity', null)(DashboardNav)
+);

--- a/frog/imports/ui/TeacherView/index.js
+++ b/frog/imports/ui/TeacherView/index.js
@@ -1,4 +1,5 @@
 // @flow
+
 import React from 'react';
 import { Meteor } from 'meteor/meteor';
 import { createContainer } from 'meteor/react-meteor-data';
@@ -10,17 +11,16 @@ import StudentList from './StudentList';
 import ButtonList from './ButtonList';
 import SessionList from './SessionList';
 import GraphView from './GraphView';
+import Dashboards from './Dashboard';
 import { Sessions } from '../../api/sessions';
 import { Activities } from '../../api/activities';
 import { Graphs } from '../../api/graphs';
 import { Logs, flushLogs } from '../../api/logs';
-import { activityTypesObj } from '../../activityTypes';
 
 const rawSessionController = ({
   session,
   visible,
   toggleVisibility,
-  logs,
   currentTime
 }) =>
   <div>
@@ -32,7 +32,7 @@ const rawSessionController = ({
             currentTime={currentTime}
           />
           {visible
-            ? <DashView logs={logs} session={session} />
+            ? <Dashboards openActivities={session.openActivities} />
             : <GraphView session={session} />}
         </div>
       : <p>Create or select a session from the list below</p>}
@@ -40,43 +40,6 @@ const rawSessionController = ({
 
 const SessionController = withVisibility(rawSessionController);
 SessionController.displayName = 'SessionController';
-
-const Dashboard = ({ logs, activities }) => {
-  let Dash = <p>NO DASHBOARD</p>;
-  if (activities) {
-    Dash = activities.map(a => {
-      const activityType = activityTypesObj[a.activityType];
-      if (activityType && activityType.Dashboard) {
-        return (
-          <activityType.Dashboard
-            logs={logs.filter(x => x.activity === a._id)}
-            key={a._id}
-          />
-        );
-      } else {
-        return null;
-      }
-    });
-  }
-  return (
-    <div id="dashboard">
-      <h1>Dashboard</h1>
-      {Dash}
-    </div>
-  );
-};
-
-const DashView = createContainer(
-  ({ session }) => ({
-    activities: (session.openActivities || []).map(x => Activities.findOne(x)),
-    logs: (session.openActivities || [])
-      .reduce(
-        (acc, x) => [...acc, ...(Logs.find({ activity: x }).fetch() || [])],
-        []
-      )
-  }),
-  Dashboard
-);
 
 const LogView = withVisibility(({ logs, toggleVisibility, visible }) => {
   if (!logs || logs.length < 1) {

--- a/frog/server/mergeData.js
+++ b/frog/server/mergeData.js
@@ -57,5 +57,20 @@ export default (activityId: string, object: ObjectT) => {
         }
       })
     );
+    const mergedLogsDoc = serverConnection.get(
+      'rz',
+      activityId + '//DASHBOARD'
+    );
+    mergedLogsDoc.fetch();
+    mergedLogsDoc.on(
+      'load',
+      Meteor.bindEnvironment(() => {
+        if (!mergedLogsDoc.type) {
+          mergedLogsDoc.create(
+            (activityType.dashboard && activityType.dashboard.initData) || {}
+          );
+        }
+      })
+    );
   });
 };

--- a/frog/server/mergeData.js
+++ b/frog/server/mergeData.js
@@ -16,6 +16,7 @@ import { activityTypesObj } from '../imports/activityTypes';
 export default (activityId: string, object: ObjectT) => {
   const { activityData } = object;
   const activity = Activities.findOne(activityId);
+  const activityType = activityTypesObj[activity.activityType];
 
   const { groups, structure } = doGetInstances(activity, object);
   groups.forEach(grouping => {
@@ -27,7 +28,6 @@ export default (activityId: string, object: ObjectT) => {
         hasMergedData: { ...(activity.hasMergedData || {}), [grouping]: true }
       }
     });
-    const activityType = activityTypesObj[activity.activityType];
     const mergeFunction = activityType.mergeFunction;
     const doc = serverConnection.get('rz', activityId + '/' + grouping);
     doc.fetch();
@@ -57,20 +57,15 @@ export default (activityId: string, object: ObjectT) => {
         }
       })
     );
-    const mergedLogsDoc = serverConnection.get(
-      'rz',
-      activityId + '//DASHBOARD'
-    );
-    mergedLogsDoc.fetch();
-    mergedLogsDoc.on(
-      'load',
-      Meteor.bindEnvironment(() => {
-        if (!mergedLogsDoc.type) {
-          mergedLogsDoc.create(
-            (activityType.dashboard && activityType.dashboard.initData) || {}
-          );
-        }
-      })
-    );
+  });
+  const mergedLogsDoc = serverConnection.get('rz', activityId + '//DASHBOARD');
+  mergedLogsDoc.fetch();
+  mergedLogsDoc.on('load', () => {
+    if (!mergedLogsDoc.type) {
+      mergedLogsDoc.create(
+        (activityType.dashboard && activityType.dashboard.initData) || {}
+      );
+    }
+    mergedLogsDoc.destroy();
   });
 };

--- a/frog/server/mergeLogData.js
+++ b/frog/server/mergeLogData.js
@@ -1,0 +1,23 @@
+// @flow
+
+import { Meteor } from 'meteor/meteor';
+import { cloneDeep } from 'lodash';
+import { generateReactiveFn } from 'frog-utils';
+
+import { serverConnection } from './share-db-manager';
+import { activityTypesObj } from '../imports/activityTypes';
+
+Meteor.methods({
+  'merge.log': (log, activity) => {
+    const doc = serverConnection.get('rz', activity._id + '//DASHBOARD');
+    doc.fetch();
+    doc.on('load', () => {
+      const dataFn = generateReactiveFn(doc);
+      const aT = activityTypesObj[activity.activityType];
+      if (aT.dashboard && aT.dashboard.mergeLog) {
+        aT.dashboard.mergeLog(cloneDeep(doc.data), dataFn, log);
+      }
+      doc.destroy();
+    });
+  }
+});


### PR DESCRIPTION
## What's new
- New field for in `ActivityPackageT` for dashboards
```JavaScript
{
  ...,
  dashboard: { 
    Viewer: ReactComponent,
    mergeLog: Function,
    initData: any
  },
  ...
}
```
- An example of dashboard on `ac-imgView` counting number of votes and number of uploads. No visualization, data pipeline only.

- In `server/mergeData` creates the document for the logs and initialise it with the `initData`

- in `server/mergeLogData` implement `Meteor.Method({'merge.log': ... }]` called from the loggers

- A component to navigate between the available dashboards when several activities are open

## Comments
- Removes the possibility of filtering selected activities (just like categories are filtered) in `ac-imgView`. It was badly implemented and was creating bugs. It can be easily re-implemented. This PR was already big enough!

## Incoming
- Nicer looking Dashboards for most of UNIL activities