### PR TITLE
Change LTI login to use token and injectData

### DIFF
--- a/frog/.meteor/packages
+++ b/frog/.meteor/packages
@@ -31,3 +31,4 @@ reywood:publish-composite
 mizzao:user-status
 standard-minifier-js
 minifier-js
+staringatlights:inject-data

--- a/frog/.meteor/versions
+++ b/frog/.meteor/versions
@@ -91,6 +91,7 @@ spacebars-compiler@1.1.3
 srp@1.0.10
 standard-minifier-css@1.3.5
 standard-minifier-js@2.2.1
+staringatlights:inject-data@2.0.5
 templating@1.3.2
 templating-compiler@1.3.3
 templating-runtime@1.3.2

--- a/frog/imports/ui/App/index.js
+++ b/frog/imports/ui/App/index.js
@@ -63,7 +63,7 @@ const subscriptionCallback = (error, response, setState) => {
 };
 
 const FROGRouter = withRouter(
-  class Router extends Component {
+  class RawRouter extends Component {
     state: {
       mode: 'ready' | 'loggingIn' | 'error' | 'waiting' | 'studentlist',
       studentlist?: string[]

--- a/frog/server/api.js
+++ b/frog/server/api.js
@@ -12,7 +12,7 @@ Picker.middleware(bodyParser.json());
 
 Picker.filter(req => req.method === 'POST').route(
   '/lti/:slug',
-  (params, request, response) => {
+  (params, request, response, next) => {
     let user;
     try {
       user = request.body.lis_person_name_full;
@@ -33,11 +33,11 @@ Picker.filter(req => req.method === 'POST').route(
     Meteor.users.update(userId, { $set: { username: user, userid: id } });
     const stampedLoginToken = Accounts._generateStampedLoginToken();
     Accounts._insertLoginToken(userId, stampedLoginToken);
-    response.writeHead(301, {
-      Location: `/${params.slug}`
+    InjectData.pushData(response, 'login', {
+      token: stampedLoginToken.token,
+      slug: params.slug
     });
-    InjectData.pushData(response, 'login', { token: stampedLoginToken.token });
-    response.end();
+    next();
   }
 );
 

--- a/frog/server/api.js
+++ b/frog/server/api.js
@@ -4,6 +4,7 @@ import { uuid } from 'frog-utils';
 import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
 import { WebApp } from 'meteor/webapp';
+import { InjectData } from 'meteor/staringatlights:inject-data';
 import fs from 'fs';
 
 Picker.middleware(bodyParser.urlencoded({ extended: false }));
@@ -30,9 +31,12 @@ Picker.filter(req => req.method === 'POST').route(
       id: user
     });
     Meteor.users.update(userId, { $set: { username: user, userid: id } });
+    const stampedLoginToken = Accounts._generateStampedLoginToken();
+    Accounts._insertLoginToken(userId, stampedLoginToken);
     response.writeHead(301, {
-      Location: `/${params.slug}?login=${encodeURI(user)}`
+      Location: `/${params.slug}`
     });
+    InjectData.pushData(response, 'login', { token: stampedLoginToken.token });
     response.end();
   }
 );

--- a/frog/server/user_accounts.js
+++ b/frog/server/user_accounts.js
@@ -31,6 +31,9 @@ const doLogin = (user, self) => {
     id: user
   });
   Meteor.users.update(userId, { $set: { username: user } });
+  const stampedLoginToken = Accounts._generateStampedLoginToken();
+  Accounts._insertLoginToken(userId, stampedLoginToken);
+
   const result = Accounts._loginUser(self, userId);
   return result;
 };


### PR DESCRIPTION
This introduces a method to inject data into the HTML served to the client, which means we can send the login information that way instead of as URL parameters. We are also sending the login token instead of the username, which is safer. (Token expires, and you cannot guess the token of another user). 

Note: check that HTML is not cached in the Nginx setup.

You can test it here: http://moodle.unil.ch/mod/lti/view.php?id=464015