### PR TITLE
fix a problem with connections 

### DIFF
--- a/frog/imports/ui/GraphEditor/Graph.js
+++ b/frog/imports/ui/GraphEditor/Graph.js
@@ -23,7 +23,7 @@ const scrollMouse = e => {
 };
 
 const mousemove = e => {
-  store.ui.socialMove(e.clientX, e.clientY);
+  store.ui.socialMove(e.clientX + 10, e.clientY - 75);
 };
 
 export default connect(


### PR DESCRIPTION
Because of the 2 top bar, there was a glitch in the Y axis that wasn't visible when you try only to move an activity (in chrome and FF), but when you try to do a connection, it's obvious (even if it is only a visual problem, the connections only depends on the mouse and not the end of the line)
So I tricked it a bit by adding the Y size of the top-bars. It's not optimal but  it seems to work.