### PR TITLE
Randomize quiz

### DIFF
--- a/ac/ac-quiz/package.json
+++ b/ac/ac-quiz/package.json
@@ -16,7 +16,8 @@
     "react-dom": "^16.0.0",
     "react-jsonschema-form": "^1.0.0",
     "react-latex": "^1.0.1",
-    "styled-components": "^2.2.3"
+    "styled-components": "^2.2.3",
+    "seededshuffle": "^0.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/ac/ac-quiz/src/ActivityRunner.jsx
+++ b/ac/ac-quiz/src/ActivityRunner.jsx
@@ -52,18 +52,20 @@ const Quiz = ({
   };
 
   const uiSchema = {};
-  const condShuffle = list =>
-    activityData.config.shuffle
-      ? seededShuffle.shuffle(list, userInfo.id, true)
+  const condShuffle = (list, type, salt) =>
+    [type, 'both'].includes(activityData.config.shuffle)
+      ? seededShuffle.shuffle(list, userInfo.id + salt, true)
       : list;
 
   const items = condShuffle(
     activityData.config.questions
       .filter(q => q.question && q.answers)
-      .map((x, i) => [x, i])
+      .map((x, i) => [x, i]),
+    'questions',
+    ''
   );
   items.forEach(([q, i], reali) => {
-    const answers = condShuffle(q.answers.map((x, y) => [x, y]));
+    const answers = condShuffle(q.answers.map((x, y) => [x, y]), 'answers', i);
     schema.properties['question ' + i] = {
       type: 'number',
       title: 'Question ' + (reali + 1),

--- a/ac/ac-quiz/src/ActivityRunner.jsx
+++ b/ac/ac-quiz/src/ActivityRunner.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Form from 'react-jsonschema-form';
 import styled from 'styled-components';
 import Latex from 'react-latex';
-import { shuffle } from 'lodash';
+import seededShuffle from 'seededshuffle';
 import type { ActivityRunnerT } from 'frog-utils';
 
 import LatexWidget from './LatexWidget';
@@ -38,7 +38,13 @@ const DescriptionField = props => (
   </QuestionTitle>
 );
 
-const Quiz = ({ activityData, data, dataFn, logger }: ActivityRunnerT) => {
+const Quiz = ({
+  activityData,
+  data,
+  dataFn,
+  logger,
+  userInfo
+}: ActivityRunnerT) => {
   const schema = {
     title: activityData.config.name,
     type: 'object',
@@ -47,7 +53,9 @@ const Quiz = ({ activityData, data, dataFn, logger }: ActivityRunnerT) => {
 
   const uiSchema = {};
   const condShuffle = list =>
-    activityData.config.shuffle ? shuffle(list) : list;
+    activityData.config.shuffle
+      ? seededShuffle.shuffle(list, userInfo.id, true)
+      : list;
 
   const items = condShuffle(
     activityData.config.questions
@@ -55,12 +63,12 @@ const Quiz = ({ activityData, data, dataFn, logger }: ActivityRunnerT) => {
       .map((x, i) => [x, i])
   );
   items.forEach(([q, i], reali) => {
-    const answers = condShuffle(q.answers);
+    const answers = condShuffle(q.answers.map((x, y) => [x, y]));
     schema.properties['question ' + i] = {
       type: 'number',
       title: 'Question ' + (reali + 1),
-      enum: answers.map((_, k) => k),
-      enumNames: answers
+      enum: answers.map(([, k]) => k),
+      enumNames: answers.map(([x]) => x)
     };
     uiSchema['question ' + i] = {
       'ui:widget': 'latexWidget',

--- a/ac/ac-quiz/src/config.js
+++ b/ac/ac-quiz/src/config.js
@@ -10,7 +10,8 @@ export default {
     shuffle: {
       type: 'string',
       title: 'Shuffle questions, answers or both for each student?',
-      enum: ['none', 'answers', 'questions', 'both']
+      enum: ['none', 'answers', 'questions', 'both'],
+      default: 'none'
     },
     guidelines: {
       type: 'string',

--- a/ac/ac-quiz/src/config.js
+++ b/ac/ac-quiz/src/config.js
@@ -7,6 +7,10 @@ export default {
       type: 'string',
       title: 'Title'
     },
+    shuffle: {
+      type: 'boolean',
+      title: 'Shuffle questions and responses for each student?'
+    },
     guidelines: {
       type: 'string',
       title: 'Guidelines'

--- a/ac/ac-quiz/src/config.js
+++ b/ac/ac-quiz/src/config.js
@@ -8,8 +8,9 @@ export default {
       title: 'Title'
     },
     shuffle: {
-      type: 'boolean',
-      title: 'Shuffle questions and responses for each student?'
+      type: 'string',
+      title: 'Shuffle questions, answers or both for each student?',
+      enum: ['none', 'answers', 'questions', 'both']
     },
     guidelines: {
       type: 'string',

--- a/ac/ac-quiz/src/meta.js
+++ b/ac/ac-quiz/src/meta.js
@@ -94,6 +94,11 @@ export const meta = {
       config: exampleConfig,
       title: 'Sample MCQ',
       activityData: {}
+    },
+    {
+      config: { ...exampleConfig, shuffle: true },
+      title: 'Sample MCQ with shuffling options',
+      activityData: {}
     }
   ]
 };

--- a/ac/ac-quiz/src/meta.js
+++ b/ac/ac-quiz/src/meta.js
@@ -87,8 +87,9 @@ const exampleConfig = {
 };
 export const meta = {
   name: 'Multiple-Choice Questions',
-  shortDesc: 'Filling a MCQ form',
-  description: 'Display a multiple-choice questions form.',
+  shortDesc: 'Filling a MCQ form (quiz)',
+  description:
+    'Display a multiple-choice questions form. Can also be used for questionnaires.',
   exampleData: [
     {
       config: exampleConfig,

--- a/ac/ac-quiz/src/meta.js
+++ b/ac/ac-quiz/src/meta.js
@@ -96,7 +96,7 @@ export const meta = {
       activityData: {}
     },
     {
-      config: { ...exampleConfig, shuffle: true },
+      config: { ...exampleConfig, shuffle: 'both' },
       title: 'Sample MCQ with shuffling options',
       activityData: {}
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5897,6 +5897,10 @@ sax@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
 
+seededshuffle@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/seededshuffle/-/seededshuffle-0.2.0.tgz#f0df7eb606e1a339d3c64e1c85ae4755d1b051a9"
+
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"


### PR DESCRIPTION
Adding option to shuffle both order of questions and order of answer alternatives for each question in ac-quiz. This is to prevent copying by looking at someone else's screen. Internally question IDs and answer alternative IDs are kept consistent, so submitted answers are comparative.

Uses seededShuffle package which will always shuffle an array in the same way for a given student ID, this is important, otherwise the answers would be reorganized for each re-render.

<img width="1040" alt="screen shot 2017-11-22 at 06 47 55" src="https://user-images.githubusercontent.com/61575/33112062-78712faa-cf51-11e7-9753-79fbed989bf5.png">

Closes #692 