### PR TITLE
Fix quiz config

### DIFF
--- a/ac/ac-quiz/src/config.js
+++ b/ac/ac-quiz/src/config.js
@@ -72,5 +72,5 @@ export const validateConfig = [
 export const configUI = {
   'questions.answers.x': { conditional: 'argueWeighting' },
   'questions.answers.y': { conditional: 'argueWeighting' },
-  'questions.answers.correct': { conditional: 'hasAnswers' }
+  'questions.answers.iscorrect': { conditional: 'hasAnswers' }
 };

--- a/ac/ac-quiz/src/config.js
+++ b/ac/ac-quiz/src/config.js
@@ -72,5 +72,5 @@ export const validateConfig = [
 export const configUI = {
   'questions.answers.x': { conditional: 'argueWeighting' },
   'questions.answers.y': { conditional: 'argueWeighting' },
-  'questions.answers.iscorrect': { conditional: 'hasAnswers' }
+  'questions.answers.isCorrect': { conditional: 'hasAnswers' }
 };

--- a/ac/ac-quiz/src/meta.js
+++ b/ac/ac-quiz/src/meta.js
@@ -178,7 +178,7 @@ const capitalQuizConfig = {
 };
 
 export default {
-  name: 'Multiple-Choice Questions',
+  name: 'Quiz',
   shortName: 'Quiz',
   shortDesc: 'Filling a MCQ form (quiz)',
   description:

--- a/ac/ac-quiz/src/meta.js
+++ b/ac/ac-quiz/src/meta.js
@@ -179,7 +179,6 @@ const capitalQuizConfig = {
 
 export default {
   name: 'Quiz',
-  shortName: 'Quiz',
   shortDesc: 'Filling a MCQ form (quiz)',
   description:
     'Display a multiple-choice questions form. Can also be used for questionnaires.',


### PR DESCRIPTION
The conditional on hasAnswer/isConfig was misspelled, meaning that the field always showed up.

Also, renaming activity to Quiz, since this is what we all think it's called every time we look in the menu. Note that this is not changing the id of the activity, so it will not break any old graphs etc.