### PR TITLE
Making shouldComponentUpdate trigger for ActivityRunners

### DIFF
--- a/frog/imports/ui/StudentView/ReactiveHOC.jsx
+++ b/frog/imports/ui/StudentView/ReactiveHOC.jsx
@@ -1,11 +1,12 @@
 // @flow
 import React, { Component } from 'react';
+import Spinner from 'react-spinner';
+import { cloneDeep } from 'lodash';
 import {
   generateReactiveFn,
   type ReactComponent,
   getDisplayName
 } from 'frog-utils';
-import Spinner from 'react-spinner';
 
 import { uploadFile } from '../../api/openUploads';
 import { connection } from '../App/index';
@@ -44,7 +45,7 @@ const ReactiveHOC = (docId: string, conn?: any) => (
         if (!this.state.dataFn) {
           this.setState({ dataFn: generateReactiveFn(this.doc) });
         }
-        this.setState({ data: this.doc.data });
+        this.setState({ data: cloneDeep(this.doc.data) });
       }
     };
 


### PR DESCRIPTION
Currently, in ReactiveHOC, we do setState({data: this.doc.data}), however, this means that the object reference never changes (only the content), which means that `shouldComponentUpdate` in ActivityRunners do not trigger when data changes. This is a problem for activities that rely on this - for example Iciar, who needs data to exchange WebRTC settings between users, but does not want to change the rendering when data updates.