### PR TITLE
Adding sentry monitoring

### DIFF
--- a/frog/client/main.html
+++ b/frog/client/main.html
@@ -1,5 +1,8 @@
 <head>
   <title>FROG</title>
+<script src="https://cdn.ravenjs.com/3.17.0/raven.min.js"
+    crossorigin="anonymous"></script>
+<script>Raven.config('https://59d972c46140436a8bd7094bd6e3eb82@sentry.io/214223').install()</script>
 </head>
 
 <body>

--- a/frog/imports/ui/App/FROGRouter.js
+++ b/frog/imports/ui/App/FROGRouter.js
@@ -24,6 +24,10 @@ const Page = ({ isNotLoggedIn, isRedirect, isStudent, path, ready }) => {
   if (isNotLoggedIn) {
     return <NotLoggedIn />;
   }
+
+  Raven.setUserContext({
+    user: Meteor.userId()
+  });
   if (!ready) {
     return process.env.NODE_ENV === 'production'
       ? <img src="/images/Spinner.gif" alt="" />

--- a/frog/imports/ui/GraphEditor/Activities.js
+++ b/frog/imports/ui/GraphEditor/Activities.js
@@ -32,6 +32,7 @@ class ActivityComponent extends Component {
   clickHandler: ?Function;
 
   componentWillMount() {
+    a;
     this.clickHandler = getClickHandler(() => {
       if (store.state.mode === 'normal' || store.state.mode === 'readOnly') {
         this.props.activity.select();

--- a/frog/package.json
+++ b/frog/package.json
@@ -48,6 +48,7 @@
     "op-prox": "1.0.0",
     "query-parse": "^1.0.0",
     "query-string": "^5.0.0",
+    "raven-js": "^3.17.0",
     "react": "^15.6.1",
     "react-addons-pure-render-mixin": "^15.6.0",
     "react-addons-test-utils": "^15.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5177,6 +5177,10 @@ randombytes@^2.0.0, randombytes@^2.0.1:
   dependencies:
     safe-buffer "^5.1.0"
 
+raven-js@^3.17.0:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.17.0.tgz#779457ac7910512c3c2cc9bb6d0a9eeb59a969ec"
+
 raw-body@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.2.0.tgz#994976cf6a5096a41162840492f0bdc5d6e7fb96"


### PR DESCRIPTION
When asking on twitter what people used for monitoring JS errors, people overwhelmingly suggested Sentry. It has an open-source client that can be self-hosted, but the hosted service allows for 10,000 events for free each month, so it's a good thing to start with. The idea is that if users get console errors, we get told about them. 

It is only turned on for production-mode right now - will be very important to discover any problems that UNIL students run into for example - we would like there to be no bugs, but if there are, much better to know about it immediately. There are lot's of options about linking github releases to logs, etc, which we can explore in the future, but the default setup already gives us a lot of data.