### PR TITLE
Collaborative editing

### DIFF
--- a/frog-utils/package.json
+++ b/frog-utils/package.json
@@ -18,7 +18,8 @@
     "react-google-charts": "^1.5.5",
     "react-jsonschema-form": "^0.49.0",
     "recompose": "^0.24.0",
-    "sharedb": "^1.0.0-beta.7"
+    "sharedb": "^1.0.0-beta.7",
+    "sharedb-string-binding": "^1.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/frog-utils/src/generateReactiveFn.js
+++ b/frog-utils/src/generateReactiveFn.js
@@ -1,5 +1,8 @@
 // @flow
 import ShareDB from 'sharedb';
+import StringBinding from 'sharedb-string-binding';
+import { get } from 'lodash';
+
 import { uuid } from './index';
 
 type rawPathT = string | string[];
@@ -17,6 +20,28 @@ class Doc {
     this.doc = doc;
     this.path = path || [];
   }
+
+  bindTextField(ref, rawpath) {
+    const path = cleanPath(this.path, rawpath);
+    if (typeof get(this.doc.data, path) !== 'string') {
+      // eslint-disable-next-line no-console
+      console.error(
+        `Cannot use bindTextField on path that is not initialized as a string, path: ${JSON.stringify(
+          path
+        )}, value ${get(this.doc.data, path)}, doc.data: ${JSON.stringify(
+          this.doc.data
+        )}.`
+      );
+    }
+    const binding = new StringBinding(
+      ref,
+      this.doc,
+      cleanPath(this.path, path)
+    );
+    binding.setup();
+    return binding;
+  }
+
   listPrepend(newVal: any, path: rawPathT) {
     this.doc.submitOp({ p: [...cleanPath(this.path, path), 0], li: newVal });
   }

--- a/frog-utils/src/index.js
+++ b/frog-utils/src/index.js
@@ -133,7 +133,11 @@ export const wordWrap = (text: string, maxLength: number): string[] => {
 const groupchars = 'ABCDEFGHIJKLMNOPQRSTUWXYZ123456789'.split('');
 export const getSlug = (n: number) => shuffle(groupchars).slice(0, n).join('');
 
-type ReactivePropsT = { path: string | string[], dataFn: Object };
+type ReactivePropsT = {
+  path: string | string[],
+  dataFn: Object,
+  type: 'textarea' | 'textinput'
+};
 
 export class ReactiveText extends Component {
   textRef: any;
@@ -156,7 +160,8 @@ export class ReactiveText extends Component {
     if (
       (nextProps.dataFn && nextProps.dataFn.doc.id) !==
         (this.props.dataFn && this.props.dataFn.doc.id) ||
-      this.props.path !== nextProps.path
+      this.props.path !== nextProps.path ||
+      this.props.type !== nextProps.type
     ) {
       this.update(nextProps);
     }
@@ -170,8 +175,13 @@ export class ReactiveText extends Component {
 
   render() {
     const rest = omit(this.props, ['path', 'dataFn']);
-    return (
-      <textarea {...rest} ref={ref => (this.textRef = ref)} defaultValue="" />
-    );
+    return this.props.type === 'textarea'
+      ? <textarea ref={ref => (this.textRef = ref)} {...rest} defaultValue="" />
+      : <input
+          type="text"
+          ref={ref => (this.textRef = ref)}
+          {...rest}
+          defaultValue=""
+        />;
   }
 }

--- a/frog-utils/src/index.js
+++ b/frog-utils/src/index.js
@@ -1,8 +1,8 @@
 // @flow
-import React from 'react';
+import React, { Component } from 'react';
 
 import { compose, withHandlers, withState } from 'recompose';
-import { shuffle } from 'lodash';
+import { shuffle, omit } from 'lodash';
 
 export {
   default as EnhancedForm,
@@ -132,3 +132,46 @@ export const wordWrap = (text: string, maxLength: number): string[] => {
 
 const groupchars = 'ABCDEFGHIJKLMNOPQRSTUWXYZ123456789'.split('');
 export const getSlug = (n: number) => shuffle(groupchars).slice(0, n).join('');
+
+type ReactivePropsT = { path: string | string[], dataFn: Object };
+
+export class ReactiveText extends Component {
+  textRef: any;
+  binding: any;
+  state: ReactivePropsT;
+
+  update = (props: ReactivePropsT) => {
+    this.setState({ path: props.path, dataFn: props.dataFn });
+    if (this.binding) {
+      this.binding.destroy();
+    }
+    this.binding = props.dataFn.bindTextField(this.textRef, props.path);
+  };
+
+  componentDidMount() {
+    this.update(this.props);
+  }
+
+  componentWillReceiveProps(nextProps: ReactivePropsT) {
+    if (
+      (nextProps.dataFn && nextProps.dataFn.doc.id) !==
+        (this.props.dataFn && this.props.dataFn.doc.id) ||
+      this.props.path !== nextProps.path
+    ) {
+      this.update(nextProps);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.binding) {
+      this.binding.destroy();
+    }
+  }
+
+  render() {
+    const rest = omit(this.props, ['path', 'dataFn']);
+    return (
+      <textarea {...rest} ref={ref => (this.textRef = ref)} defaultValue="" />
+    );
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6296,6 +6296,12 @@ sharedb-redis-pubsub@^1.0.0-beta.1:
     redis "^2.6.0"
     sharedb "^1.0.0-beta"
 
+sharedb-string-binding@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/sharedb-string-binding/-/sharedb-string-binding-1.0.0.tgz#0770e36cdcf2c608844dddf8f0a38be42564b102"
+  dependencies:
+    text-diff-binding "^1.0.0"
+
 sharedb@^1.0.0-beta, sharedb@^1.0.0-beta.7:
   version "1.0.0-beta.7"
   resolved "https://registry.yarnpkg.com/sharedb/-/sharedb-1.0.0-beta.7.tgz#82118293db29dd3d781692ae3a39cfdef297b698"
@@ -6755,6 +6761,10 @@ test-exclude@^4.1.1:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
+
+text-diff-binding@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/text-diff-binding/-/text-diff-binding-1.1.0.tgz#3e0adfcb7aee19c16e3afd3e7b7d897998e42a27"
 
 text-table@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This PR adds collaborative editing. It adds a bindTextField method to dataFn, which receives a ref and a path. It needs to be destroyed on unmounting.

To take care of this (ref, destroy etc), we expose a ReactiveText from frog-utils, which take dataFn and path and type (textarea/textfield), and takes care of everything else. I have tested that it works fine when changing props, changing activity, etc.