### PR TITLE
Making developer not-logged-in message more friendly

### DIFF
--- a/frog/imports/ui/App/NotLoggedIn.js
+++ b/frog/imports/ui/App/NotLoggedIn.js
@@ -66,7 +66,7 @@ const NotLoggedIn = () => {
               <b>
                 <i>http://localhost:3000</i>
               </b>{' '}
-              as teacher, and{' '}
+              as teacher, and <h3>Shortcuts</h3>
               <b>
                 <i>http://dev1:3000</i>{' '}
               </b>{' '}

--- a/frog/imports/ui/App/NotLoggedIn.js
+++ b/frog/imports/ui/App/NotLoggedIn.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { sample } from 'lodash';
+import FlexView from 'react-flexview';
 
 const randomName = () =>
   sample([
@@ -20,23 +21,82 @@ const randomName = () =>
   ]);
 
 const NotLoggedIn = () => {
-  const name = randomName();
-  return (
-    <div>
-      <h1>FROG: Not logged in</h1>
-      <p>
-        {`FROG is currently in development mode, to access teacher mode, use <FROG_URL>/#/teacher/[view]. [view] could be 'admin', 'graph' or 'teacher' (to run a graph). Or, to create/log in as a student, use <FROG_URL>/#/<student_name>. <FROG_URL> is typically localhost:3000, so a typical student login could be localhost:3000/#/peter.`}
-      </p>
-      <ul>
-        <li>
-          <Link to="/graph?login=teacher">Log in as teacher</Link>
-        </li>
-        <li>
-          <Link to={`/student?login=${name}`}>Log in as {name} (student)</Link>
-        </li>
-      </ul>
-    </div>
-  );
+  if (process.env.NODE_ENV !== 'production') {
+    const name = randomName();
+    return (
+      <div style={{ margin: '25px' }}>
+        <h1>FROG: Not logged in</h1>
+        <FlexView>
+          <div style={{ width: '50%' }}>
+            <h3>How to login as any user during development</h3>
+            <p>
+              FROG is currently in development mode, to access teacher mode, use{' '}
+              <b>
+                <i>{`<FROG_URL>?login=teacher`}</i>
+              </b>. Or, to create/log in as a student, use{' '}
+              <b>
+                <i>{`<FROG_URL>?login=<student_name>`}</i>
+              </b>.{' '}
+            </p>
+            <p>
+              <b>
+                <i>{`<FROG_URL>`}</i>
+              </b>{' '}
+              is typically{' '}
+              <b>
+                <i>http://localhost:3000</i>
+              </b>, so a typical student login could be{' '}
+              <b>
+                <i>http://localhost:3000?login=peter</i>
+              </b>.
+            </p>
+            <p>
+              You can log in as one user in one tab, and another user in another
+              tab, however on reload, all tabs will log in as the last user
+              (unless you use different browsers, privacy-mode etc). A quick
+              work-around is to define in /etc/hosts:
+            </p>
+            <pre>{`127.0.0.1	localhost
+127.0.0.1	dev1
+127.0.0.1	dev2
+127.0.0.1	dev3
+127.0.0.1	dev4`}</pre>
+            <p>
+              That way, you can log in to{' '}
+              <b>
+                <i>http://localhost:3000</i>
+              </b>{' '}
+              as teacher, and{' '}
+              <b>
+                <i>http://dev1:3000</i>{' '}
+              </b>{' '}
+              as a student, and these logins will survive reloads.
+            </p>
+            <p>
+              More information for developers about code style, developer tools,{' '}
+              type definitions, and data structures, on the{' '}
+              <b>
+                <a href="https://github.com/chili-epfl/frog">GitHub wiki</a>.
+              </b>
+            </p>
+          </div>
+          <FlexView vAlignContent="top" marginLeft={40} width="50%">
+            <div>
+              <h3>Shortcuts</h3>
+              <ul>
+                <li>
+                  <Link to="?login=teacher">Log in as teacher</Link>
+                </li>
+                <li>
+                  <Link to={`?login=${name}`}>Log in as {name} (student)</Link>
+                </li>
+              </ul>
+            </div>
+          </FlexView>
+        </FlexView>
+      </div>
+    );
+  } else return <p>Not logged in</p>;
 };
 
 NotLoggedIn.displayName = 'NotLoggedIn';

--- a/frog/imports/ui/App/index.js
+++ b/frog/imports/ui/App/index.js
@@ -79,7 +79,6 @@ class FROGRouter extends Component {
       this.state.mode === 'waiting' &&
       prevProps.location.search !== this.props.location.search
     ) {
-      console.log('update');
       this.update();
     }
   }

--- a/frog/imports/ui/App/index.js
+++ b/frog/imports/ui/App/index.js
@@ -15,6 +15,7 @@ import {
 } from 'react-router-dom';
 import Spinner from 'react-spinner';
 import { toObject as queryToObject } from 'query-parse';
+import NotLoggedIn from './NotLoggedIn';
 
 import StudentView from '../StudentView';
 
@@ -70,6 +71,20 @@ class FROGRouter extends Component {
   }
 
   componentWillMount() {
+    this.update();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      this.state.mode === 'waiting' &&
+      prevProps.location.search !== this.props.location.search
+    ) {
+      console.log('update');
+      this.update();
+    }
+  }
+
+  update() {
     const query = queryToObject(this.props.location.search.slice(1));
     const hasLogin = query.login;
 
@@ -133,7 +148,7 @@ class FROGRouter extends Component {
         );
       }
     }
-    return <h1>Must log in to use system</h1>;
+    return <NotLoggedIn update={this.update} />;
   }
 }
 


### PR DESCRIPTION
We used to have a "nice" message when a developer opened FROG without logging in, but it disappeared when rewriting the login sequence. I put it back, and made it even nicer :) I think this is important, as there are more and more people installing FROG for the first time, and it doesn't feel very welcoming to see "You are not logged in" when booting. I have verified that this is not displayed in production mode. 

![screen shot 2017-10-27 at 09 12 26](https://user-images.githubusercontent.com/61575/32092004-01bfb49e-baf7-11e7-8481-59ea097f3be5.png)
