### PR TITLE
Fixing op-control problem

### DIFF
--- a/frog/imports/api/graphs.js
+++ b/frog/imports/api/graphs.js
@@ -37,7 +37,6 @@ export const addGraph = (graphObj?: Object): string => {
   const newOp = graphObj.operators.map(op => {
     const id = uuid();
     matching[op._id] = id;
-
     if (op.data) {
       const opT = operatorTypesObj[op.operatorType];
       const schema = calculateSchema(op.data, opT.config, opT.configUI);
@@ -51,6 +50,12 @@ export const addGraph = (graphObj?: Object): string => {
         if (path[1] === 'items') {
           op.data[path[0]].forEach((_, i) => {
             const relpath = [path[0], i, path[2]];
+            const curRef = get(op.data, relpath);
+            set(op.data, relpath, matching[curRef]);
+          });
+        } else if (path[2] === 'items') {
+          op.data[path[1]].forEach((_, i) => {
+            const relpath = [path[1], i, path[3]];
             const curRef = get(op.data, relpath);
             set(op.data, relpath, matching[curRef]);
           });


### PR DESCRIPTION
This is not pretty code but it fixes op-control when copying graph. If you can fix this to be truly recursive (work with arrays at any level, any number of arrays etc) it would be nice, otherwise let's just leave it like this until we probably change the way we structure activity IDs, so we don't need to constantly keep them up to date.

Closes #690.