### PR TITLE
Changing throw to console.error in dataStructureTools

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,7 @@ module.exports = {
     'func-names': 'off',
     'jsx-a11y/label-has-for': 'off',
     'react/require-default-props': 'off',
-    'no-console': 'error',
+    'no-console': ['error', { allow: ['warn', 'error'] }],
     'consistent-return': 'off',
     'import/no-absolute-path': 'off',
     'no-else-return': 'off',

--- a/frog-utils/src/dataStructureTools.js
+++ b/frog-utils/src/dataStructureTools.js
@@ -44,26 +44,30 @@ export const extractUnit = (
     if (activityStructure === 'individual') {
       return data.payload[attributeValue];
     }
-    throw 'Cannot provide individually mapped product to an activity above plane 1';
+    console.error(
+      'Cannot provide individually mapped product to an activity above plane 1'
+    );
   } else {
     if (typeof activityStructure === 'object') {
       if (data.structure.groupingKey !== activityStructure.groupingKey) {
-        throw 'Incompatible grouping keys';
+        console.error('Incompatible grouping keys');
       }
       if (data.payload[attributeValue] !== undefined) {
         return data.payload[attributeValue];
       } else {
-        throw 'Grouping value not found in activityData';
+        console.error('Grouping value not found in activityData');
       }
     }
 
     if (activityStructure === 'individual') {
       if (!socialStructure) {
-        throw 'Cannot map group product to individual without a social structure';
+        console.error(
+          'Cannot map group product to individual without a social structure'
+        );
       }
       const studentAttributes = focusStudent(socialStructure)[attributeValue];
       if (!studentAttributes) {
-        throw 'Student not in social structure';
+        console.error('Student not in social structure');
       }
       if (
         typeof data.structure === 'object' &&
@@ -73,11 +77,13 @@ export const extractUnit = (
         if (data.payload[grp] !== undefined) {
           return data.payload[grp];
         }
-        throw 'Grouping value not found in activityData';
+        console.error('Grouping value not found in activityData');
       }
-      throw 'Student not in group matching groupingKey';
+      console.error('Student not in group matching groupingKey');
     }
-    throw 'Cannot provide group mapped product to a full-class activity';
+    console.error(
+      'Cannot provide group mapped product to a full-class activity'
+    );
   }
 };
 


### PR DESCRIPTION
Not sure what the best way of dealing with this is - but at least this gives us warnings in console, whereas the previous way (throw), when called from within a Promise, only gives us "error undefined", which takes forever to try to hunt down.