### PR TITLE
Don't require guidelines in ac-brainstorm

### DIFF
--- a/ac/ac-brainstorm/src/config.js
+++ b/ac/ac-brainstorm/src/config.js
@@ -2,7 +2,6 @@
 
 export const config = {
   type: 'object',
-  required: ['text'],
   properties: {
     text: {
       type: 'string',


### PR DESCRIPTION
It's not necessary to require guidelines in brainstorm, and easy to fix.

Note that we should revisit how we do preview, by for example separating out config and exampleData, switching between seeing examples and configuring yourself etc. This is a larger project.

Closes #933 