### PR TITLE
Fixing ac/op side-panel editing behaviour

### DIFF
--- a/frog/imports/ui/GraphEditor/SidePanel/ConfigForm.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/ConfigForm.jsx
@@ -14,19 +14,17 @@ import {
 type PropT = Object;
 
 export default class ConfigForm extends Component {
-  // credit to Stian Håklev
-  shouldComponentUpdate(nextProps: PropT) {
-    let should = false;
-    // form must be refreshed when control operators change the applytoall value
-    if (this.props.nodeType.type === 'control') {
-      const thisData = this.props.node.data || {};
-      const nextData = nextProps.node.data || {};
-      should = should || thisData.applytoall !== nextData.applytoall;
-    }
-    // form must update if another ac/op is selected
-    should = should || this.props.node._id !== nextProps.node._id;
+  state: { formData: Object };
 
-    return should;
+  constructor(props: PropT) {
+    super(props);
+    this.state = { formData: this.props.node.data };
+  }
+
+  componentWillReceiveProps(nextProps: PropT) {
+    if (this.props.node._id !== nextProps.node._id) {
+      this.setState({ formData: nextProps.node.data });
+    }
   }
 
   render() {
@@ -38,7 +36,7 @@ export default class ConfigForm extends Component {
       refreshValidate
     } = this.props;
     const props = {
-      formData: node.data,
+      formData: this.state.formData,
       ...addSocialFormSchema(nodeType.config, nodeType.configUI),
       widgets: {
         socialAttributeWidget: SelectFormWidget,
@@ -50,6 +48,7 @@ export default class ConfigForm extends Component {
         groupingKey: node.groupingKey
       },
       onChange: data => {
+        this.setState({ formData: data.formData });
         if (node.operatorType) {
           addOperator(node.operatorType, data.formData, node._id);
         } else {


### PR DESCRIPTION
This PR tries to address the following issue:
- conditional fields do not trigger while a form is in focus

while preserving:
- editing within a string does not jump to the end
- deleting a default value is not impossible

It does this by keeping formData in local state, which means it always runs through the proper functions (conditional etc), but is not reset unless the user is switching to a different node. This means that it does not listen to changes from the database.

(I know I said we should not keep props in state, but in this case I think it makes sense).

Closes #469 