### PR TITLE
CSS Cleanup

### DIFF
--- a/frog/client/stylesheets/bootstrap-isolated.css
+++ b/frog/client/stylesheets/bootstrap-isolated.css
@@ -3,14 +3,6 @@
  * Copyright 2011-2016 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */
-html {
-  font-family: sans-serif;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-}
-body {
-  margin: 0;
-}
 div.bootstrap article,
 div.bootstrap aside,
 div.bootstrap details,

--- a/frog/client/stylesheets/main.css
+++ b/frog/client/stylesheets/main.css
@@ -8,15 +8,4 @@ body,
   font-family: Roboto, sans-serif;
   height: 100%;
   width: 100%;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 0;
-  margin: 0;
-  font-size: 12pt;
-}
-
-#app {
-  overflow: hidden;
 }

--- a/frog/imports/ui/App/index.js
+++ b/frog/imports/ui/App/index.js
@@ -230,12 +230,10 @@ export default class Root extends React.Component<
       return (
         <ErrorBoundary>
           <Router>
-            <div style={{ width: '100%', height: '100%' }}>
-              <Switch>
-                <Route path="/:slug" component={FROGRouter} />
-                <Route component={FROGRouter} />
-              </Switch>
-            </div>
+            <Switch>
+              <Route path="/:slug" component={FROGRouter} />
+              <Route component={FROGRouter} />
+            </Switch>
           </Router>
         </ErrorBoundary>
       );

--- a/frog/imports/ui/StudentView/SessionBody.jsx
+++ b/frog/imports/ui/StudentView/SessionBody.jsx
@@ -120,26 +120,25 @@ const StudentView = ({ activities, session, token, classes }) => (
   </div>
 );
 
+const StyledStudentView = withStyles(styles)(StudentView);
+
 const SessionBody = ({
   activities,
   session,
-  token,
-  classes
+  token
 }: {
   activities: Array<Object>,
   session: Object,
-  classes: Object,
   token?: { value: string }
 }) => (
-  <div id="student" className={classes.root}>
+  <React.Fragment>
     {session.countdownStartTime && <Countdown session={session} />}
-    <StudentView
+    <StyledStudentView
       session={session}
       activities={activities}
-      classes={classes}
       token={token}
     />
-  </div>
+  </React.Fragment>
 );
 
 SessionBody.displayName = 'SessionBody';
@@ -147,4 +146,4 @@ SessionBody.displayName = 'SessionBody';
 export default withTracker(() => ({
   session: Sessions.findOne(),
   activities: Activities.find().fetch()
-}))(withStyles(styles)(SessionBody));
+}))(SessionBody);


### PR DESCRIPTION
This enables scroll on the Sessions page as a permanent fix. The height should be automatic to not allow scroll which I will take it up once I redo Sessions page.  

@lfaucon withStyles renders CSS based on the component name to make it local scoped. When we do this: 

```
styles = {
  root: {
    margin: 0
  }
}

const X = withStyles(styles)(({classes} => <div className={classes.root} />))
```

the CSS rendered on the client is `<div class="Component-root-1 /> `

whereas if you do: 

```
styles = {
  root: {
    margin: 0
  }
}

const X = ({classes} => <div className={classes.root} />)
const StyledX = withStyles(styles)(X) 
```
the CSS rendered on the client is `<div class="X-root-1 /> `

this makes CSS local scoped otherwise all components with direct withStyles will have a class of Component and then they will clash. ¯\_(ツ)_/¯

