### PR TITLE
Hiding streaming operator and upload

### DIFF
--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
@@ -1,12 +1,13 @@
 // @flow
 
 import React from 'react';
-import { ChangeableText } from 'frog-utils';
-import { activityTypesObj } from '/imports/activityTypes';
-import { addActivity, setStreamTarget } from '/imports/api/activities';
 import FlexView from 'react-flexview';
 import { FormGroup, FormControl, Button } from 'react-bootstrap';
+import { withState } from 'recompose';
+import { ChangeableText, A } from 'frog-utils';
 
+import { activityTypesObj } from '/imports/activityTypes';
+import { addActivity, setStreamTarget } from '/imports/api/activities';
 import { connect } from '../../store';
 import { ErrorList, ValidButton } from '../../Validator';
 import { RenameField } from '../../Rename';
@@ -30,8 +31,12 @@ const StreamSelect = ({ activity, targets, onChange }) => (
   </FormGroup>
 );
 
-const EditActivity = props => {
-  const activity = props.activity;
+const RawEditActivity = ({
+  advancedOpen,
+  setAdvancedOpen,
+  activity,
+  ...props
+}) => {
   const graphActivity = props.store.activityStore.all.find(
     act => act.id === activity._id
   );
@@ -126,13 +131,6 @@ const EditActivity = props => {
             }}
           />
         )}
-        <StreamSelect
-          activity={activity}
-          targets={props.store.activityStore.all.filter(
-            a => a.plane === 3 && a.id !== activity._id
-          )}
-          onChange={streamTarget => setStreamTarget(activity._id, streamTarget)}
-        />
       </div>
       <ConfigForm
         {...{
@@ -142,9 +140,27 @@ const EditActivity = props => {
           refreshValidate: props.store.refreshValidate
         }}
       />
-      <FileForm />
+      <A onClick={() => setAdvancedOpen(!advancedOpen)}>Advanced...</A>
+      {advancedOpen && [
+        <div>
+          Select streaming target
+          <StreamSelect
+            activity={activity}
+            targets={props.store.activityStore.all.filter(
+              a => a.plane === 3 && a.id !== activity._id
+            )}
+            onChange={streamTarget =>
+              setStreamTarget(activity._id, streamTarget)
+            }
+          />
+        </div>,
+        <FileForm />
+      ]}
     </div>
   );
 };
 
+const EditActivity = withState('advancedOpen', 'setAdvancedOpen', false)(
+  RawEditActivity
+);
 export default connect(EditActivity);

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
@@ -142,7 +142,7 @@ const RawEditActivity = ({
       />
       <A onClick={() => setAdvancedOpen(!advancedOpen)}>Advanced...</A>
       {advancedOpen && [
-        <div>
+        <div key="stream">
           Select streaming target
           <StreamSelect
             activity={activity}
@@ -154,7 +154,7 @@ const RawEditActivity = ({
             }
           />
         </div>,
-        <FileForm />
+        <FileForm key="fileform" />
       ]}
     </div>
   );


### PR DESCRIPTION
Not beautiful design, but a quick intervention to clean up activity sidepanel and avoid confusion with new developers - I'm hiding stream target and upload behind an "advanced" toggle.

<img width="449" alt="screen shot 2017-11-22 at 07 19 45" src="https://user-images.githubusercontent.com/61575/33112851-a0830f8c-cf55-11e7-9756-6378c3ed0551.png">


<img width="456" alt="screen shot 2017-11-22 at 07 19 48" src="https://user-images.githubusercontent.com/61575/33112854-a31c2850-cf55-11e7-814a-db1071a840ea.png">
