### PR TITLE
Updating ac-video dashboard

### DIFF
--- a/ac/ac-video/src/dashboard.js
+++ b/ac/ac-video/src/dashboard.js
@@ -4,13 +4,28 @@ import React, { Component } from 'react';
 import { ProgressBar } from 'react-bootstrap';
 import { colorRange as color } from 'frog-utils';
 
-const VideoProgress = ({ data }) => {
+export const mergeLog = (data: any, dataFn: any, log: any) => {
+  if (log.payload) {
+    const payload = { ...log.payload, updatedAt: log.updatedAt };
+    Object.keys(payload).forEach(key => {
+      if (data[log.userId]) {
+        dataFn.objInsert(payload[key], [log.userId, key]);
+      } else {
+        dataFn.objInsert({ [key]: payload[key] }, log.userId);
+      }
+    });
+  }
+};
+
+export const initData = {};
+
+const VideoProgress = ({ data, user }) => {
   let backgroundColor;
   let bsStyle;
 
   if (data.paused) {
     bsStyle = 'warning';
-    backgroundColor = color(data.updated_at);
+    backgroundColor = color(data.updatedAt);
   }
 
   if (data.ended) {
@@ -22,10 +37,10 @@ const VideoProgress = ({ data }) => {
       <h4
         style={{
           float: 'left',
-          marginRight: '1em'
+          width: '5em'
         }}
       >
-        {data.username}
+        {user}
       </h4>
       <ProgressBar
         now={data.played * 100}
@@ -37,30 +52,49 @@ const VideoProgress = ({ data }) => {
   );
 };
 
-class Dash extends Component {
+class Viewer extends Component {
   state: Object;
   interval: any;
+  unmounted: boolean;
 
   constructor(props: any) {
     super(props);
-    this.state = {};
+    this.state = { unmounted: false };
   }
 
   componentDidMount() {
-    this.interval = setInterval(() => this.forceUpdate(), 2000);
+    this.interval = setInterval(() => {
+      if (!this.unmounted) {
+        this.forceUpdate();
+      }
+    }, 2000);
   }
 
   componentWillUnmount() {
+    this.unmounted = true;
     window.clearInterval(this.interval);
   }
 
   render() {
+    if (!this.props.data) {
+      return null;
+    }
     return (
       <div>
-        {this.props.logs.map(x => <VideoProgress data={x} key={x._id} />)}
+        {Object.keys(this.props.data).map(x =>
+          <VideoProgress
+            data={this.props.data[x]}
+            user={this.props.users[x]}
+            key={x}
+          />
+        )}
       </div>
     );
   }
 }
 
-export default Dash;
+export default {
+  Viewer,
+  mergeLog,
+  initData
+};

--- a/ac/ac-video/src/index.js
+++ b/ac/ac-video/src/index.js
@@ -4,7 +4,7 @@ import React from 'react';
 import ReactPlayer from 'react-player';
 import { type ActivityRunnerT } from 'frog-utils';
 
-import Dashboard from './dashboard';
+import dashboard from './dashboard';
 
 export const meta = {
   name: 'Video player',
@@ -65,5 +65,5 @@ export default {
   ActivityRunner,
   config,
   meta,
-  Dashboard
+  dashboard
 };

--- a/frog/imports/ui/TeacherView/Dashboard.jsx
+++ b/frog/imports/ui/TeacherView/Dashboard.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
+import { Meteor } from 'meteor/meteor';
 import { createContainer } from 'meteor/react-meteor-data';
 
 import { withState } from 'recompose';
@@ -16,7 +17,7 @@ const Container = styled.div`
   flex-direction: row;
 `;
 
-class Dashboard extends Component {
+class DashboardComp extends Component {
   state: { data: any };
   doc: any;
   timeout: ?number;
@@ -72,13 +73,29 @@ class Dashboard extends Component {
 
   render() {
     const aT = activityTypesObj[this.props.activity.activityType];
+    const users = this.props.users
+      ? this.props.users.reduce(
+          (acc, x) => ({ ...acc, [x._id]: x.username }),
+          {}
+        )
+      : {};
+
     return aT.dashboard && aT.dashboard.Viewer
-      ? <aT.dashboard.Viewer data={this.state.data} />
+      ? <div style={{ width: '100%' }}>
+          <aT.dashboard.Viewer users={users} data={this.state.data} />
+        </div>
       : <p>The selected activity does not provide a dashboard</p>;
   }
 }
 
-const DashboardNav = ({ activityId, setActivity, openActivities }) => {
+const Dashboard = createContainer(
+  ({ session }) => ({
+    users: Meteor.users.find({ joinedSessions: session.slug }).fetch()
+  }),
+  DashboardComp
+);
+
+const DashboardNav = ({ activityId, setActivity, openActivities, session }) => {
   const aId =
     activityId || (openActivities.length > 0 && openActivities[0]._id);
   if (!aId) {
@@ -101,7 +118,10 @@ const DashboardNav = ({ activityId, setActivity, openActivities }) => {
             </NavItem>
           )}
         </Nav>
-        <Dashboard activity={openActivities.find(a => a._id === aId)} />
+        <Dashboard
+          session={session}
+          activity={openActivities.find(a => a._id === aId)}
+        />
       </Container>
     </div>
   );

--- a/frog/imports/ui/TeacherView/index.js
+++ b/frog/imports/ui/TeacherView/index.js
@@ -20,7 +20,10 @@ const rawSessionController = ({ session, visible, toggleVisibility }) =>
       ? <div>
           <ButtonList session={session} toggle={toggleVisibility} />
           {visible
-            ? <Dashboards openActivities={session.openActivities} />
+            ? <Dashboards
+                session={session}
+                openActivities={session.openActivities}
+              />
             : <GraphView session={session} />}
         </div>
       : <p>Create or select a session from the list below</p>}


### PR DESCRIPTION
This updates the ac-video dashboard to work with the current API. I also added users ({userId: username}) to the argument that Viewer is called with - we can discuss about what other information the Viewer should have access to. 

I'm still figuring out how to most efficiently work with reactive data, but the function I wrote to merge objects, while checking whether the object already exists, might be wrapped in a general function and used elsewhere. Note that I'm starting just with an empty {} in initData. Also, I noticed that shareDB batches the several operations done for an incoming log entry, and sends them all in bulk (and this work is done on the server anyway of course, although the update is then sent to the teacher client). 

Issues:
- if you toggle the dashboard on and off, you sometimes get errors that it's trying to forceUpdate after unmount. I try to avoid this, but even cancelling the timeout in willDismount doesn't seem to work. It doesn't crash though.
- if we think that a dashboard state can always be reconstructed by running all log messages throug the mergeLog function, and further, that we will be receiving large numbers of log entries, we might consider using an in-memory shareDB instance for dashboards, to avoid trashing MongoDB with all the updates