### PR TITLE
Add global groups to op-create-groups

### DIFF
--- a/frog/imports/api/__tests__/validGraphFnTest.js
+++ b/frog/imports/api/__tests__/validGraphFnTest.js
@@ -4,7 +4,6 @@ import valid from '../validGraphFn';
 
 const resultToIds = graph => {
   const res = valid(graph.activities, graph.operators, graph.connections);
-  console.log(res);
   return res.errors.filter(x => x.type !== 'missingConfig').map(x => x.id);
 };
 

--- a/frog/imports/api/__tests__/validGraphFnTest.js
+++ b/frog/imports/api/__tests__/validGraphFnTest.js
@@ -4,6 +4,7 @@ import valid from '../validGraphFn';
 
 const resultToIds = graph => {
   const res = valid(graph.activities, graph.operators, graph.connections);
+  console.log(res);
   return res.errors.filter(x => x.type !== 'missingConfig').map(x => x.id);
 };
 
@@ -187,7 +188,7 @@ const g6 = {
       time: 1.890625,
       y: 338,
       type: 'social',
-      operatorType: 'op-create-groups'
+      operatorType: 'op-prox'
     }
   ],
   connections: [

--- a/op/op-create-groups/src/__tests__/index.js
+++ b/op/op-create-groups/src/__tests__/index.js
@@ -41,3 +41,54 @@ test('Create one large group with everyone', () =>
   expect(operator({ strategy: 'minimum', groupsize: 999 }, obj)).toEqual({
     group: { '1': ['1', '2', '3', '4', '5'] }
   }));
+
+test('Create two groups, odd number', () =>
+  expect(operator({ groupnumber: true, globalnum: 2 }, obj)).toEqual({
+    group: { '1': ['3', '4', '5'], '2': ['1', '2'] }
+  }));
+
+test('Create two groups, exact number', () =>
+  expect(operator({ groupnumber: true, globalnum: 2 }, obj4)).toEqual({
+    group: { '1': ['3', '4'], '2': ['1', '2'] }
+  }));
+
+test('Create three groups, very unequal', () =>
+  expect(operator({ groupnumber: true, globalnum: 3 }, obj4)).toEqual({
+    group: { '1': ['4'], '2': ['3'], '3': ['1', '2'] }
+  }));
+
+const obj11 = {
+  globalStructure: {
+    studentIds: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11']
+  }
+};
+
+test('Works with large numbers, 3', () =>
+  expect(operator({ groupnumber: true, globalnum: 3 }, obj11)).toEqual({
+    group: {
+      '1': ['6', '7', '8', '9'],
+      '2': ['2', '3', '4', '5'],
+      '3': ['1', '10', '11']
+    }
+  }));
+
+test('Works with large numbers, 4', () =>
+  expect(operator({ groupnumber: true, globalnum: 4 }, obj11)).toEqual({
+    group: {
+      '1': ['7', '8', '9'],
+      '2': ['4', '5', '6'],
+      '3': ['11', '2', '3'],
+      '4': ['1', '10']
+    }
+  }));
+
+test('Works with large numbers, 5', () =>
+  expect(operator({ groupnumber: true, globalnum: 5 }, obj11)).toEqual({
+    group: {
+      '1': ['8', '9'],
+      '2': ['6', '7'],
+      '3': ['4', '5'],
+      '4': ['2', '3'],
+      '5': ['1', '10', '11']
+    }
+  }));

--- a/op/op-create-groups/src/index.js
+++ b/op/op-create-groups/src/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { shuffle, chunk, compact } from 'lodash';
+import { shuffle, chunk, compact, range } from 'lodash';
 import { type socialOperatorT } from 'frog-utils';
 
 const meta = {
@@ -12,41 +12,80 @@ const meta = {
 
 const config = {
   type: 'object',
+  required: ['grouping', 'groupsize', 'strategy', 'globalnum'],
   properties: {
+    groupnumber: {
+      type: 'boolean',
+      title: 'Specify desired number of groups, instead of number of members'
+    },
     groupsize: {
       type: 'number',
       title: 'Desired group size',
       default: 3
     },
     strategy: {
+      default: 'minimum',
       type: 'string',
       title:
         'Group formation strategy, optimize for at least this number of students in each group (minimum) or no more than this number of students per group (maximum)?',
       enum: ['minimum', 'maximum']
     },
+    globalnum: {
+      type: 'number',
+      title:
+        'Desired number of groups in the class (if you enter 3, and there are only 2 students, there will be only 2 groups)'
+    },
     grouping: {
       type: 'string',
-      title: "Name of social attribute (default 'group')"
+      title: 'Name of social attribute',
+      default: 'group'
     }
   }
 };
 
+const configUI = {
+  groupsize: { conditional: formdata => !formdata.groupnumber },
+  strategy: { conditional: formdata => !formdata.groupnumber },
+  globalnum: { conditional: 'groupnumber' }
+};
+
 const outputDefinition = conf => [(conf && conf.grouping) || 'group'];
+
+const splitArray = (ary, splits) => {
+  const grpsize = Math.round(ary.length / splits);
+  const grps = range(1, splits).map(() => ary.splice(-grpsize));
+  if (ary.length > 0) {
+    grps.push(ary);
+  }
+  return grps;
+};
 
 const operator = (configData, object) => {
   const { globalStructure } = object;
 
   const ids = shuffle(globalStructure.studentIds);
-  if (ids && configData.groupsize >= ids.length) {
-    return { group: { '1': ids } };
-  }
+  let struct: string[][];
+  if (configData.groupnumber) {
+    let globalnum = configData.globalnum;
+    if (ids && configData.globalnum >= ids.length) {
+      globalnum = ids.length;
+    }
+    struct = splitArray(ids, globalnum);
+  } else {
+    if (ids && configData.groupsize >= ids.length) {
+      return { group: { '1': ids } };
+    }
 
-  const struct = chunk(ids, configData.groupsize);
-  const last = struct.slice(-1)[0];
-  if (last.length < configData.groupsize && configData.strategy === 'minimum') {
-    const leftover = struct.pop();
-    while (leftover.length > 0) {
-      struct.forEach(x => x.push(leftover.pop()));
+    struct = chunk(ids, configData.groupsize);
+    const last = struct.slice(-1)[0];
+    if (
+      last.length < configData.groupsize &&
+      configData.strategy === 'minimum'
+    ) {
+      const leftover = struct.pop();
+      while (leftover.length > 0) {
+        struct.forEach(x => x.push(leftover.pop()));
+      }
     }
   }
   const newGrouping =
@@ -68,6 +107,7 @@ export default ({
   type: 'social',
   operator,
   config,
+  configUI,
   meta,
   outputDefinition
 }: socialOperatorT);


### PR DESCRIPTION
This adds the option to split a class in a number of equal-ish sized groups, rather than to specify the size of each group. 