### PR TITLE
fix the close preview problem

### DIFF
--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/ChooseActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/ChooseActivity.js
@@ -13,8 +13,7 @@ import { connect } from '../../store';
 type StateT = {
   expanded: ?string,
   searchStr: string,
-  showInfo: ?string,
-  libraryOpen: boolean
+  showInfo: ?string
 };
 
 type PropsT = {
@@ -32,10 +31,13 @@ export class ChooseActivityType extends Component<PropsT, StateT> {
     this.state = {
       expanded: null,
       searchStr: '',
-      showInfo: null,
-      libraryOpen: false
+      showInfo: null
     };
     this.inputRef = null;
+  }
+
+  componentWillUnmount() {
+    return this.props.store && this.props.store.ui.setLibraryOpen(false);
   }
 
   render() {
@@ -65,8 +67,8 @@ export class ChooseActivityType extends Component<PropsT, StateT> {
       )
       .sort((x: Object, y: Object) => (x.meta.name < y.meta.name ? -1 : 1));
 
-    const closeLibrary = () => this.setState({ libraryOpen: false });
-
+    const closeLibrary = () =>
+      this.props.store && this.props.store.ui.setLibraryOpen(false);
     return (
       <div
         style={{
@@ -103,7 +105,10 @@ export class ChooseActivityType extends Component<PropsT, StateT> {
           </div>
           <Button
             className={
-              this.state.libraryOpen ? 'btn btn-success' : 'btn btn-primary'
+              this.props.store &&
+              (this.props.store.ui.libraryOpen
+                ? 'btn btn-success'
+                : 'btn btn-primary')
             }
             style={{
               position: 'relative',
@@ -112,64 +117,72 @@ export class ChooseActivityType extends Component<PropsT, StateT> {
               width: '100px'
             }}
             onClick={() =>
-              this.setState({ libraryOpen: !this.state.libraryOpen })
+              this.props.store &&
+              this.props.store.ui.setLibraryOpen(
+                !this.props.store.ui.libraryOpen
+              )
             }
           >
             {' '}
-            {this.state.libraryOpen ? 'New activity' : 'Library'}{' '}
+            {this.props.store &&
+              (this.props.store.ui.libraryOpen
+                ? 'New activity'
+                : 'Library')}{' '}
           </Button>
         </div>
-        {this.state.libraryOpen ? (
-          <ActivityLibrary
-            {...closeLibrary}
-            activityId={this.props.activity._id}
-            searchStr={this.state.searchStr}
-            store={this.props.store}
-          />
-        ) : (
-          <div
-            className="list-group"
-            style={{
-              height: '93%',
-              width: '100%',
-              overflowY: 'scroll',
-              transform: 'translateY(10px)'
-            }}
-          >
-            {filteredList.length === 0 ? (
-              <div
-                style={{
-                  marginTop: '20px',
-                  marginLeft: '10px',
-                  fontSize: '40px'
-                }}
-              >
-                No result
-              </div>
-            ) : (
-              filteredList.map((x: ActivityPackageT) => (
-                <ListComponent
-                  hasPreview={
-                    !this.props.hidePreview && x.meta.exampleData !== undefined
-                  }
-                  onSelect={() => select(x)}
-                  showExpanded={this.state.expanded === x.id}
-                  expand={() => this.setState({ expanded: x.id })}
-                  key={x.id}
-                  onPreview={() =>
-                    this.props.store &&
-                    this.props.store.ui.setShowPreview({
-                      activityTypeId: x.id
-                    })
-                  }
-                  object={x}
-                  searchS={this.state.searchStr}
-                  eventKey={x.id}
-                />
-              ))
-            )}
-          </div>
-        )}
+        {this.props.store &&
+          (this.props.store.ui.libraryOpen ? (
+            <ActivityLibrary
+              {...closeLibrary}
+              activityId={this.props.activity._id}
+              searchStr={this.state.searchStr}
+              store={this.props.store}
+            />
+          ) : (
+            <div
+              className="list-group"
+              style={{
+                height: '93%',
+                width: '100%',
+                overflowY: 'scroll',
+                transform: 'translateY(10px)'
+              }}
+            >
+              {filteredList.length === 0 ? (
+                <div
+                  style={{
+                    marginTop: '20px',
+                    marginLeft: '10px',
+                    fontSize: '40px'
+                  }}
+                >
+                  No result
+                </div>
+              ) : (
+                filteredList.map((x: ActivityPackageT) => (
+                  <ListComponent
+                    hasPreview={
+                      !this.props.hidePreview &&
+                      x.meta.exampleData !== undefined
+                    }
+                    onSelect={() => select(x)}
+                    showExpanded={this.state.expanded === x.id}
+                    expand={() => this.setState({ expanded: x.id })}
+                    key={x.id}
+                    onPreview={() =>
+                      this.props.store &&
+                      this.props.store.ui.setShowPreview({
+                        activityTypeId: x.id
+                      })
+                    }
+                    object={x}
+                    searchS={this.state.searchStr}
+                    eventKey={x.id}
+                  />
+                ))
+              )}
+            </div>
+          ))}
         {this.state.showInfo !== null && (
           <Preview
             activityTypeId={this.state.showInfo}

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/ChooseActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/ChooseActivity.js
@@ -36,10 +36,6 @@ export class ChooseActivityType extends Component<PropsT, StateT> {
     this.inputRef = null;
   }
 
-  componentWillUnmount() {
-    return this.props.store && this.props.store.ui.setLibraryOpen(false);
-  }
-
   render() {
     const select = this.props.onSelect
       ? this.props.onSelect

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/index.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/index.js
@@ -7,11 +7,10 @@ import ChooseActivity from './ChooseActivity';
 import EditActivity from './EditActivity';
 
 export default withTracker(({ id }) => ({ activity: Activities.findOne(id) }))(
-  ({ activity }) => {
-    if (activity.activityType && activity.activityType !== '') {
-      return <EditActivity activity={activity} />;
-    } else {
-      return <ChooseActivity activity={activity} />;
-    }
-  }
+  ({ activity }) =>
+    activity.activityType && activity.activityType !== '' ? (
+      <EditActivity activity={activity} />
+    ) : (
+      <ChooseActivity activity={activity} />
+    )
 );

--- a/frog/imports/ui/GraphEditor/store/elemClass.js
+++ b/frog/imports/ui/GraphEditor/store/elemClass.js
@@ -6,6 +6,7 @@ export default class Elem {
   constructor() {
     extendObservable(this, {
       select: action(() => {
+        store.ui.setLibraryOpen(false);
         if (store.state.mode === 'readOnly') {
           if (this.klass !== 'connection') {
             store.ui.setShowInfo(this.klass, this.id);

--- a/frog/imports/ui/GraphEditor/store/uiStore.js
+++ b/frog/imports/ui/GraphEditor/store/uiStore.js
@@ -20,6 +20,7 @@ export default class uiStore {
       scrollIntervalID: '',
       selected: undefined,
       showPreview: false,
+      libraryOpen: false,
       showInfo: false,
 
       setIsSvg: action((isSvg: boolean) => {
@@ -89,6 +90,10 @@ export default class uiStore {
 
       setShowPreview: action((x: ?Object) => {
         this.showPreview = x;
+      }),
+
+      setLibraryOpen: action((x: boolean) => {
+        this.libraryOpen = x;
       }),
 
       cancelInfo: action(() => {


### PR DESCRIPTION
The only thing left is when you have 2 activities w/o type and you go from one to the other, the variable libraryOpen of the store stays the same since the ChooseActivity doesn't unmount.

close #832 