### PR TITLE
Add slug to session dropdown in teacher view

### DIFF
--- a/frog/imports/ui/TeacherView/SessionList.jsx
+++ b/frog/imports/ui/TeacherView/SessionList.jsx
@@ -39,7 +39,7 @@ const SessionList = ({
           eventKey={session._id}
           onClick={() => setTeacherSession(session._id)}
         >
-          {session.name}
+          {session.name} ({session.slug})
         </MenuItem>
       ))}
     </DropdownButton>


### PR DESCRIPTION
Makes it much easier to find an old session, especially when you have twenty copies (many restarts)