### PR TITLE
Fixing inconsistency of keyboard shortcut activation in graph editor

### DIFF
--- a/frog/imports/ui/GraphEditor/index.js
+++ b/frog/imports/ui/GraphEditor/index.js
@@ -11,7 +11,6 @@ import EditorContainer from './EditorContainer';
 class AppClass extends Component {
   componentWillMount() {
     store.setBrowserHistory(this.props.history);
-    bindKeys();
     this.updateGraphId(this.props.match && this.props.match.params.graphId);
   }
 
@@ -29,6 +28,10 @@ class AppClass extends Component {
     const graphId = assignGraph(graphIdWanted);
     store.setId(graphId);
   };
+
+  componentDidMount() {
+    bindKeys();
+  }
 
   componentWillUnmount() {
     Mousetrap.reset();


### PR DESCRIPTION
This might work - I couldn't reproduce 'w' etc not working after this change, can you try it?

Closes #686 