### PR TITLE
Check for groupingKey in op-distribute

### DIFF
--- a/op/op-distribute/src/index.js
+++ b/op/op-distribute/src/index.js
@@ -32,6 +32,16 @@ const config = {
   }
 };
 
+const validateConfig = [
+  formData =>
+    !formData.individual && !formData.grouping
+      ? {
+          err:
+            'If you want to distribute to groups, you need groupingKey, otherwise select distributing to individuals'
+        }
+      : null
+];
+
 const configUI = {
   grouping: { conditional: formData => !formData.individual }
 };
@@ -93,5 +103,6 @@ export default ({
   operator,
   config,
   meta,
-  configUI
+  configUI,
+  validateConfig
 }: productOperatorT);


### PR DESCRIPTION
Absence of grouping key, unless individual: true, leads to crash. 