### PR TITLE
Change Progress Calculation

### DIFF
--- a/ac/ac-stroop/src/ActivityRunner.jsx
+++ b/ac/ac-stroop/src/ActivityRunner.jsx
@@ -364,14 +364,22 @@ const Question = props => {
 };
 
 const Main = withState('question', 'setQuestion', null)(props => {
-  const { activityData, question, setQuestion, data, dataFn } = props;
+  const { activityData, question, setQuestion, data, dataFn, logger } = props;
   const { maxQuestions, delay } = activityData.config;
   const lang = data.language;
   const { name } = props.userInfo;
   if (!lang) {
     return <Form onSubmit={l => dataFn.objInsert(l, 'language')} name={name} />;
   } else if (question === null) {
-    const start = () => setQuestion('waiting');
+    const start = () => {
+      setQuestion('waiting');
+      logger([
+        {
+          type: 'progress',
+          value: data.progress / activityData.config.questions.length
+        }
+      ]);
+    };
     const { guidelines } = activityData.config[lang];
     return <Guidelines start={start} guidelines={guidelines} lang={lang} />;
   } else if (question === 'waiting') {

--- a/ac/ac-timedQuiz/src/ActivityRunner.jsx
+++ b/ac/ac-timedQuiz/src/ActivityRunner.jsx
@@ -164,13 +164,21 @@ const Question = props => {
 };
 
 const Main = withState('question', 'setQuestion', null)(props => {
-  const { activityData, question, setQuestion, data } = props;
+  const { activityData, question, setQuestion, data, logger } = props;
   const { questions, delay, guidelines } = activityData.config;
   const { name } = props.userInfo;
   let shuffledQ = questionsWithIndex(props);
   if (question === null) {
     shuffledQ = shuffledQuestions(props);
-    const start = () => setQuestion('waiting');
+    const start = () => {
+      setQuestion('waiting');
+      logger([
+        {
+          type: 'progress',
+          value: data.progress / activityData.config.questions.length
+        }
+      ]);
+    };
     return <Guidelines start={start} guidelines={guidelines} name={name} />;
   } else if (question === 'waiting') {
     const next = () => {

--- a/frog-utils/src/dashboards/progress.js
+++ b/frog-utils/src/dashboards/progress.js
@@ -52,7 +52,7 @@ const LineChart = ({
 const TIMEWINDOW = 5;
 
 const Viewer = TimedComponent((props: Object) => {
-  const { data, instances, activity, timeNow } = props;
+  const { data, activity, timeNow } = props;
 
   const numWindow =
     activity.actualClosingTime === undefined
@@ -68,7 +68,7 @@ const Viewer = TimedComponent((props: Object) => {
             TIMEWINDOW
         );
   const timingData = [[0, 0, 0]];
-  const factor = 100 / Math.max(Object.keys(instances).length, 1);
+  const factor = 100 / Math.max(Object.keys(data.progress).length, 1);
   for (let i = 0, j = -1; i <= numWindow; i += 1) {
     while (
       data.timing.length > j + 1 &&


### PR DESCRIPTION
The progress calculation is changed to just students that have started the activity and students are now marked as starting the activity when they hit the start button (or other specified starting point at the beginning of an activity).