### PR TITLE
Fix crash in sidepanel

### DIFF
--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/index.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/index.js
@@ -11,7 +11,7 @@ export default withTracker(({ id }) => ({ activity: Activities.findOne(id) }))(
     if (!activity) {
       return null;
     }
-    if (activity.activityType && activity.activityType !== '') {
+    if (activity.activityType) {
       return <EditActivity activity={activity} />;
     } else {
       return <ChooseActivity activity={activity} />;

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/index.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/index.js
@@ -8,6 +8,9 @@ import EditActivity from './EditActivity';
 
 export default withTracker(({ id }) => ({ activity: Activities.findOne(id) }))(
   ({ activity }) => {
+    if (!activity) {
+      return null;
+    }
     if (activity.activityType && activity.activityType !== '') {
       return <EditActivity activity={activity} />;
     } else {

--- a/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/index.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/index.js
@@ -17,7 +17,7 @@ export default withTracker(({ id }) => ({ operator: Operators.findOne(id) }))(
     if (!operator) {
       return null;
     }
-    if (operator.operatorType && operator.operatorType !== '') {
+    if (operator.operatorType) {
       return <EditOperator operator={operator} />;
     } else {
       return <ChooseOperatorType operator={operator} />;

--- a/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/index.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/index.js
@@ -14,6 +14,9 @@ const ChooseOperatorType = connect(ChooseOperatorTypeComp);
 
 export default withTracker(({ id }) => ({ operator: Operators.findOne(id) }))(
   ({ operator }) => {
+    if (!operator) {
+      return null;
+    }
     if (operator.operatorType && operator.operatorType !== '') {
       return <EditOperator operator={operator} />;
     } else {


### PR DESCRIPTION
I got a crash several times when I deleted an activity while the sidepanel was open. This isn't supposed to happen, but maybe there is some kind of synchronicity problem - because the activity component subscribes to the store independently, maybe it gets rerendered when an activity is deleted slightly before the sidepanel/index component gets rerendered (and realizes there is no selected activity, so it shouldn't show the activity sidepanel).

Anyway this should fix the bug.