### PR TITLE
Deal with groupingKey properly in preview

### DIFF
--- a/frog/imports/ui/Preview/Content.jsx
+++ b/frog/imports/ui/Preview/Content.jsx
@@ -108,7 +108,7 @@ export default ({
           plane,
           activityData.config
         )}
-        groupingValue={instance}
+        groupingValue={plane === 1 ? idx + 1 : instance}
       />
     );
   };

--- a/frog/imports/ui/Preview/Content.jsx
+++ b/frog/imports/ui/Preview/Content.jsx
@@ -149,7 +149,13 @@ export default ({
               <MosaicWindow
                 path={path}
                 reload={JSON.stringify({ config, showData })}
-                title={name + '/' + instance + ' - ' + activityType.meta.name}
+                title={
+                  name +
+                  '/' +
+                  ['individual', instance, 'all'][plane - 1] +
+                  ' - ' +
+                  activityType.meta.name
+                }
               >
                 <Run name={name} idx={idx} instance={instance} />
               </MosaicWindow>

--- a/frog/imports/ui/Preview/Controls.jsx
+++ b/frog/imports/ui/Preview/Controls.jsx
@@ -87,7 +87,7 @@ export default (props: Object) => {
     const newPlane = 1 + plane % 3;
     setPlane(newPlane);
     setInstances(
-      users.map((name, idx) => [name, groupName(idx), 'all'][newPlane - 1])
+      users.map((name, idx) => [idx + 1, groupName(idx), 'all'][newPlane - 1])
     );
   };
 

--- a/frog/imports/ui/Preview/Controls.jsx
+++ b/frog/imports/ui/Preview/Controls.jsx
@@ -76,7 +76,7 @@ export default (props: Object) => {
     const newName = names[users.length % names.length];
     const newGroup = 1 + Math.floor(users.length / 2);
     setUsers([...users, newName]);
-    setInstances([...instances, [newName, newGroup, 'all'][plane - 1]]);
+    setInstances([...instances, [undefined, newGroup, 'all'][plane - 1]]);
   };
   const remove = () => {
     setUsers(users.slice(0, users.length - 1));
@@ -87,7 +87,7 @@ export default (props: Object) => {
     const newPlane = 1 + plane % 3;
     setPlane(newPlane);
     setInstances(
-      users.map((name, idx) => [idx + 1, groupName(idx), 'all'][newPlane - 1])
+      users.map((name, idx) => [undefined, groupName(idx), 'all'][newPlane - 1])
     );
   };
 


### PR DESCRIPTION
This feeds the studentId properly to the groupingKey in activityRunner, but in the Mosaic display, it shows as 'Chen Li/individual' instead of 'Chen Li/1', to make it more clear what's going on.