### PR TITLE
Making sure reactive data for p3 with social operator still works

### DIFF
--- a/frog/imports/ui/StudentView/Runner.jsx
+++ b/frog/imports/ui/StudentView/Runner.jsx
@@ -34,10 +34,10 @@ const Runner = ({ path, activity, sessionId, object, single }) => {
   const studentSoc = socStructure[Meteor.userId()];
 
   let groupingValue;
-  if (studentSoc && activity.groupingKey) {
-    groupingValue = studentSoc[activity.groupingKey];
-  } else if (activity.plane === 3) {
+  if (activity.plane === 3) {
     groupingValue = 'all';
+  } else if (activity.plane === 2) {
+    groupingValue = studentSoc[activity.groupingKey];
   } else {
     groupingValue = Meteor.userId();
   }


### PR DESCRIPTION
Somehow if a p3 activity has a social operator connected to it, we give instance names according to the social operator. However the activity tries to load /all, and we get a mismatch. This PR fixes this issue - a p3 activity should always have the instance name /all, etc. 

This led to a bug for a semester project. Hope this doesn't break any existing graphs, but I don't think it should. 