### PR TITLE
Unifying copying/adding graph

### DIFF
--- a/frog/imports/api/sessions.js
+++ b/frog/imports/api/sessions.js
@@ -185,7 +185,13 @@ Meteor.methods({
       name: { $regex: '#' + graph.name + '*' }
     }).count();
     const sessionName = '#' + graph.name + ' ' + (count + 1);
-    const copyGraphId = addGraph(sessionName);
+
+    const copyGraphId = addGraph({
+      graph: graph,
+      activities: Activities.find({ graphId }).fetch(),
+      operators: Operators.find({ graphId }).fetch(),
+      connections: Connections.find({ graphId }).fetch()
+    });
 
     Sessions.insert({
       _id: sessionId,
@@ -201,38 +207,6 @@ Meteor.methods({
 
     Graphs.update(copyGraphId, { $set: { sessionId } });
 
-    const matching = {};
-    const activities = Activities.find({ graphId }).fetch();
-    activities.forEach(activity => {
-      matching[activity._id] = addSessionItem(
-        'activities',
-        copyGraphId,
-        activity
-      );
-    });
-
-    const operators = Operators.find({ graphId }).fetch();
-    operators.forEach(operator => {
-      matching[operator._id] = addSessionItem(
-        'operators',
-        copyGraphId,
-        operator
-      );
-    });
-
-    const connections = Connections.find({ graphId }).fetch();
-    connections.forEach(connection => {
-      addSessionItem('connections', copyGraphId, {
-        source: {
-          id: matching[connection.source.id],
-          type: connection.source.type
-        },
-        target: {
-          id: matching[connection.target.id],
-          type: connection.target.type
-        }
-      });
-    });
     setTeacherSession(sessionId);
     return sessionId;
   },

--- a/frog/imports/api/sessions.js
+++ b/frog/imports/api/sessions.js
@@ -32,22 +32,6 @@ export const setStudentSession = (sessionId: string) => {
   );
 };
 
-const addSessionItem = (type, graphId, params) => {
-  const id = uuid();
-  const collections = {
-    activities: Activities,
-    operators: Operators,
-    connections: Connections
-  };
-  collections[type].insert({
-    ...params,
-    createdAt: new Date(),
-    graphId,
-    _id: id
-  });
-  return id;
-};
-
 export const addSession = (graphId: string) => {
   Meteor.call('add.session', graphId, (err, result) => {
     if (result === 'invalidGraph') {
@@ -187,7 +171,7 @@ Meteor.methods({
     const sessionName = '#' + graph.name + ' ' + (count + 1);
 
     const copyGraphId = addGraph({
-      graph: graph,
+      graph,
       activities: Activities.find({ graphId }).fetch(),
       operators: Operators.find({ graphId }).fetch(),
       connections: Connections.find({ graphId }).fetch()

--- a/frog/imports/ui/GraphEditor/utils/export.js
+++ b/frog/imports/ui/GraphEditor/utils/export.js
@@ -1,12 +1,10 @@
 import fileDialog from 'file-dialog';
 import Stringify from 'json-stringify-pretty-compact';
 import FileSaver from 'file-saver';
-import { uuid } from 'frog-utils';
 import { omit } from 'lodash';
 
 import { Activities, Operators, Connections } from '../../../api/activities';
 import { Graphs, addGraph } from '../../../api/graphs';
-import { getGlobalSetting, setGlobalSetting } from '../../../api/global';
 import { store } from '../store';
 
 const clean = obj => {

--- a/frog/imports/ui/GraphEditor/utils/export.js
+++ b/frog/imports/ui/GraphEditor/utils/export.js
@@ -5,7 +5,7 @@ import { uuid } from 'frog-utils';
 import { omit } from 'lodash';
 
 import { Activities, Operators, Connections } from '../../../api/activities';
-import { Graphs, addGraph, uploadGraph } from '../../../api/graphs';
+import { Graphs, addGraph } from '../../../api/graphs';
 import { getGlobalSetting, setGlobalSetting } from '../../../api/global';
 import { store } from '../store';
 
@@ -40,24 +40,7 @@ export const duplicateGraph = graphId =>
 const doImportGraph = graphStr => {
   try {
     const graphObj = JSON.parse(graphStr.target.result);
-    const importNo = getGlobalSetting('importNo') || 0;
-    setGlobalSetting('importNo', importNo + 1);
-    const graphId = addGraph(graphObj.graph.name + ' ' + importNo, {
-      ...graphObj.graph,
-      _id: uuid(),
-      sessionId: null
-    });
-    const fixId = id => importNo + '-' + id;
-    const specify = obj => ({ ...obj, _id: fixId(obj._id), graphId });
-    uploadGraph({
-      activities: graphObj.activities.map(specify),
-      operators: graphObj.operators.map(specify),
-      connections: graphObj.connections.map(specify).map(x => ({
-        ...x,
-        source: { ...x.source, id: fixId(x.source.id) },
-        target: { ...x.target, id: fixId(x.target.id) }
-      }))
-    });
+    const graphId = addGraph(graphObj);
     store.setId(graphId);
   } catch (e) {
     // eslint-disable-next-line no-alert


### PR DESCRIPTION
I have a new function, addGraph in api/graphs, which takes an object with graph, activities, operators, connections, or empty. If empty, it just creates a new unnamed graph. If not, it does all the copying logic (updating ids in connections etc). It does all the updating of act/op/conn in memory, before writing the final version to Mongo (the previous case, we first wrote to Mongo, then updated the connections in the database through a loop).

Now the same logic is used for copying a graph when creating a session, in the graph editor, and when importing a graph. This makes it easier to add new logic in the future. 