### PR TITLE
Updating form data when switching node

### DIFF
--- a/frog-utils/src/EnhancedForm.js
+++ b/frog-utils/src/EnhancedForm.js
@@ -99,7 +99,8 @@ class EnhancedForm extends Component {
   componentDidUpdate = (prevProps: Object) => {
     if (
       !isEqual(this.props.schema, prevProps.schema) ||
-      !isEqual(this.props.uiSchema, prevProps.uiSchema)
+      !isEqual(this.props.uiSchema, prevProps.uiSchema) ||
+      !isEqual(this.props.id, prevProps.id)
     ) {
       this.hides = [];
       this.formData = this.props.formData;

--- a/frog/imports/ui/GraphEditor/SidePanel/ConfigForm.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/ConfigForm.jsx
@@ -50,6 +50,7 @@ export default class ConfigForm extends Component {
         socialAttributeWidget: SelectFormWidget,
         activityWidget: SelectActivityWidget
       },
+      id: node._id,
       formContext: {
         options: valid.social[node._id] || [],
         connectedActivities,


### PR DESCRIPTION
Currently EnhancedForm also takes an optional id prop, which is used to determine whether a new object is displayed, and to decide to redraw the form. This is used by ConfigForm to update formData when a new node is selected.