### PR TITLE
Fixes word-cloud crash

### DIFF
--- a/ac/ac-chat/src/Dashboard.jsx
+++ b/ac/ac-chat/src/Dashboard.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import WordCloud from 'react-d3-cloud';
+import { isEmpty } from 'lodash';
 import { type LogDBT } from 'frog-utils';
 
 const fontSizeMapper = (itMax, word) => 10 + word.value * 150 / Number(itMax);
@@ -24,10 +25,13 @@ const Viewer = ({ data }: Object) => {
 };
 
 const mergeLog = (data: any, dataFn: Object, log: LogDBT) => {
-  const tmp = String(log.value);
+  const tmp = log.value && String(log.value);
+
   if (tmp)
     tmp
-      .split(' ')
+      .split(/[ _().!,]/)
+      .map(x => x.trim())
+      .filter(x => !isEmpty(x))
       .forEach(
         word =>
           data[word]

--- a/ac/ac-chat/src/Dashboard.jsx
+++ b/ac/ac-chat/src/Dashboard.jsx
@@ -29,9 +29,10 @@ const mergeLog = (data: any, dataFn: Object, log: LogDBT) => {
 
   if (tmp)
     tmp
-      .split(/[ _().!,]/)
+      .split(/[ :;?_().!,]/)
       .map(x => x.trim())
       .filter(x => !isEmpty(x))
+      .map(x => x.toLowerCase())
       .forEach(
         word =>
           data[word]


### PR DESCRIPTION
This makes sure there are never dots in Mongo keys for wordcloud, and also cleans up words a bit in general. We can make this more sophisticated in the future (stemming, semantics etc), but for now it should be safe to use.

Closes #931