### PR TITLE
Fix preview of ac-image

### DIFF
--- a/frog/imports/ui/Preview/Preview.js
+++ b/frog/imports/ui/Preview/Preview.js
@@ -112,7 +112,7 @@ export const StatelessPreview = withState('reload', 'setReload', '')(
             const mergeFunction = activityType.mergeFunction;
             if (
               mergeFunction &&
-              example &&
+              example !== undefined &&
               activityType.meta.exampleData &&
               activityType.meta.exampleData[example]
             ) {


### PR DESCRIPTION
Originally coded tested a number, but 0 is false, so the first example would not be properly imported (somehow this didn't apply to all activities, but especially the ac-image). This fixes that.