### PR TITLE
Small fixes to op-hypothesis

### DIFF
--- a/op/op-hypothesis/src/index.js
+++ b/op/op-hypothesis/src/index.js
@@ -28,23 +28,29 @@ export const config = {
     }
   }
 };
-const safeFirst = ary => (ary.length > 0 ? ary[0] : '');
 const validateConfig = [
   formData =>
     formData.tag || formData.url ? null : { err: 'You need either tag or URL' }
 ];
 
+const safeFirst = ary => (ary.length > 0 ? ary[0] : '');
+
 const getText = ary =>
-  ary ? safeFirst(compact(ary.map(y => y.exact))).replace('\t', '') : '';
+  ary ? safeFirst(compact(ary.map(y => y.exact))).replace(/\t/gi, '') : '';
 
 const mapQuery = query => {
   const res = query.rows
     .map(x => ({
       id: uuid(),
-      content: x.text,
-      title: getText(x.target && x.target.length > 0 && x.target[0].selector)
+      content: x.text && x.text.replace(/\t/gi, ''),
+      title: getText(x.target && x.target.length > 0 && x.target[0].selector),
+      doc:
+        x.document &&
+        x.document.title &&
+        x.document.title[0] &&
+        x.document.title[0].replace(/\t/gi, '')
     }))
-    .filter(x => x.title);
+    .filter(x => x.title || x.content);
   return wrapUnitAll(res);
 };
 
@@ -57,7 +63,7 @@ export const operator = (configData: {
     tag: configData.tag,
     source: configData.url
   });
-  const url = 'https://hypothes.is/api/search?' + query;
+  const url = 'https://hypothes.is/api/search?' + query + '&limit=200';
   return fetch(url)
     .then(e => e.json())
     .then(mapQuery);


### PR DESCRIPTION
I needed to use op-hypothesis, and found a few small fixes which makes the output more robust, and also fetches more annotations (which you can later reduce with settings etc). (I know we should fix the tests, but I think it's pretty hard. Anyway it should work unless hypothesis changes its API... should probably be more robust aginst that, but anyway if the API is broken or down, the whole script is not going to work anyway)...