### PR TITLE
Automatically set graph width on export

### DIFF
--- a/frog/imports/ui/GraphEditor/TopPanel/Settings.js
+++ b/frog/imports/ui/GraphEditor/TopPanel/Settings.js
@@ -49,7 +49,7 @@ export const ConfigMenu = connect(
       <MenuItem eventKey="3" onSelect={importGraph}>
         Import graph
       </MenuItem>
-      <MenuItem eventKey="4" onSelect={exportPicture}>
+      <MenuItem eventKey="4" onSelect={() => exportPicture()}>
         Export as image
       </MenuItem>
     </DropdownButton>

--- a/frog/imports/ui/GraphEditor/store/activity.js
+++ b/frog/imports/ui/GraphEditor/store/activity.js
@@ -2,6 +2,7 @@
 
 import { observable, computed, action } from 'mobx';
 import cuid from 'cuid';
+
 import { store } from './index';
 import Elem from './elemClass';
 import { timeToPx, timeToPxScreen, between } from '../utils';

--- a/frog/imports/ui/GraphEditor/store/activityStore.js
+++ b/frog/imports/ui/GraphEditor/store/activityStore.js
@@ -1,6 +1,6 @@
 // @flow
 import { computed, action, observable } from 'mobx';
-import { omit } from 'lodash';
+import { omit, maxBy } from 'lodash';
 
 import Activity from './activity';
 import { duplicateActivity } from '../../../api/activities';
@@ -199,5 +199,11 @@ export default class ActivityStore {
   @computed
   get history(): Array<any> {
     return this.all.map(x => ({ ...omit(x, 'over') }));
+  }
+
+  @computed
+  get furthestActivity(): number {
+    const max = maxBy(this.all, x => x.startTime + x.length);
+    return max && Math.ceil(max.startTime + max.length);
   }
 }

--- a/frog/imports/ui/GraphEditor/store/operatorStore.js
+++ b/frog/imports/ui/GraphEditor/store/operatorStore.js
@@ -1,6 +1,7 @@
 // @flow
 import { computed, action, observable } from 'mobx';
-import { omit } from 'lodash';
+import { omit, maxBy } from 'lodash';
+
 import { store } from './index';
 import Operator from './operator';
 
@@ -47,5 +48,11 @@ export default class OperatorStore {
   @computed
   get history(): Array<any> {
     return this.all.map(x => ({ ...omit(x, 'over') }));
+  }
+
+  @computed
+  get furthestOperator(): number {
+    const op = maxBy(this.all, x => x.time);
+    return op && op.time + 1;
   }
 }

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -70,7 +70,12 @@ export default class Store {
   browserHistory: any;
   url: string;
 
-  @observable graphDuration: number = 120;
+  @observable _graphDuration: number = 120;
+
+  @computed
+  get graphDuration(): number {
+    return this.ui.isSvg ? this.ui.furthestObject : this._graphDuration;
+  }
 
   set state(newState: StateT) {
     this._state = newState;
@@ -104,11 +109,11 @@ export default class Store {
     if (duration && duration >= 30 && duration <= 1200) {
       const oldPanTime = this.ui.panTime;
       // changes the scale on duration change
-      this.ui.setScaleValue(this.ui.scale / this.graphDuration * duration);
-      this.graphDuration = duration;
+      this._graphDuration = duration;
+      this.ui.setScaleValue(this.ui.scale / this.graphDuration);
       const needPanDelta = timeToPx(oldPanTime - this.ui.panTime, 1);
       this.ui.panDelta(needPanDelta);
-      Graphs.update(this.graphId, { $set: { duration: this.graphDuration } });
+      Graphs.update(this.graphId, { $set: { duration: this._graphDuration } });
     }
   };
 
@@ -303,7 +308,7 @@ export default class Store {
         graphId: this.graphId
       })),
       graphId: this.graphId,
-      graphDuration: this.graphDuration
+      graphDuration: this._graphDuration
     };
   }
 }

--- a/frog/imports/ui/GraphEditor/store/uiStore.js
+++ b/frog/imports/ui/GraphEditor/store/uiStore.js
@@ -253,4 +253,15 @@ export default class uiStore {
   get rightEdgeTime(): number {
     return pxToTime(this.panOffset + this.panBoxSize * this.scale, this.scale);
   }
+
+  @computed
+  get furthestObject(): number {
+    return Math.ceil(
+      Math.max(
+        store.operatorStore.furthestOperator || 0,
+        store.activityStore.furthestActivity || 0,
+        30
+      )
+    );
+  }
 }

--- a/frog/imports/ui/GraphEditor/utils/exportPicture.js
+++ b/frog/imports/ui/GraphEditor/utils/exportPicture.js
@@ -12,9 +12,9 @@ export default (dataCB: string => void) => {
   const canvas = document.createElement('canvas');
 
   const oldScale = store.ui.scale;
+  store.ui.setIsSvg(true);
   store.ui.setScaleValue(store.graphDuration / 30);
   store.ui.setGraphWidth(1768);
-  store.ui.setIsSvg(true);
   render(
     <Provider store={store}>
       <Graph viewBox={[0, 0, 1, 1].join(' ')} isSvg scaled hasTimescale />
@@ -37,7 +37,7 @@ export default (dataCB: string => void) => {
       height: 600
     });
   }
+  store.ui.setIsSvg(false);
   store.ui.setScaleValue(oldScale);
   store.ui.updateGraphWidth();
-  store.ui.setIsSvg(false);
 };


### PR DESCRIPTION
This fixes a bug in image export (currently it's broken for exporting from graph), and automatically resizes the graph based on the further-most operator/activity when exporting an image (min. 30 min).

Closes #666 