### PR TITLE
Fixes activities in preview that don't export dashboards

### DIFF
--- a/frog/imports/ui/Preview/dashboardInPreviewAPI.js
+++ b/frog/imports/ui/Preview/dashboardInPreviewAPI.js
@@ -74,18 +74,20 @@ export const mergeData = (
   config: Object,
   startingTime?: Date
 ) => {
-  Object.keys(aT.dashboard).forEach(name => {
-    if (DocumentCache[name]) {
-      const dash = aT.dashboard[name];
-      const [doc, dataFn] = DocumentCache[name];
-      dash.mergeLog(
-        doc.data,
-        dataFn,
-        log,
-        activityDbObject(config, aT.id, startingTime)
-      );
-    }
-  });
+  if (aT.dashboard) {
+    Object.keys(aT.dashboard).forEach(name => {
+      if (DocumentCache[name]) {
+        const dash = aT.dashboard[name];
+        const [doc, dataFn] = DocumentCache[name];
+        dash.mergeLog(
+          doc.data,
+          dataFn,
+          log,
+          activityDbObject(config, aT.id, startingTime)
+        );
+      }
+    });
+  }
 };
 
 export const createLogger = (


### PR DESCRIPTION
The preview functionality was trying to run mergeData on dashboards even for activities that don't export any dashboards, like Brainstorm (has dashboard, but hasn't been upgraded to the new API). 

Closes #932