### PR TITLE
Improve config of ac-ranking

### DIFF
--- a/ac/ac-ranking/src/ActivityRunner.jsx
+++ b/ac/ac-ranking/src/ActivityRunner.jsx
@@ -133,7 +133,7 @@ const ActivityRunner = (props: ActivityRunnerT) => {
       },
       {
         type: 'progress',
-        value: config.justify ? progress / 2 : progress
+        value: config.mustJustify ? progress / 2 : progress
       },
       {
         type: 'coordinates',
@@ -146,7 +146,7 @@ const ActivityRunner = (props: ActivityRunnerT) => {
   const done =
     answers[userInfo.id] &&
     nKey(answers[userInfo.id]) === nKey(config.answers) &&
-    (!config.justify || justification.length > 0);
+    (!config.mustJustify || justification.length > 0);
 
   const onSubmit = () => {
     if (done) {
@@ -199,7 +199,7 @@ const ActivityRunner = (props: ActivityRunnerT) => {
                     display: 'block'
                   }}
                 >
-                  {config.answers
+                  {(config.answers || [])
                     .filter(ans => !(answers[userInfo.id] || {})[ans])
                     .map(ans => (
                       <AddAnswer
@@ -213,7 +213,7 @@ const ActivityRunner = (props: ActivityRunnerT) => {
               </div>
             </div>
             <hr style={{ height: '5px' }} />
-            <Justification {...props} key="justification" />
+            {config.justify && <Justification {...props} key="justification" />}
             <div>
               <button
                 onClick={onSubmit}

--- a/ac/ac-ranking/src/config.js
+++ b/ac/ac-ranking/src/config.js
@@ -3,17 +3,17 @@
 export const config = {
   type: 'object',
   properties: {
-    title: {
-      title: 'Prompt',
-      type: 'string' // note that it will not autoload in preview with rte
-    },
     guidelines: {
       title: 'Guidelines',
       type: 'string'
     },
     justify: {
       type: 'boolean',
-      title: 'Students must provide a justification for their ranking'
+      title: 'Show textbox where students can justify their ranking'
+    },
+    mustJustify: {
+      type: 'boolean',
+      title: 'Require students to fill out the justification before submitting'
     },
     answers: {
       type: 'array',
@@ -21,4 +21,8 @@ export const config = {
       items: { type: 'string' }
     }
   }
+};
+
+export const configUI = {
+  mustJustify: { conditional: 'justify' }
 };

--- a/ac/ac-ranking/src/index.js
+++ b/ac/ac-ranking/src/index.js
@@ -2,7 +2,7 @@
 
 import { type ActivityPackageT } from 'frog-utils';
 
-import { config } from './config';
+import { config, configUI } from './config';
 import ActivityRunner from './ActivityRunner';
 import dashboard from './Dashboard';
 import meta from './meta';
@@ -17,6 +17,7 @@ export default ({
   type: 'react-component',
   meta,
   config,
+  configUI,
   ActivityRunner,
   dashboard,
   dataStructure


### PR DESCRIPTION
I removed the Prompt, because it's not used, I changed justification into two choices, one to display the box, the other to require it, and updated ActivityRunner to take this into account. 

Made the changes on your branch, so I made it into a PR on your branch, Louis. If you merge your PR to develop, you can change the root of this to develop.

Also it was crashing when there were no questions in the config, I fixed this. (We could also make questions obligatory in the config, but I guess if you just want to use it with incoming data). 