### PR TITLE
Fixing file upload

### DIFF
--- a/frog/client/main.jsx
+++ b/frog/client/main.jsx
@@ -4,6 +4,9 @@ import { render } from 'react-dom';
 
 import App from '../imports/ui/App';
 
+global.Buffer = function() {};
+global.Buffer.isBuffer = () => false;
+
 Meteor.startup(() => {
   render(<App />, document.getElementById('render-target'));
 });

--- a/frog/client/main.jsx
+++ b/frog/client/main.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Meteor } from 'meteor/meteor';
 import { render } from 'react-dom';
+import Buffer from 'buffer';
 
 import App from '../imports/ui/App';
 
-global.Buffer = function() {};
-global.Buffer.isBuffer = () => false;
+global.Buffer = Buffer.Buffer;
 
 Meteor.startup(() => {
   render(<App />, document.getElementById('render-target'));

--- a/frog/package.json
+++ b/frog/package.json
@@ -28,6 +28,7 @@
     "ac-video": "1.0.0",
     "bcrypt": "^1.0.3",
     "body-parser": "^1.18.2",
+    "buffer": "^5.1.0",
     "bufferutil": "^3.0.3",
     "color-hash": "^1.0.3",
     "cuid": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1551,6 +1551,13 @@ buffer@^5.0.3:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
+buffer@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.1.0.tgz#c913e43678c7cb7c8bd16afbcddb6c5505e8f9fe"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
 buffers@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"


### PR DESCRIPTION
Buffer was previously supplied by Meteor, but no more after upgrade ([link](https://forums.meteor.com/t/solved-meteor-1-5-buffer-is-not-defined/36902/9)), this broke the file upload in ac-image.