### PR TITLE
Fixing form definition of ac-quiz

### DIFF
--- a/ac/ac-quiz/src/ActivityRunner.jsx
+++ b/ac/ac-quiz/src/ActivityRunner.jsx
@@ -52,7 +52,7 @@ const Quiz = ({ activityData, data, dataFn }: ActivityRunnerT) => {
     .filter(q => q.question && q.answers)
     .forEach((q, i) => {
       const radio = {
-        type: 'string',
+        type: 'number',
         enum: q.answers,
         title: ' '
       };


### PR DESCRIPTION
Currently the ac-quiz stores answers as numbers, but the definition asks for strings, which leads to conflict when trying to submit.