### PR TITLE
Adding web-terminal to Meteor

### DIFF
--- a/frog/.meteor/packages
+++ b/frog/.meteor/packages
@@ -32,3 +32,4 @@ abernix:standard-minifier-js
 meteorhacks:picker
 mizzao:timesync
 reywood:publish-composite
+qualia:web-shell

--- a/frog/.meteor/versions
+++ b/frog/.meteor/versions
@@ -90,6 +90,7 @@ practicalmeteor:mocha@2.4.5_6
 practicalmeteor:mocha-core@1.0.1
 practicalmeteor:sinon@1.14.1_2
 promise@0.10.0-beta.16
+qualia:web-shell@0.0.6
 raix:eventemitter@0.1.3
 random@1.0.10
 rate-limit@1.0.8


### PR DESCRIPTION
According to this: https://forums.meteor.com/t/web-shell-use-meteor-shell-in-the-browser/39279

Only active in development mode for now. I tested it, and it's quite neat for quick playing with code/
looking up things (Meteor.users.find({}) etc.