### PR TITLE
Avoid logging out admin in Preview

### DIFF
--- a/frog/imports/ui/App/index.js
+++ b/frog/imports/ui/App/index.js
@@ -63,7 +63,7 @@ class FROGRouter extends Component {
 
   componentWillMount() {
     const query = queryToObject(this.props.location.search.slice(1));
-    const hasQuery = Object.keys(query).length > 0;
+    const hasLogin = query.login;
 
     if (this.state.mode !== 'loggingIn') {
       if (process.env.NODE_ENV !== 'production') {
@@ -86,7 +86,7 @@ class FROGRouter extends Component {
         }
       }
 
-      if (!hasQuery && this.state.mode !== 'ready') {
+      if (!hasLogin && this.state.mode !== 'ready') {
         if (Accounts._storedLoginToken()) {
           this.setState({ mode: 'loggingIn' });
           Accounts.loginWithToken(Accounts._storedLoginToken(), err => {


### PR DESCRIPTION
This fixes the issue that admin would get logged out when reloading in preview, because it only checked for query parameters, not the login parameter, and Preview users query parameters as well.