### PR TITLE
Improving Preview

### DIFF
--- a/frog/imports/ui/Preview/index.js
+++ b/frog/imports/ui/Preview/index.js
@@ -27,7 +27,7 @@ const PreviewPage = ({
   history
 }) => {
   const showData = queryToObject(search.slice(1)).showData === 'true';
-  const windows = parseInt(queryToObject(search.slice(1)).windows) || 1;
+  const windows = parseInt(queryToObject(search.slice(1)).windows, 10) || 1;
   const setExample = ex =>
     history.push(`/preview/${activityTypeId || ''}/${ex}`);
   const setShowData = ex =>

--- a/frog/imports/ui/Preview/index.js
+++ b/frog/imports/ui/Preview/index.js
@@ -27,17 +27,22 @@ const PreviewPage = ({
   history
 }) => {
   const showData = queryToObject(search.slice(1)).showData === 'true';
+  const windows = parseInt(queryToObject(search.slice(1)).windows) || 1;
   const setExample = ex =>
     history.push(`/preview/${activityTypeId || ''}/${ex}`);
   const setShowData = ex =>
     history.push(`/preview/${activityTypeId || ''}/${example}?showData=${ex}`);
   const dismiss = () => history.push(`/preview`);
+  const setWindows = ex =>
+    history.push(`/preview/${activityTypeId || ''}/${example}?windows=${ex}`);
   return activityTypeId
     ? <StatelessPreview
         {...{
           activityTypeId,
           example,
           setExample,
+          setWindows,
+          windows,
           showData,
           setShowData,
           dismiss,


### PR DESCRIPTION
This PR adds to improvements to Preview

- The size of the activity should now fit into the preview box without scrolling (if it is a full-screen activity, using height: 100% etc). This has been tested with a few different activities.
- There is now the possibility to see how an activity would look with multiple other activities. There are win+ and win- buttons, incrementing/decrementing the number of windows. 

Known issues:
- sometimes when rapidly adding/removing windows, I get eventEmitter errors. I don't think this is a big issue though. 
- somehow the buttons in Mosaic don't render properly anymore. However, this is the case even when running a script, so I don't think it's related to this PR.