### PR TITLE
Make file upload work when using external IP

### DIFF
--- a/ac/ac-uploader/src/ActivityRunner.jsx
+++ b/ac/ac-uploader/src/ActivityRunner.jsx
@@ -16,16 +16,10 @@ const ActivityRunner = (
   return (
     <div style={{ width: '100%', height: '100%' }}>
       <Presentation activityData={activityData} />
-      {!done && (
-        <div
-          style={{
-            transform: 'translateY(100px)'
-          }}
-        >
-          <UploadPanel {...props} />
-          <List data={data} dataFn={dataFn} />
-        </div>
-      )}
+      {!done && [
+        <UploadPanel key="panel" {...props} />,
+        <List key="list" data={data} dataFn={dataFn} />
+      ]}
     </div>
   );
 };

--- a/ac/ac-uploader/src/UploadPanel.jsx
+++ b/ac/ac-uploader/src/UploadPanel.jsx
@@ -4,6 +4,8 @@ import React from 'react';
 import Dropzone from 'react-dropzone';
 import styled from 'styled-components';
 
+import { uuid } from 'frog-utils';
+
 export default ({
   activityData,
   data,
@@ -16,17 +18,12 @@ export default ({
     ? activityData.config.maxNumbFile
     : 10;
 
-  const onDrop = f => {
-    uploadFn(f, url => {
-      // setTimeout, otherwise HTTP request sends back code 503
-      setTimeout(
-        () =>
-          dataFn.objInsert(
-            { url, idStudent: userInfo.id },
-            Object.keys(data).length
-          ),
-        500
-      );
+  const onDrop = files => {
+    files.forEach(file => {
+      const fileId = uuid();
+      uploadFn(file, fileId).then(url => {
+        dataFn.objInsert({ url, key: fileId, studentId: userInfo.id }, fileId);
+      });
     });
   };
 

--- a/frog-utils/src/types.js
+++ b/frog-utils/src/types.js
@@ -75,7 +75,7 @@ export type ActivityRunnerT = {
   data: any,
   dataFn: Object,
   stream: (value: any, path: string[]) => void,
-  uploadFn: (files: Array<any>, callback: (string) => any) => void,
+  uploadFn: (files: Array<any>, name: string) => Promise<*>,
   userInfo: { id: string, name: string },
   groupingValue: string
 };

--- a/frog/imports/api/openUploads.js
+++ b/frog/imports/api/openUploads.js
@@ -1,4 +1,5 @@
 // @flow
+
 import { Meteor } from 'meteor/meteor';
 
 export const uploadFile = (file: any, name: string) =>

--- a/frog/imports/api/uploads.js
+++ b/frog/imports/api/uploads.js
@@ -1,1 +1,0 @@
-export const Uploads = { insert: () => {} };

--- a/frog/imports/ui/App/index.js
+++ b/frog/imports/ui/App/index.js
@@ -30,7 +30,10 @@ const TeacherLoadable = Loadable({
 
 const shareDbUrl =
   (Meteor.settings && Meteor.settings.public.sharedburl) ||
-  'ws://localhost:3002';
+  (window.location.protocol === 'https:' ? 'wss:' : 'ws:') +
+    '//' +
+    window.location.hostname +
+    ':3002';
 
 const socket = new ReconnectingWebSocket(shareDbUrl);
 export const connection = new sharedbClient.Connection(socket);

--- a/frog/imports/ui/GraphEditor/SidePanel/fileUploader.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/fileUploader.jsx
@@ -5,7 +5,8 @@ import CopyToClipboard from 'react-copy-to-clipboard';
 import { Collapse } from 'react-bootstrap';
 import Dropzone from 'react-dropzone';
 
-import { Uploads } from '../../../api/uploads';
+import { uuid } from 'frog-utils';
+import { uploadFile } from '../../../api/openUploads';
 
 const Header = ({ display, setState }) => (
   <div style={{ display: 'flex', flexDirection: 'row' }}>
@@ -22,19 +23,18 @@ const Header = ({ display, setState }) => (
 );
 
 const FileBox = ({ urls, setState }) => {
-  const onDrop = files => {
-    if (files.length > 1) {
-      window.alert('Only 1 file at a time please'); //eslint-disable-line
+  const onDropRecursive = (files, i, newUrls) => {
+    if (i >= files.length) {
+      setState({ urls: [...urls, ...newUrls] });
     } else {
-      Uploads.insert(files[0], (err, fileObj) => {
-        const newUrl =
-          window.location.origin + '/cfs/files/uploads/' + fileObj._id;
-        setState({
-          urls: [...urls, newUrl]
-        });
+      const fileId = uuid();
+      uploadFile(files[i], fileId).then(newUrl => {
+        onDropRecursive(files, i + 1, [...newUrls, newUrl]);
       });
     }
   };
+
+  const onDrop = files => onDropRecursive(files, 0, []);
 
   return (
     <Dropzone

--- a/frog/server/minio.js
+++ b/frog/server/minio.js
@@ -3,7 +3,7 @@ import { shuffle } from 'lodash';
 
 if (process.env.NODE_ENV !== 'production') {
   Meteor.methods({
-    'minio.signedurl': name => 'http://localhost:3000/file?name=' + name
+    'minio.signedurl': name => '/file?name=' + name
   });
 } else {
   Meteor.methods({


### PR DESCRIPTION
Previous development mode had hard-coded localhost, which means that if you run FROG in development but expose a public IP/DNS, it would fail. Made it more flexible.