### PR TITLE
Fix 784

### DIFF
--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
@@ -42,7 +42,7 @@ const RawEditActivity = ({
   const graphActivity = props.store.activityStore.all.find(
     act => act.id === activity._id
   );
-  const outgoingConnections = props.store.connectionStore.all.find(
+  const outgoingConnections = props.store.connectionStore.all.filter(
     conn => conn.source.id === activity._id
   );
 


### PR DESCRIPTION
@houshuang It has nothing to do with the renaming in `validator`. It came from your H5P PR which was too big for me to read every line and I did not check that it did not break the graph editor. It would be great if we can add the test "Can edit and activity with an outgoing connection".

You should read the documentation for `find` and `filter`. Flow does not tell you that you are calling `map` on a non-array, because you might have an object with a function field `map`. What should we do about this?  

Closes #784
