### PR TITLE
Add streaming feature

### DIFF
--- a/ac/ac-imgClass/src/imgClassifier.jsx
+++ b/ac/ac-imgClass/src/imgClassifier.jsx
@@ -79,6 +79,9 @@ export default ({ activityData, data, dataFn }: ActivityRunnerT) => {
     categ.forEach((x, i) => Mousetrap.unbind(shortCuts[i]));
   return (
     <div style={{ margin: '1%', height: '100%' }}>
+      <pre>
+        {JSON.stringify(data, null, 2)}
+      </pre>
       <h4>
         {activityData.config.title}
       </h4>

--- a/ac/ac-imgView/src/components/UploadDragDrop.jsx
+++ b/ac/ac-imgView/src/components/UploadDragDrop.jsx
@@ -4,15 +4,19 @@ import React from 'react';
 import Dropzone from 'react-dropzone';
 import styled from 'styled-components';
 
-const UploadDragDrop = ({ data, dataFn, uploadFn, logger }: Object) => {
+import { uuid } from 'frog-utils';
+
+const UploadDragDrop = ({ data, dataFn, stream, uploadFn, logger }: Object) => {
   const onDrop = f => {
     uploadFn(f, url => {
       logger('upload');
       // setTimeout, otherwise HTTP request sends back code 503
-      setTimeout(
-        () => dataFn.objInsert({ url, votes: {} }, Object.keys(data).length),
-        500
-      );
+      setTimeout(() => {
+        dataFn.objInsert({ url, votes: {} }, Object.keys(data).length);
+        if (stream) {
+          stream.objInsert({ url }, uuid());
+        }
+      }, 500);
     });
   };
 

--- a/frog/imports/api/activities.js
+++ b/frog/imports/api/activities.js
@@ -34,6 +34,9 @@ export const addActivity = (
   }
 };
 
+export const setStreamTarget = (activityId: string, streamTarget: string) =>
+  Activities.update(activityId, { $set: { streamTarget } });
+
 export const duplicateActivity = (activity: ActivityDbT) =>
   Activities.insert({
     ...activity,

--- a/frog/imports/api/graphs.js
+++ b/frog/imports/api/graphs.js
@@ -26,11 +26,13 @@ export const addGraph = (graphObj?: Object): string => {
 
   const matching = {};
 
-  const newAct = graphObj.activities.map(activity => {
-    const id = uuid();
-    matching[activity._id] = id;
-    return { ...activity, _id: id, graphId };
-  });
+  const newAct = graphObj.activities
+    .map(activity => {
+      const id = uuid();
+      matching[activity._id] = id;
+      return { ...activity, _id: id, graphId };
+    })
+    .map(ac => ({ ...ac, streamTarget: matching[ac.streamTarget] }));
 
   const newOp = graphObj.operators.map(op => {
     const id = uuid();

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
@@ -3,9 +3,9 @@
 import React from 'react';
 import { ChangeableText } from 'frog-utils';
 import { activityTypesObj } from '/imports/activityTypes';
-import { addActivity } from '/imports/api/activities';
+import { addActivity, setStreamTarget } from '/imports/api/activities';
 import FlexView from 'react-flexview';
-import { Button } from 'react-bootstrap';
+import { FormGroup, FormControl, Button } from 'react-bootstrap';
 
 import { connect } from '../../store';
 import { ErrorList, ValidButton } from '../../Validator';
@@ -13,6 +13,21 @@ import { RenameField } from '../../Rename';
 import FileForm from '../fileUploader';
 import { SelectAttributeWidget } from '../FormUtils';
 import ConfigForm from '../ConfigForm';
+
+const StreamSelect = ({ activity, targets, onChange }) =>
+  <FormGroup controlId="selectGrouping">
+    <FormControl
+      onChange={e => onChange(e.target.value)}
+      componentClass="select"
+      value={activity.streamTarget}
+    >
+      {[{ id: 'undefined', title: 'Choose a target' }, ...targets].map(x =>
+        <option value={x.id} key={x.id}>
+          {' '}{x.title}{' '}
+        </option>
+      )}
+    </FormControl>
+  </FormGroup>;
 
 const EditActivity = props => {
   const activity = props.activity;
@@ -103,6 +118,11 @@ const EditActivity = props => {
               props.store.refreshValidate();
             }}
           />}
+        <StreamSelect
+          activity={activity}
+          targets={props.store.activityStore.all.filter(a => a.plane === 3)}
+          onChange={streamTarget => setStreamTarget(activity._id, streamTarget)}
+        />
       </div>
       <ConfigForm
         {...{


### PR DESCRIPTION
## Changes

Any activity can be configured to stream to a P3 activity. Then its ActivityRunner gets a props `stream` which is a reactiveFunction on the data of the P3 activity instance. I find it pretty simple and I think it will be easier to implement next week script that way rather than with a fake P3 activity.

Graph for testing: https://github.com/chili-epfl/FROG-graphs/blob/master/STREAMING_EXAMPLE.frog 

## Future Work

Need to review the UI of ac-imgClass to handle the external updating of the image list.