### PR TITLE
Enable local file uploads also in production

### DIFF
--- a/frog/server/api.js
+++ b/frog/server/api.js
@@ -41,7 +41,7 @@ Picker.filter(req => req.method === 'POST').route(
   }
 );
 
-if (process.env.NODE_ENV !== 'production') {
+if (process.env.NODE_ENV !== 'production' || !Meteor.settings.Minio) {
   WebApp.connectHandlers.use('/file', (req, res) => {
     res.setHeader('Access-Control-Allow-Methods', 'PUT');
     res.setHeader('Access-Control-Allow-Origin', '*');

--- a/frog/server/minio.js
+++ b/frog/server/minio.js
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { shuffle } from 'lodash';
 
-if (process.env.NODE_ENV !== 'production') {
+if (process.env.NODE_ENV !== 'production' || !Meteor.settings.Minio) {
   Meteor.methods({
     'minio.signedurl': name => '/file?name=' + name
   });


### PR DESCRIPTION
We used to only allow local file uploads (without Minio) in dev, but for example frogpublic with mup deploy is "production", but doesn't need Minio. This fixes this - you need to specify Minio URLs in the settings to enable Minio.