### PR TITLE
Adding error boundary for individual activities

### DIFF
--- a/frog/imports/ui/StudentView/ReactiveHOC.jsx
+++ b/frog/imports/ui/StudentView/ReactiveHOC.jsx
@@ -8,6 +8,7 @@ import {
   getDisplayName,
   uuid
 } from 'frog-utils';
+import { ErrorBoundary } from '../App/ErrorBoundary';
 
 import { uploadFile } from '../../api/openUploads';
 import { connection } from '../App/connection';
@@ -82,13 +83,15 @@ const ReactiveHOC = (
 
     render = () =>
       this.state.data ? (
-        <WrappedComponent
-          uuid={this.state.uuid}
-          dataFn={this.state.dataFn}
-          uploadFn={uploadFile}
-          data={this.state.data}
-          {...this.props}
-        />
+        <ErrorBoundary msg="Activity crashed, try reloading">
+          <WrappedComponent
+            uuid={this.state.uuid}
+            dataFn={this.state.dataFn}
+            uploadFn={uploadFile}
+            data={this.state.data}
+            {...this.props}
+          />
+        </ErrorBoundary>
       ) : (
         <Spinner />
       );


### PR DESCRIPTION
In ReactiveHOC is actually the best place to put it to make sure it works both in Preview and in actual running. 

In the example below, four activities have crashed, but you can still use the interface fully. 

![screen shot 2018-03-07 at 13 57 47](https://user-images.githubusercontent.com/61575/37093594-29cf541e-2210-11e8-8de9-6c2c786c9758.png)
