### PR TITLE
Chat Redesign

### DIFF
--- a/ac/ac-chat/src/Chat.jsx
+++ b/ac/ac-chat/src/Chat.jsx
@@ -70,11 +70,6 @@ const Chatmsg = ({ msg }) => (
 export default class Chat extends Component<ActivityRunnerT> {
   node: any;
 
-  constructor(props: Object) {
-    super(props);
-    this.scrollToBottom = this.scrollToBottom.bind(this);
-  }
-
   scrollToBottom = () => {
     const scrollHeight = this.node.scrollHeight;
     const height = this.node.clientHeight;

--- a/ac/ac-chat/src/Chat.jsx
+++ b/ac/ac-chat/src/Chat.jsx
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
 
 import { type ActivityRunnerT, uuid } from 'frog-utils';
 
@@ -69,7 +68,7 @@ const Chatmsg = ({ msg }) => (
 );
 
 export default class Chat extends Component<ActivityRunnerT> {
-  ref: any;
+  node: any;
 
   constructor(props: Object) {
     super(props);
@@ -77,11 +76,13 @@ export default class Chat extends Component<ActivityRunnerT> {
   }
 
   scrollToBottom = () => {
-    const scrollHeight = this.ref.scrollHeight;
-    const height = this.ref.clientHeight;
+    const scrollHeight = this.node.scrollHeight;
+    const height = this.node.clientHeight;
     const maxScrollTop = scrollHeight - height;
-    ReactDOM.findDOMNode(this.ref).scrollTop =
-      maxScrollTop > 0 ? maxScrollTop : 0;
+    const domNode = this.node;
+    if (domNode instanceof Element) {
+      domNode.scrollTop = Math.max(maxScrollTop, 0);
+    }
   };
   componentDidMount() {
     this.scrollToBottom();
@@ -97,7 +98,7 @@ export default class Chat extends Component<ActivityRunnerT> {
     return (
       <div style={styles.root}>
         <h4 style={styles.header}>{activityData.config.title}</h4>
-        <div style={styles.content} ref={ref => (this.ref = ref)}>
+        <div style={styles.content} ref={node => (this.node = node)}>
           {data.map(chatmsg => <Chatmsg msg={chatmsg} key={chatmsg.id} />)}
         </div>
 

--- a/ac/ac-chat/src/Chat.jsx
+++ b/ac/ac-chat/src/Chat.jsx
@@ -68,7 +68,7 @@ const Chatmsg = ({ msg }) => (
   </div>
 );
 
-export default class Chat extends Component {
+export default class Chat extends Component<ActivityRunnerT> {
   ref: any;
 
   constructor(props: Object) {
@@ -83,7 +83,6 @@ export default class Chat extends Component {
     ReactDOM.findDOMNode(this.ref).scrollTop =
       maxScrollTop > 0 ? maxScrollTop : 0;
   };
-
   componentDidMount() {
     this.scrollToBottom();
   }

--- a/ac/ac-chat/src/Chat.jsx
+++ b/ac/ac-chat/src/Chat.jsx
@@ -82,9 +82,6 @@ export default class Chat extends Component {
     const maxScrollTop = scrollHeight - height;
     ReactDOM.findDOMNode(this.ref).scrollTop =
       maxScrollTop > 0 ? maxScrollTop : 0;
-    // console.log(scrollHeight, height, maxScrollTop);
-
-    // console.log('fired');
   };
 
   componentDidMount() {

--- a/ac/ac-chat/src/Chat.jsx
+++ b/ac/ac-chat/src/Chat.jsx
@@ -1,33 +1,122 @@
 // @flow
 
-import React from 'react';
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
 
 import { type ActivityRunnerT, uuid } from 'frog-utils';
 
 import TextInput from './TextInput';
 
-const Chatmsg = ({ msg }) => (
-  <li>
-    {msg.user}: {msg.msg}
-  </li>
-);
+const styles = {
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    height: '100%',
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"'
+  },
+  header: {
+    flex: '0 0 auto',
+    margin: '0',
+    boxShadow: '0 4px 6px 0 hsla(0,0%,0%,0.2)',
+    padding: '20px 0',
+    color: 'white',
+    background: 'rgb(71, 118, 230)',
+    display: 'flex',
+    justifyContent: 'center'
+  },
+  inputContainer: {
+    display: 'flex',
+    flex: '0 0 auto',
+    flexDirection: 'column',
+    background: '#EAEAEA',
+    justifyContent: 'center',
+    padding: '20px'
+  },
+  content: {
+    flex: '1 1 auto',
+    overflowY: 'auto',
+    listStyle: 'none',
+    padding: '0 20px'
+  },
+  textInput: {
+    fontSize: '12pt',
+    padding: '20px',
+    borderRadius: '5px',
+    border: '1px solid lightgrey',
+    resize: 'none'
+  },
+  msg: {
+    margin: '20px 0',
+    padding: '15px',
+    border: '1px solid #e0e0e0',
+    borderRadius: '200px 200px 200px 0px',
+    width: 'fit-content'
+  },
+  user: {
+    fontSize: '10pt',
+    paddingBottom: '2px',
+    color: '#0606066b'
+  }
+};
 
-export default ({
-  logger,
-  activityData,
-  data,
-  dataFn,
-  userInfo
-}: ActivityRunnerT) => (
-  <div>
-    <h4>{activityData.config.title}</h4>
-    <ul>{data.map(chatmsg => <Chatmsg msg={chatmsg} key={chatmsg.id} />)}</ul>
-    <TextInput
-      callbackFn={e => {
-        const id = uuid();
-        dataFn.listAppend({ msg: e, user: userInfo.name, id });
-        logger({ type: 'chat', value: e, itemId: id });
-      }}
-    />
+const Chatmsg = ({ msg }) => (
+  <div style={styles.msg}>
+    <div style={styles.user}>{msg.user}</div>
+    {msg.msg}
   </div>
 );
+
+export default class Chat extends Component {
+  ref: any;
+
+  constructor(props: Object) {
+    super(props);
+    this.scrollToBottom = this.scrollToBottom.bind(this);
+  }
+
+  scrollToBottom = () => {
+    const scrollHeight = this.ref.scrollHeight;
+    const height = this.ref.clientHeight;
+    const maxScrollTop = scrollHeight - height;
+    ReactDOM.findDOMNode(this.ref).scrollTop =
+      maxScrollTop > 0 ? maxScrollTop : 0;
+    // console.log(scrollHeight, height, maxScrollTop);
+
+    // console.log('fired');
+  };
+
+  componentDidMount() {
+    this.scrollToBottom();
+  }
+
+  componentDidUpdate() {
+    this.scrollToBottom();
+  }
+
+  render() {
+    const { activityData, data, dataFn, userInfo, logger } = this.props;
+
+    return (
+      <div style={styles.root}>
+        <h4 style={styles.header}>{activityData.config.title}</h4>
+        <div style={styles.content} ref={ref => (this.ref = ref)}>
+          {data.map(chatmsg => <Chatmsg msg={chatmsg} key={chatmsg.id} />)}
+        </div>
+
+        <div style={styles.inputContainer}>
+          <TextInput
+            style={styles.textInput}
+            callbackFn={e => {
+              const id = uuid();
+              dataFn.listAppend({ msg: e, user: userInfo.name, id });
+              logger({ type: 'chat', value: e, itemId: id });
+              this.scrollToBottom();
+            }}
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/ac/ac-chat/src/TextInput.jsx
+++ b/ac/ac-chat/src/TextInput.jsx
@@ -28,8 +28,11 @@ class TextInput extends Component<Object, TextInputStateT> {
 
   render() {
     return (
-      <input
+      <textarea
+        rows="2"
+        cols="50"
         type="text"
+        style={this.props.style}
         value={this.state.value}
         onChange={this.handleChange}
         onKeyPress={this.onKeyPress}


### PR DESCRIPTION
This is how it looks now. 

Student View: 
<img width="1440" alt="screen shot 2018-02-28 at 8 55 33 am" src="https://user-images.githubusercontent.com/10279686/36776209-3d5398de-1c65-11e8-9e11-d204edacb227.png">

On Mobile: 
![image](https://user-images.githubusercontent.com/10279686/36776474-3032e7f8-1c66-11e8-9253-86adda915f93.png)

Activity Preview: 
<img width="1440" alt="screen shot 2018-02-28 at 8 54 35 am" src="https://user-images.githubusercontent.com/10279686/36776210-3d69e5ee-1c65-11e8-8ad7-1ed64d67527c.png">

While doing an activity (Brainstorm + Chat): 
![image](https://user-images.githubusercontent.com/10279686/36783227-ac3ba73a-1c7b-11e8-863e-c9b0428e4026.png)


Tech Notes: 
* Fully adaptable UI. 
* Uses vanilla CSS. No MUI/Bootstrap. 

Work left (which I need to get some idea about): 
- [ ] Get feedback from all. (Design is an iterative process)
- [ ] Figure out where to put CSS. What is the current approach we are taking? As far as I can see we have some CSS that is inside CSS files and some using inline styles. 
- [ ] Missing types for flow. 
