### PR TITLE
Making quiz-order seeded by groupingValue, not studentId

### DIFF
--- a/ac/ac-quiz/src/ActivityRunner.jsx
+++ b/ac/ac-quiz/src/ActivityRunner.jsx
@@ -43,7 +43,7 @@ const Quiz = ({
   data,
   dataFn,
   logger,
-  userInfo
+  groupingValue
 }: ActivityRunnerT) => {
   const schema = {
     title: activityData.config.name,
@@ -55,7 +55,7 @@ const Quiz = ({
 
   const condShuffle = (list, type, salt) =>
     [type, 'both'].includes(activityData.config.shuffle)
-      ? seededShuffle.shuffle(list, userInfo.id + salt, true)
+      ? seededShuffle.shuffle(list, groupingValue + salt, true)
       : list;
 
   const questions = condShuffle(


### PR DESCRIPTION
This makes it consistent within groups for p2 (or for whole class in p3).