### PR TITLE
Send log message on mount of activity

### DIFF
--- a/frog/imports/ui/StudentView/Runner.jsx
+++ b/frog/imports/ui/StudentView/Runner.jsx
@@ -97,18 +97,7 @@ const Runner = ({ path, activity, sessionId, object, single }) => {
   }
 };
 
-export const RunActivity = ({
-  reactiveId,
-  logger,
-  activityData,
-  username,
-  userid,
-  stream,
-  groupingValue,
-  activityTypeId,
-  readOnly,
-  sessionId
-}: {
+type PropsT = {
   reactiveId: string,
   logger: Function,
   activityData?: Object | null,
@@ -119,32 +108,51 @@ export const RunActivity = ({
   activityTypeId: string,
   readOnly?: boolean,
   sessionId: string
-}) => {
-  const activityType = activityTypesObj[activityTypeId];
-  const RunComp = activityType.ActivityRunner;
-  RunComp.displayName = activityType.id;
-  const formatProduct = activityType.formatProduct;
-  const transform = formatProduct
-    ? x => formatProduct((activityData && activityData.config) || {}, x)
-    : x => x;
-  const ActivityToRun = ReactiveHOC(reactiveId, undefined, transform, readOnly)(
-    RunComp
-  );
-
-  return (
-    <ActivityToRun
-      activityData={activityData}
-      userInfo={{
-        name: username,
-        id: userid
-      }}
-      logger={logger}
-      stream={stream}
-      groupingValue={groupingValue}
-      sessionId={sessionId}
-    />
-  );
 };
+
+export class RunActivity extends React.Component<PropsT, {}> {
+  ActivityToRun: any;
+
+  constructor(props: PropsT) {
+    super();
+    const { reactiveId, activityData, activityTypeId, readOnly } = props;
+    const activityType = activityTypesObj[activityTypeId];
+    const RunComp = activityType.ActivityRunner;
+    RunComp.displayName = activityType.id;
+    const formatProduct = activityType.formatProduct;
+    const transform = formatProduct
+      ? x => formatProduct((activityData && activityData.config) || {}, x)
+      : x => x;
+
+    this.ActivityToRun = ReactiveHOC(
+      reactiveId,
+      undefined,
+      transform,
+      readOnly
+    )(RunComp);
+  }
+
+  componentDidMount() {
+    this.props.logger({ type: 'activityDidMount' });
+  }
+
+  render() {
+    const Activity = this.ActivityToRun;
+    return (
+      <Activity
+        activityData={this.props.activityData}
+        userInfo={{
+          name: this.props.username,
+          id: this.props.userid
+        }}
+        logger={this.props.logger}
+        stream={this.props.stream}
+        groupingValue={this.props.groupingValue}
+        sessionId={this.props.sessionId}
+      />
+    );
+  }
+}
 
 export default createContainer(({ activity }) => {
   const object = Objects.findOne(activity._id);


### PR DESCRIPTION
This sends a log message for each activity exactly when it mounts in the browser. However, note that this will generate a huge amount of messages - for example 200 students who have three activities open on next.activity, will in a few seconds generate 600 messages. We need more testing to determine whether this is a problem or not.