### PR TITLE
Always let teacher log in

### DIFF
--- a/frog/server/joinSession.js
+++ b/frog/server/joinSession.js
@@ -11,7 +11,7 @@ function sessionJoin(slug: string) {
   if (!session) {
     return { result: 'error', message: 'No such session' };
   }
-  if (session.tooLate) {
+  if (session.tooLate && user.username !== 'teacher') {
     return { result: 'error', message: 'Too late' };
   }
 


### PR DESCRIPTION
Teacher cannot access p2 activities, so should always be able to join a session.