### PR TITLE
Fixing EnhancedSchema (again) and some other related bugs

### DIFF
--- a/frog-utils/src/EnhancedForm.js
+++ b/frog-utils/src/EnhancedForm.js
@@ -61,12 +61,12 @@ const deleteFromSchema = (schema, x) => {
   deleteFromSchemaRecursive(schema, toDeleteList);
 };
 
-const calculateSchema = (
+export const calculateSchema = (
   formData: Object = {},
   schema: Object,
   UISchema: Object,
-  oldHides: string[],
-  oldSchema: Object
+  oldHides?: string[] = [],
+  oldSchema?: Object
 ): [Object, string[]] => {
   const hide = calculateHides(formData, schema, UISchema);
   if (!isEqual(hide, oldHides)) {
@@ -74,13 +74,14 @@ const calculateSchema = (
     hide.forEach(x => deleteFromSchema(newSchema, x));
     return [newSchema, hide];
   } else {
-    return [oldSchema, oldHides];
+    return [oldSchema || schema, oldHides];
   }
 };
 
 class EnhancedForm extends Component {
-  state: { schema?: Object };
+  state: { formData?: ?Object, schema?: Object };
   hides: string[];
+  formData: ?Object;
 
   componentWillMount() {
     if (!this.props.formData && jsonSchemaDefaults(this.props.schema) !== {}) {
@@ -90,38 +91,61 @@ class EnhancedForm extends Component {
       });
     } else {
       this.updateSchema(this.props);
+      this.formData = this.props.formData;
+      this.setState({ formData: this.props.formData });
     }
   }
 
-  componentWillReceiveProps(nextProps: Object) {
-    if (!isEqual(this.props, nextProps)) {
-      this.setState({ schema: undefined });
-      if (
-        !isEqual(this.props.schema, nextProps.schema) ||
-        !isEqual(this.props.uiSchema, nextProps.uiSchema)
-      ) {
-        this.hides = [];
-      }
-      this.updateSchema(nextProps);
+  componentDidUpdate = (prevProps: Object) => {
+    if (
+      !isEqual(this.props.schema, prevProps.schema) ||
+      !isEqual(this.props.uiSchema, prevProps.uiSchema)
+    ) {
+      this.hides = [];
+      this.formData = this.props.formData;
+      this.setState({ formData: this.props.formData });
+      this.updateSchema(this.props, true);
     }
-  }
+  };
 
-  updateSchema(props: Object) {
+  onChange = (e: { formData: Object }) => {
+    this.formData = e.formData;
+    if (this.props.onChange) {
+      this.props.onChange(e);
+    }
+    this.updateSchema(this.props);
+  };
+
+  updateSchema = (props: Object, newSchema: boolean = false) => {
     const [schema, hides] = calculateSchema(
-      props.formData,
+      this.formData || this.props.formData,
       props.schema,
       props.uiSchema,
       this.hides || [],
-      (this.state && this.state.schema) || this.props.schema
+      (this.state && !newSchema && this.state.schema) || this.props.schema
     );
     this.hides = hides;
-    this.setState({
-      schema
-    });
-  }
+    if (
+      JSON.stringify((this.state && this.state.schema) || {}) !==
+      JSON.stringify(schema)
+    ) {
+      this.setState({
+        schema,
+        formData: this.formData
+      });
+    }
+  };
+
   render() {
     return (
-      this.state.schema && <Form {...this.props} schema={this.state.schema} />
+      this.state.schema && (
+        <Form
+          {...this.props}
+          onChange={this.onChange}
+          schema={this.state.schema}
+          formData={this.state.formData}
+        />
+      )
     );
   }
 }

--- a/frog-utils/src/index.js
+++ b/frog-utils/src/index.js
@@ -7,7 +7,8 @@ import { shuffle } from 'lodash';
 export {
   default as EnhancedForm,
   hideConditional,
-  calculateHides
+  calculateHides,
+  calculateSchema
 } from './EnhancedForm';
 export { generateReactiveFn, inMemoryReactive } from './generateReactiveFn';
 export { Highlight } from './highlightSubstring';

--- a/frog/imports/api/graphs.js
+++ b/frog/imports/api/graphs.js
@@ -3,7 +3,7 @@
 import { Meteor } from 'meteor/meteor';
 import traverse from 'traverse';
 import { Mongo } from 'meteor/mongo';
-import { uuid } from 'frog-utils';
+import { uuid, calculateSchema } from 'frog-utils';
 import { get, set } from 'lodash';
 
 import { Activities, Connections, Operators } from './activities';
@@ -39,7 +39,8 @@ export const addGraph = (graphObj?: Object): string => {
     matching[op._id] = id;
 
     if (op.data) {
-      const schema = operatorTypesObj[op.operatorType].config;
+      const opT = operatorTypesObj[op.operatorType];
+      const schema = calculateSchema(op.data, opT.config, opT.configUI);
       const paths = traverse.paths(schema).filter(x => x.pop() === 'type');
       const activityPaths = paths.filter(
         x => get(schema, [...x, 'type']) === 'activity'

--- a/frog/imports/ui/GraphEditor/SidePanel/ConfigForm.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/ConfigForm.jsx
@@ -27,6 +27,14 @@ export default class ConfigForm extends Component {
     }
   }
 
+  shouldComponentUpdate(nextProps: PropT): boolean {
+    if (this.props.node._id === nextProps.node._id) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+
   render() {
     const {
       node,
@@ -48,7 +56,6 @@ export default class ConfigForm extends Component {
         groupingKey: node.groupingKey
       },
       onChange: data => {
-        this.setState({ formData: data.formData });
         if (node.operatorType) {
           addOperator(node.operatorType, data.formData, node._id);
         } else {


### PR DESCRIPTION
This PR is another effort to fix/improve EnhancedForm, which still wasn't behaving properly.

What I am doing now is to let it revert to being an uncontrolled form (ie. we don't pass formData into the props on every change). However, we use onChange to store the changes, which are both stored in the database, and used to recalculate the schema (and then the schema is updated only if it has actually changed). Note the difference between this.formData, which does not cause a re-render when updating, and this.state.formData, which does. (Together with this.state.schema). 

The idea is that SidePanel should only re-render the form when there is a new activity/operator, and EnhancedForm should only re-render the form when its a new Activity/Operator, or the schema has changed (due to hiding etc). This should make typing much more stable. We are not worried about synchronizing state with other users live anyway (if we were, we'd have to use Collaborative Form). 

I also fixed a bug in graph copy (api/graphs), where it saw that an operator had an activity selection field (although it was hidden), and tried to look up the activity id. 

I messed around for quite a while trying different things while trying to solve this - it's possible that with my latest change, some of the code is obsolete, however it seems to work well now - any change requires testing. A useful thing is to put a console.count in the render statements of both EnhancedForm and ConfigForm, to make sure they are not re-rendering when you don't want them to.