### PR TITLE
Automatically assign names to ac/op in graph editor

### DIFF
--- a/ac/ac-autocode/src/index.js
+++ b/ac/ac-autocode/src/index.js
@@ -16,6 +16,7 @@ import {
 const meta = {
   // the description when choosing the type of an activity
   name: 'Auto-graded coding',
+  shortName: 'Coding',
   type: 'react-component',
   shortDesc: 'Autograded code snippets',
   description:

--- a/ac/ac-ck-board/src/meta.js
+++ b/ac/ac-ck-board/src/meta.js
@@ -2,6 +2,7 @@
 
 export const meta = {
   name: 'Common Knowledge board',
+  shortName: 'CK Board',
   mode: 'collab',
   shortDesc: '2D board for placing items',
   description:

--- a/ac/ac-classifier/src/meta.js
+++ b/ac/ac-classifier/src/meta.js
@@ -2,6 +2,7 @@
 
 export default {
   name: 'Learning Component Classifier',
+  shortName: 'Classifier',
   type: 'react-component',
   shortDesc: 'Quickly display images to classify',
   description:

--- a/ac/ac-display-social/src/index.js
+++ b/ac/ac-display-social/src/index.js
@@ -6,6 +6,7 @@ import { uniq } from 'lodash';
 
 const meta = {
   name: 'Display social attribute',
+  shortName: 'Display social',
   shortDesc: 'Display the social attribute chosen',
   description: '',
   exampleData: [

--- a/ac/ac-quiz/src/meta.js
+++ b/ac/ac-quiz/src/meta.js
@@ -179,6 +179,7 @@ const capitalQuizConfig = {
 
 export default {
   name: 'Multiple-Choice Questions',
+  shortName: 'Quiz',
   shortDesc: 'Filling a MCQ form (quiz)',
   description:
     'Display a multiple-choice questions form. Can also be used for questionnaires.',

--- a/frog-utils/src/types.js
+++ b/frog-utils/src/types.js
@@ -120,6 +120,7 @@ export type ActivityPackageT = {
   type: 'react-component',
   meta: {
     name: string,
+    shortName?: string,
     shortDesc: string,
     description: string,
     exampleData?: { title: string, config?: Object, data?: any }[]
@@ -165,6 +166,7 @@ export type productOperatorT = {
   type: 'product',
   meta: {
     name: string,
+    shortName?: string,
     shortDesc: string,
     description: string
   },
@@ -182,6 +184,7 @@ export type controlOperatorT = {
   type: 'control',
   meta: {
     name: string,
+    shortName?: string,
     shortDesc: string,
     description: string
   },
@@ -199,6 +202,7 @@ export type socialOperatorT = {
   type: 'social',
   meta: {
     name: string,
+    shortName?: string,
     shortDesc: string,
     description: string
   },

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/ChooseActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/ChooseActivity.js
@@ -47,18 +47,18 @@ export class ChooseActivityType extends Component<PropsT, StateT> {
     const select = this.props.onSelect
       ? this.props.onSelect
       : aT => {
-          const graphActivity = this.props.store.activityStore.all.find(
-            act => act.id === this.props.activity._id
-          );
           const defaultConf = jsonSchemaDefaults(aT.config);
           addActivity(aT.id, defaultConf, this.props.activity._id);
-          if (this.props.activity.title === 'Unnamed') {
-            const newName =
-              activityTypesObj[aT.id].meta.shortName ||
-              activityTypesObj[aT.id].meta.name;
-            graphActivity.rename(newName);
-          }
           if (this.props.store) {
+            if (this.props.activity.title === 'Unnamed') {
+              const graphActivity = this.props.store.activityStore.all.find(
+                act => act.id === this.props.activity._id
+              );
+              const newName =
+                activityTypesObj[aT.id].meta.shortName ||
+                activityTypesObj[aT.id].meta.name;
+              graphActivity.rename(newName);
+            }
             this.props.store.addHistory();
           }
         };

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/ChooseActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/ChooseActivity.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import { type ActivityPackageT, type ActivityDbT } from 'frog-utils';
-import { activityTypes } from '/imports/activityTypes';
+import { activityTypes, activityTypesObj } from '/imports/activityTypes';
 import { addActivity } from '/imports/api/activities';
 import { Button } from 'react-bootstrap';
 import jsonSchemaDefaults from 'json-schema-defaults';
@@ -23,7 +23,8 @@ type PropsT = {
   onSelect?: Function,
   onPreview?: Function,
   activity: ActivityDbT,
-  onlyHasPreview?: boolean
+  onlyHasPreview?: boolean,
+  store: Object
 };
 
 export class ChooseActivityType extends Component<PropsT, StateT> {
@@ -46,8 +47,17 @@ export class ChooseActivityType extends Component<PropsT, StateT> {
     const select = this.props.onSelect
       ? this.props.onSelect
       : aT => {
+          const graphActivity = this.props.store.activityStore.all.find(
+            act => act.id === this.props.activity._id
+          );
           const defaultConf = jsonSchemaDefaults(aT.config);
           addActivity(aT.id, defaultConf, this.props.activity._id);
+          if (this.props.activity.title === 'Unnamed') {
+            const newName =
+              activityTypesObj[aT.id].meta.shortName ||
+              activityTypesObj[aT.id].meta.name;
+            graphActivity.rename(newName);
+          }
           if (this.props.store) {
             this.props.store.addHistory();
           }

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
@@ -133,9 +133,6 @@ const RawEditActivity = ({
                 EditComponent={RenameField}
                 activityId={activity._id}
                 value={graphActivity.title}
-                onChange={grp =>
-                  addActivity(activity.activityType, null, activity._id, grp)
-                }
               />
             </h3>
             <font size={-3}>

--- a/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/ChooseOperator.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/ChooseOperator.jsx
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 
 import type { operatorPackageT, OperatorDbT } from 'frog-utils';
 import { Operators } from '/imports/api/activities';
-import { operatorTypes } from '/imports/operatorTypes';
+import { operatorTypes, operatorTypesObj } from '/imports/operatorTypes';
 import { type StoreProp } from '../../store';
 import ListComponent from '../ListComponent';
 
@@ -22,10 +22,16 @@ export default class ChooseOperatorTypeComp extends Component<PropsT, StateT> {
 
   render() {
     const select = operatorType => {
+      const graphOperator = this.props.store.operatorStore.all.find(
+        op => op.id === this.props.operator._id
+      );
+      const newName =
+        operatorTypesObj[operatorType.id].meta.shortName ||
+        operatorTypesObj[operatorType.id].meta.name;
       Operators.update(this.props.operator._id, {
         $set: { operatorType: operatorType.id }
       });
-      this.props.store.addHistory();
+      graphOperator.rename(newName);
     };
 
     const changeSearch = e =>

--- a/op/op-aggregate-p2/src/index.js
+++ b/op/op-aggregate-p2/src/index.js
@@ -4,6 +4,7 @@ import { type productOperatorT, focusStudent } from 'frog-utils';
 
 const meta = {
   name: 'Aggregate items to p2',
+  shortName: 'Aggregate->p2',
   shortDesc: 'Aggregate items from individuals',
   description: 'Sending to appropriate groups'
 };

--- a/op/op-aggregate/src/index.js
+++ b/op/op-aggregate/src/index.js
@@ -5,6 +5,7 @@ import { type productOperatorT, wrapUnitAll } from 'frog-utils';
 
 const meta = {
   name: 'Aggregate items',
+  shortName: 'Aggregate',
   shortDesc: 'Aggregate items from groups',
   description: 'Optionally selecting the top n items by score'
 };

--- a/op/op-argue/src/index.js
+++ b/op/op-argue/src/index.js
@@ -9,10 +9,7 @@ const meta = {
   description: 'Group students with as many similar answers as possible.'
 };
 
-const config = {
-  type: 'object',
-  properties: {}
-};
+const config = {};
 
 const optim = values => values.reduce((acc, x) => acc + Math.sqrt(x), 0);
 

--- a/op/op-check-concepts/src/index.js
+++ b/op/op-check-concepts/src/index.js
@@ -4,6 +4,7 @@ import type { productOperatorT } from 'frog-utils';
 
 const meta = {
   name: 'Provide feedback based on concepts in text',
+  shortName: 'Feedback',
   shortDesc: 'Group students to argue',
   description: 'Group students with as many similar answers as possible.'
 };

--- a/op/op-control-group/src/index.js
+++ b/op/op-control-group/src/index.js
@@ -6,7 +6,7 @@ import { invert, compact } from 'lodash';
 import { config, configUI } from './config';
 
 const meta = {
-  name: 'Social -> Control',
+  name: 'Social->Control',
   shortDesc: 'Maps social attributes to control structures',
   description: ''
 };

--- a/op/op-distribute-category/src/index.js
+++ b/op/op-distribute-category/src/index.js
@@ -5,6 +5,7 @@ import { type productOperatorT, focusStudent } from 'frog-utils';
 
 const meta = {
   name: 'Distribute categorized objects',
+  shortName: 'Distribute categorized',
   shortDesc: 'Distribute categorized products objects to instances',
   description: 'Distribute categorized products objects to instances.'
 };

--- a/op/op-group-identical/src/index.js
+++ b/op/op-group-identical/src/index.js
@@ -6,6 +6,7 @@ import type { socialOperatorT } from 'frog-utils';
 
 const meta = {
   name: 'Group based on identical student data',
+  shortName: 'Group identical',
   shortDesc: 'Group identical students together',
   description: 'Group students with as many similar answers as possible'
 };

--- a/op/op-hypothesis/src/index.js
+++ b/op/op-hypothesis/src/index.js
@@ -11,6 +11,7 @@ import {
 
 export const meta = {
   name: 'Get ideas from Hypothesis',
+  shortName: 'Hypothesis',
   shortDesc: 'Get ideas from Hypothesis API',
   description: 'Collect ideas from an Hypothesis API by hashtag or document id.'
 };

--- a/op/op-performance-select/src/index.js
+++ b/op/op-performance-select/src/index.js
@@ -4,6 +4,7 @@ import type { controlOperatorT } from 'frog-utils';
 
 const meta = {
   name: 'Select activity based on past performance',
+  shortName: 'Performance split',
   shortDesc:
     'Split students into two groups based on quiz scores, and assign activities',
   description: ''

--- a/op/op-social-name/src/index.js
+++ b/op/op-social-name/src/index.js
@@ -3,6 +3,7 @@ import { type socialOperatorT, focusRole } from 'frog-utils';
 
 const meta = {
   name: 'Assign group by name',
+  shortName: 'Manually group',
   shortDesc: 'Maps students to groups by name',
   description:
     'Input a list of student names, and group names, and it matches the students to the groups'


### PR DESCRIPTION
With this PR, newly created activities and operators that have not yet been named (ie. the name = unnamed), are automatically assigned the name of the operator/activity type when that has been chosen. I also introduce a new optional shortName property, which can be used for this (if not, the normal name is used).

This will help us avoid the list of "Unnamed" activities when we quickly design a graph etc.