### PR TITLE
Try to keep activity position constant

### DIFF
--- a/frog/imports/ui/StudentView/SessionBody.jsx
+++ b/frog/imports/ui/StudentView/SessionBody.jsx
@@ -5,6 +5,7 @@ import { createContainer } from 'meteor/react-meteor-data';
 import { Mosaic } from 'react-mosaic-component';
 import { Activities } from '../../api/activities';
 import { Sessions } from '../../api/sessions';
+import { sortBy } from 'lodash';
 
 import Runner from './Runner';
 import Countdown from './Countdown';
@@ -33,7 +34,7 @@ const ActivityContainer = ({ activities, sessionId }) => {
             sessionId={sessionId}
           />
         )}
-        initialValue={getInitialState(activities)}
+        initialValue={getInitialState(sortBy(activities, 'activityType'))}
       />
     );
   }

--- a/frog/imports/ui/StudentView/SessionBody.jsx
+++ b/frog/imports/ui/StudentView/SessionBody.jsx
@@ -2,11 +2,11 @@
 
 import React from 'react';
 import { createContainer } from 'meteor/react-meteor-data';
+import { sortBy } from 'lodash';
 import { Mosaic } from 'react-mosaic-component';
+
 import { Activities } from '../../api/activities';
 import { Sessions } from '../../api/sessions';
-import { sortBy } from 'lodash';
-
 import Runner from './Runner';
 import Countdown from './Countdown';
 


### PR DESCRIPTION
When you have two different activities, and you transition to either two new activities with the same activity types, it is confusing that the activities might switch places, because layout is dependent on activity ordering in the database, which is probably based on creation time or something... In the future we might want to have some more intelligent logic, for example if you have a chat on the left, and open a new activity, the chat should always stay on the left. For now, I'm just sorting by activityTypes, so two activities with the same two activityTypes, will always have the same positioning.