### PR TITLE
Adding sentry monitoring

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,8 @@ module.exports = {
     Blob: true,
     WebSocket: true,
     Presences: true,
-    jest: true
+    jest: true,
+    Raven: true
   },
   rules: {
     'jsx-a11y/label-has-for': 'off',

--- a/frog/client/main.html
+++ b/frog/client/main.html
@@ -1,4 +1,9 @@
 <head>
+  <script src="https://cdn.ravenjs.com/3.17.0/raven.min.js"
+    crossorigin="anonymous"></script>
+  <script>
+    if(process.env.NODE_ENV === 'production') {Raven.config(Meteor.settings.public.sentry_token).install()}
+</script>
   <title>FROG</title>
 </head>
 

--- a/frog/imports/ui/StudentView/index.js
+++ b/frog/imports/ui/StudentView/index.js
@@ -16,6 +16,10 @@ class StudentViewComp extends Component {
   }
 
   componentWillMount() {
+    // $FlowFixMe
+    Raven.setUserContext({
+      user: Meteor.userId()
+    });
     this.checkSessionJoin(this.props.match.params.slug);
   }
 


### PR DESCRIPTION
When asking on twitter what people used for monitoring JS errors, people overwhelmingly suggested Sentry. It has an open-source client that can be self-hosted, but the hosted service allows for 10,000 events for free each month, so it's a good thing to start with. The idea is that if users get console errors, we get told about them.

It is only turned on for production-mode right now - will be very important to discover any problems that UNIL students run into for example - we would like there to be no bugs, but if there are, much better to know about it immediately. There are lot's of options about linking github releases to logs, etc, which we can explore in the future, but the default setup already gives us a lot of data.

Closing old #475 for this