### PR TITLE
Allow deep conditional fields

### DIFF
--- a/frog-utils/src/EnhancedForm.js
+++ b/frog-utils/src/EnhancedForm.js
@@ -33,6 +33,34 @@ export const calculateHides = (
   return hide;
 };
 
+const deleteFromSchemaRecursive = (schema, toDeleteList) => {
+  if (toDeleteList.length < 1 || !schema) return;
+
+  // if type array or object, we go one step deeper in the schema
+  // to find the property to delete
+  if (schema.type === 'array') {
+    deleteFromSchemaRecursive(schema.items, toDeleteList);
+  }
+  if (schema.type === 'object') {
+    deleteFromSchemaRecursive(schema.properties, toDeleteList);
+  }
+
+  // if we are at the end of the list we delete the element, otherwise
+  // we make a step in the schema
+  if (toDeleteList.length === 1) {
+    delete schema[toDeleteList[0]];
+  } else {
+    const newSchema = schema[toDeleteList[0]];
+    toDeleteList.shift();
+    deleteFromSchemaRecursive(newSchema, toDeleteList);
+  }
+};
+
+const deleteFromSchema = (schema, x) => {
+  const toDeleteList = x.split('.');
+  deleteFromSchemaRecursive(schema, toDeleteList);
+};
+
 const calculateSchema = (
   formData: Object = {},
   schema: Object,
@@ -40,7 +68,7 @@ const calculateSchema = (
 ): Object => {
   const hide = calculateHides(formData, schema, UISchema);
   const newSchema = cloneDeep(schema);
-  hide.forEach(x => delete newSchema.properties[x]);
+  hide.forEach(x => deleteFromSchema(newSchema, x));
   return newSchema;
 };
 


### PR DESCRIPTION
This allows to make conditional fields that are nested in a deeper level of the formSchema. 

For example: 
ac-quiz could have a field `customWeighting` which will be the condition for all the answers of the quiz to be configured with weights `X` and `Y`. These fields of the formSchema are in an object in an array in an object in an array in an object.