### PR TITLE
Adding option to run without tokens also in production

### DIFF
--- a/frog/imports/ui/App/NotLoggedIn.js
+++ b/frog/imports/ui/App/NotLoggedIn.js
@@ -21,7 +21,10 @@ const randomName = () =>
   ]);
 
 const NotLoggedIn = ({ login }: { login: Function }) => {
-  if (process.env.NODE_ENV !== 'production') {
+  if (
+    process.env.NODE_ENV !== 'production' ||
+    Meteor.settings.public.friendlyProduction
+  ) {
     const name = randomName();
     return (
       <div style={{ margin: '25px' }}>

--- a/frog/imports/ui/App/NotLoggedIn.js
+++ b/frog/imports/ui/App/NotLoggedIn.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { A } from 'frog-utils';
 import { sample } from 'lodash';
 import FlexView from 'react-flexview';
+import { Meteor } from 'meteor/meteor';
 
 const randomName = () =>
   sample([

--- a/frog/imports/ui/App/connection.js
+++ b/frog/imports/ui/App/connection.js
@@ -18,7 +18,10 @@ if (Meteor.isClient) {
   socket = new ReconnectingWebSocket(shareDbUrl);
   _connection = new sharedbClient.Connection(socket);
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (
+    process.env.NODE_ENV !== 'production' ||
+    Meteor.settings.public.friendlyProduction
+  ) {
     window.connection = _connection;
   }
 }

--- a/frog/server/main.js
+++ b/frog/server/main.js
@@ -36,7 +36,10 @@ Connections._ensureIndex('source.id');
 startShareDB();
 teacherImports();
 
-if (process.env.NODE_ENV === 'production') {
+if (
+  process.env.NODE_ENV === 'production' &&
+  !Meteor.settings.public.friendlyProduction
+) {
   if (!Meteor.settings.token) {
     Meteor.settings.token = uuid();
   }

--- a/frog/server/user_accounts.js
+++ b/frog/server/user_accounts.js
@@ -43,6 +43,7 @@ Meteor.methods({
     if (
       !isStudentList &&
       process.env.NODE_ENV === 'production' &&
+      !Meteor.settings.public.friendlyProduction &&
       token !== Meteor.settings.token
     ) {
       return 'NOTVALID';


### PR DESCRIPTION
This enables a Meteor settings that let's you run "insecure" in production mode as well - for example for mup, we won't need ?token=secret anymore, it will show the "nice" login screen etc. 