### PR TITLE
Disable keys in ac-stroop during waiting

### DIFF
--- a/ac/ac-stroop/src/ActivityRunner.jsx
+++ b/ac/ac-stroop/src/ActivityRunner.jsx
@@ -128,6 +128,7 @@ const Question = props => {
     dataFn.numIncr(isCorrectAnswer, 'score');
     // Goes on to next question
     setQuestion('waiting');
+    Mousetrap.reset();
   };
 
   Mousetrap.bind('y', onClick(true));


### PR DESCRIPTION
Fixes bug that let students press y/n even while waiting for a new question