### PR TITLE
Improving Preview

### DIFF
--- a/frog/imports/ui/App/APICall.js
+++ b/frog/imports/ui/App/APICall.js
@@ -32,6 +32,7 @@ export default ({ data }) => {
       <ApiForm
         activityType={data.activityType}
         config={data.config}
+        hidePreview
         hideValidator={data.hideValidator}
       />
     );

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/ChooseActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/ChooseActivity.js
@@ -173,11 +173,10 @@ export class ChooseActivityType extends Component<PropsT, StateT> {
                     onPreview={() => {
                       if (this.props.onPreview) {
                         this.props.onPreview(x.id);
-                      } else {
-                        this.props.store &&
-                          this.props.store.ui.setShowPreview({
-                            activityTypeId: x.id
-                          });
+                      } else if (this.props.store) {
+                        this.props.store.ui.setShowPreview({
+                          activityTypeId: x.id
+                        });
                       }
                     }}
                     object={x}

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/ChooseActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/ChooseActivity.js
@@ -20,7 +20,9 @@ type PropsT = {
   store?: Object,
   hidePreview?: boolean,
   onSelect?: Function,
-  activity: ActivityDbT
+  onPreview?: Function,
+  activity: ActivityDbT,
+  onlyHasPreview?: boolean
 };
 
 export class ChooseActivityType extends Component<PropsT, StateT> {
@@ -37,6 +39,9 @@ export class ChooseActivityType extends Component<PropsT, StateT> {
   }
 
   render() {
+    const activityTypesFiltered = this.props.onlyHasPreview
+      ? activityTypes.filter(x => x.meta.exampleData !== undefined)
+      : activityTypes;
     const select = this.props.onSelect
       ? this.props.onSelect
       : activityType => {
@@ -54,7 +59,7 @@ export class ChooseActivityType extends Component<PropsT, StateT> {
         searchStr: e.target.value.toLowerCase()
       });
 
-    const filteredList = activityTypes
+    const filteredList = activityTypesFiltered
       .filter(
         x =>
           x.meta.name.toLowerCase().includes(this.state.searchStr) ||
@@ -165,12 +170,16 @@ export class ChooseActivityType extends Component<PropsT, StateT> {
                     showExpanded={this.state.expanded === x.id}
                     expand={() => this.setState({ expanded: x.id })}
                     key={x.id}
-                    onPreview={() =>
-                      this.props.store &&
-                      this.props.store.ui.setShowPreview({
-                        activityTypeId: x.id
-                      })
-                    }
+                    onPreview={() => {
+                      if (this.props.onPreview) {
+                        this.props.onPreview(x.id);
+                      } else {
+                        this.props.store &&
+                          this.props.store.ui.setShowPreview({
+                            activityTypeId: x.id
+                          });
+                      }
+                    }}
                     object={x}
                     searchS={this.state.searchStr}
                     eventKey={x.id}

--- a/frog/imports/ui/GraphEditor/SidePanel/ApiForm.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ApiForm.js
@@ -10,18 +10,25 @@ import validateConfig from '/imports/api/validateConfig';
 import { ShowErrorsRaw, ValidButtonRaw } from '../Validator';
 import ConfigForm from './ConfigForm';
 import { ChooseActivityType } from './ActivityPanel/ChooseActivity';
+import Store from '../store/store';
+
+const store = new Store();
+
+type ConfigPropsT = {
+  config: Object,
+  activity: ActivityDbT,
+  onConfigChange?: Function,
+  setValid: Function,
+  reload?: string
+};
 
 class Config extends React.Component<
-  { config: Object, activity: ActivityDbT, setValid: Function },
+  ConfigPropsT,
   { formData: Object, valid: any[] }
 > {
   aT: any;
 
-  constructor(props: {
-    activity: ActivityDbT,
-    setValid: Function,
-    config: Object
-  }) {
+  constructor(props: ConfigPropsT) {
     super(props);
     this.state = {
       formData: this.props.config,
@@ -45,16 +52,24 @@ class Config extends React.Component<
       this.aT.configUI
     );
     this.props.setValid(valid);
-    window.parent.postMessage(
-      {
-        type: 'frog-config',
+    if (this.props.onConfigChange) {
+      this.props.onConfigChange({
         activityType: this.aT.id,
         config: formData,
-        errors: valid,
-        valid: valid.length === 0
-      },
-      '*'
-    );
+        errors: valid
+      });
+    } else {
+      window.parent.postMessage(
+        {
+          type: 'frog-config',
+          activityType: this.aT.id,
+          config: formData,
+          errors: valid,
+          valid: valid.length === 0
+        },
+        '*'
+      );
+    }
   };
 
   render() {
@@ -68,6 +83,8 @@ class Config extends React.Component<
         <div>
           <ConfigForm
             node={this.props.activity}
+            data={this.props.config}
+            reload={this.props.reload}
             onChange={e => {
               this.setState({ formData: e.formData });
               this.check();
@@ -85,7 +102,12 @@ class Config extends React.Component<
 type PropsT = {
   activityType?: string,
   config?: Object,
-  hideValidator?: boolean
+  hideValidator?: boolean,
+  onSelect?: Function,
+  onPreview?: Function,
+  onConfigChange?: Function,
+  hidePreview?: boolean,
+  reload?: string
 };
 
 class State {
@@ -113,7 +135,7 @@ const ApiForm = observer(
     PropsT,
     {
       activity: {
-        id: string,
+        _id: string,
         activityType?: string,
         data?: Object
       }
@@ -123,12 +145,27 @@ const ApiForm = observer(
       super(props);
       this.state = {
         activity: {
-          id: '1',
+          _id: '1',
           activityType: this.props.activityType,
           data: this.props.config
         }
       };
     }
+
+    componentWillReceiveProps = nextprops => {
+      if (
+        this.props.activityType !== nextprops.activityType ||
+        this.props.config !== nextprops.config
+      ) {
+        this.setState({
+          activity: {
+            _id: '1',
+            activityType: nextprops.activityType,
+            data: nextprops.config
+          }
+        });
+      }
+    };
 
     render() {
       return (
@@ -137,9 +174,11 @@ const ApiForm = observer(
             <div>
               <div style={{ position: 'absolute', top: '10px' }}>
                 <Config
+                  onConfigChange={this.props.onConfigChange}
                   activity={this.state.activity}
                   setValid={state.setValid}
-                  config={{}}
+                  reload={this.props.reload}
+                  config={this.props.config || {}}
                 />
               </div>
               {!this.props.hideValidator && (
@@ -151,13 +190,18 @@ const ApiForm = observer(
           ) : (
             <div style={{ position: 'absolute', top: '30px' }}>
               <ChooseActivityType
+                store={store}
                 activity={this.state.activity}
-                hidePreview
-                onSelect={e =>
+                hidePreview={this.props.hidePreview}
+                onPreview={this.props.onPreview}
+                onSelect={e => {
+                  if (this.props.onSelect) {
+                    this.props.onSelect(e.id);
+                  }
                   this.setState({
-                    activity: { id: '1', activityType: e.id, config: {} }
-                  })
-                }
+                    activity: { _id: '1', activityType: e.id, config: {} }
+                  });
+                }}
               />
             </div>
           )}

--- a/frog/imports/ui/GraphEditor/SidePanel/ConfigForm.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/ConfigForm.jsx
@@ -24,12 +24,13 @@ type ConfigFormPropsT = {
   valid: any,
   refreshValidate: Function,
   reload?: any,
-  widgets?: any
+  widgets?: any,
+  data?: Object
 };
 
 export default class ConfigForm extends Component<
   ConfigFormPropsT,
-  { formData: Object }
+  { formData: Object, id?: string }
 > {
   constructor(props: ConfigFormPropsT) {
     super(props);
@@ -38,8 +39,16 @@ export default class ConfigForm extends Component<
 
   componentWillReceiveProps(nextProps: ConfigFormPropsT) {
     if (
-      this.props.node._id !== nextProps.node._id ||
-      this.props.reload !== nextProps.reload
+      this.props.reload !== nextProps.reload &&
+      this.props.data !== nextProps.data
+    ) {
+      this.setState({ formData: nextProps.data, id: nextProps.reload });
+      return;
+    }
+    if (
+      (this.props.node._id !== nextProps.node._id ||
+        this.props.reload !== nextProps.reload) &&
+      !nextProps.data
     ) {
       const coll = this.props.node.operatorType ? Operators : Activities;
       this.setState({ formData: coll.findOne(nextProps.node._id).data });
@@ -47,6 +56,12 @@ export default class ConfigForm extends Component<
   }
 
   shouldComponentUpdate(nextProps: ConfigFormPropsT): boolean {
+    if (
+      this.props.data !== nextProps.data &&
+      this.props.reload !== nextProps.reload
+    ) {
+      return true;
+    }
     if (
       this.props.node._id === nextProps.node._id &&
       this.props.reload === nextProps.reload &&
@@ -95,7 +110,12 @@ export default class ConfigForm extends Component<
 
     const nodeConfig = this.props.nodeType.config;
     return nodeConfig && ![{}, undefined].includes(nodeConfig.properties) ? (
-      <EnhancedForm showErrorList={false} noHtml5Validate {...props}>
+      <EnhancedForm
+        showErrorList={false}
+        noHtml5Validate
+        {...props}
+        id={this.state.id}
+      >
         <div />
       </EnhancedForm>
     ) : null;

--- a/frog/imports/ui/Preview/Preview.js
+++ b/frog/imports/ui/Preview/Preview.js
@@ -56,6 +56,7 @@ const Collections = {};
 export const StatelessPreview = withState('reload', 'setReload', '')(
   ({
     activityTypeId,
+    noModal,
     example,
     setExample,
     showData,
@@ -74,7 +75,10 @@ export const StatelessPreview = withState('reload', 'setReload', '')(
     setFullWindow,
     reload,
     showDashExample,
-    setShowDashExample
+    setShowDashExample,
+    externalReload = '',
+    allExamples,
+    onExample
   }: {
     activityTypeId: string,
     example: number,
@@ -91,18 +95,22 @@ export const StatelessPreview = withState('reload', 'setReload', '')(
     config?: Object,
     isSeparatePage: boolean,
     setReload: string => void,
+    externalReload: string,
     windows: number,
     setWindows: number => void,
     fullWindow: boolean,
     setFullWindow: boolean => void,
-    reload: string
+    reload: string,
+    noModal?: boolean,
+    allExamples?: boolean,
+    onExample?: Function
   }) => {
     const activityType = activityTypesObj[activityTypeId];
     const RunComp = activityType.ActivityRunner;
     RunComp.displayName = activityType.id;
 
     const examples =
-      (config
+      (config && !allExamples
         ? uniqBy(activityType.meta.exampleData, x => Stringify(x.data))
         : activityType.meta.exampleData) || {};
 
@@ -303,7 +311,13 @@ export const StatelessPreview = withState('reload', 'setReload', '')(
                 key={x.title}
                 className="examples"
                 eventKey={i}
-                onClick={() => setExample(i)}
+                onClick={() => {
+                  if (onExample) {
+                    onExample(i);
+                  } else {
+                    setExample(i);
+                  }
+                }}
               >
                 {x.title}
               </NavItem>
@@ -355,7 +369,7 @@ export const StatelessPreview = withState('reload', 'setReload', '')(
                     example={example}
                     activity={activityDbObject}
                     config={activityData.config}
-                    reload={reload}
+                    reload={reload + externalReload}
                     doc={dashboard}
                     instances={users
                       .filter((_, i) => i % 2 !== 0)
@@ -371,7 +385,7 @@ export const StatelessPreview = withState('reload', 'setReload', '')(
               ) : (
                 <MosaicWindow
                   path={path}
-                  reload={reload}
+                  reload={reload + externalReload}
                   example={example}
                   title={
                     x + '/' + Math.ceil(id / 2) + ' - ' + activityType.meta.name
@@ -417,6 +431,12 @@ export const StatelessPreview = withState('reload', 'setReload', '')(
         </Draggable>
         <ReactTooltip delayShow={1000} />
       </div>
+    ) : noModal ? (
+      <React.Fragment>
+        {Controls}
+        {showLogs && !showDashExample ? <ShowLogs logs={Logs} /> : Content}
+        <ReactTooltip delayShow={1000} />
+      </React.Fragment>
     ) : (
       <Modal
         ariaHideApp={false}

--- a/frog/imports/ui/Preview/index.js
+++ b/frog/imports/ui/Preview/index.js
@@ -2,24 +2,76 @@
 import * as React from 'react';
 import { toObject, toString } from 'query-parse';
 import { withRouter } from 'react-router';
-import { A } from 'frog-utils';
+import { withState, compose } from 'recompose';
 import { omitBy } from 'lodash';
+import { uuid } from 'frog-utils';
 
-import { StatelessPreview } from './Preview';
-import { activityTypes } from '../../activityTypes';
+import ApiForm from '../GraphEditor/SidePanel/ApiForm';
+import Preview, { StatelessPreview } from './Preview';
+import { activityTypesObj } from '../../activityTypes';
 
-const ActivityList = ({ history }) => (
-  <div>
-    <h2>Choose activity to preview</h2>
-    <ul>
-      {activityTypes.filter(x => x.meta.exampleData).map(act => (
-        <li key={act.id}>
-          <A onClick={() => history.push(`/preview/${act.id}`)}>{act.id}</A>
-        </li>
-      ))}
-    </ul>
+// const store = new Store();
+const RawActivityList = ({
+  config,
+  setConfig,
+  activityType,
+  setActivityType,
+  history
+}) => (
+  <div
+    style={{
+      position: 'absolute',
+      top: '50px',
+      display: 'flex',
+      flexDirection: 'row',
+      width: '100%',
+      height: '100%'
+    }}
+  >
+    <div style={{ width: '500px', position: 'relative' }}>
+      <ApiForm
+        config={config.config}
+        reload={config.reload}
+        activityType={activityType}
+        onConfigChange={e => {
+          if (e.errors.length === 0) {
+            setConfig({ ...config, ...e });
+            setActivityType(e.activityType);
+          }
+        }}
+        onPreview={e => history.push(`/preview/${e}`)}
+      />
+    </div>
+    {config.config && (
+      <div style={{ width: '100%', height: 'calc(100% - 100px)' }}>
+        <Preview
+          noModal
+          activityTypeId={config.activityType}
+          config={config.config}
+          allExamples
+          onExample={e => {
+            setConfig({
+              ...config,
+              reload: uuid(),
+              config:
+                activityTypesObj[config.activityType].meta.exampleData[e].config
+            });
+          }}
+          externalReload={config.reload}
+          dismiss={() => {
+            setConfig({});
+            setActivityType(undefined);
+          }}
+        />
+      </div>
+    )}
   </div>
 );
+
+const ActivityList = compose(
+  withState('config', 'setConfig', {}),
+  withState('activityType', 'setActivityType', '')
+)(RawActivityList);
 
 const PreviewPage = ({
   match: { params: { activityTypeId = null, example = 0 } },

--- a/frog/imports/ui/Preview/index.js
+++ b/frog/imports/ui/Preview/index.js
@@ -35,7 +35,7 @@ const RawActivityList = ({
         activityType={activityType}
         onConfigChange={e => {
           if (e.errors.length === 0) {
-            setConfig({ ...config, ...e });
+            setConfig({ ...config, externalReload: uuid(), ...e });
             setActivityType(e.activityType);
           }
         }}
@@ -53,11 +53,12 @@ const RawActivityList = ({
             setConfig({
               ...config,
               reload: uuid(),
+              externalReload: uuid(),
               config:
                 activityTypesObj[config.activityType].meta.exampleData[e].config
             });
           }}
-          externalReload={config.reload}
+          externalReload={config.externalReload}
           dismiss={() => {
             setConfig({});
             setActivityType(undefined);

--- a/frog/imports/ui/Preview/index.js
+++ b/frog/imports/ui/Preview/index.js
@@ -10,6 +10,24 @@ import ApiForm from '../GraphEditor/SidePanel/ApiForm';
 import Preview, { StatelessPreview } from './Preview';
 import { activityTypesObj } from '../../activityTypes';
 
+const style = {
+  main: {
+    position: 'absolute',
+    top: '50px',
+    display: 'flex',
+    flexDirection: 'row',
+    width: '100%',
+    height: 'calc(100% - 50px)'
+  },
+  side: {
+    width: '500px',
+    position: 'relative',
+    overflow: 'auto',
+    height: '100%'
+  },
+  preview: { width: '100%', height: 'calc(100% - 50px)', overflow: 'visible' }
+};
+
 // const store = new Store();
 const RawActivityList = ({
   config,
@@ -18,17 +36,8 @@ const RawActivityList = ({
   setActivityType,
   history
 }) => (
-  <div
-    style={{
-      position: 'absolute',
-      top: '50px',
-      display: 'flex',
-      flexDirection: 'row',
-      width: '100%',
-      height: '100%'
-    }}
-  >
-    <div style={{ width: '500px', position: 'relative' }}>
+  <div style={style.main}>
+    <div style={style.side}>
       <ApiForm
         config={config.config}
         reload={config.reload}
@@ -43,7 +52,7 @@ const RawActivityList = ({
       />
     </div>
     {config.config && (
-      <div style={{ width: '100%', height: 'calc(100% - 100px)' }}>
+      <div style={style.preview}>
         <Preview
           noModal
           activityTypeId={config.activityType}


### PR DESCRIPTION
This PR uses the standard activity selector from the side panel on the preview page. To access the traditional preview, with stable URLs, click the preview button. If you "select" an activity type, you get a config panel, and the moment the config is valid, it will preview on the right. You can click on any of the examples to pre-fill the preview with the config, etc.

Currently there is no way of getting back to the list of the activity types if you have a config that is invalid (the X button is only shown when activity gets rendered at least once). You can just switch tabs for now to get back. 

It needs better integration with the activity library etc going forwards. 

Closes #605 