### PR TITLE
More Preview fixes

### DIFF
--- a/frog/imports/ui/GraphEditor/SidePanel/ApiForm.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ApiForm.js
@@ -187,7 +187,9 @@ const ApiForm = observer(
                 />
               </div>
               {!this.props.hideValidator && (
-                <div style={{ position: 'absolute', right: '20px' }}>
+                <div
+                  style={{ position: 'absolute', right: '20px', top: '10px' }}
+                >
                   <Valid />
                 </div>
               )}
@@ -226,7 +228,13 @@ const Valid = observer(() => (
 const Errors = observer(() => (
   <React.Fragment>
     {state.showErrors ? (
-      <div style={{ position: 'absolute', top: '20px', right: '200px' }}>
+      <div
+        style={{
+          position: 'absolute',
+          top: '25px',
+          right: '90px'
+        }}
+      >
         <ShowErrorsRaw errors={state.valid} />
       </div>
     ) : null}

--- a/frog/imports/ui/Preview/ConfigPanel.jsx
+++ b/frog/imports/ui/Preview/ConfigPanel.jsx
@@ -25,9 +25,12 @@ export default ({
   reloadAPIform,
   setConfig,
   setExample,
+  setShowDashExample,
   activityTypeId,
   setReloadAPIform,
   setActivityTypeId,
+  showDash,
+  setShowDash,
   instances
 }: Object) => (
   <div style={style.side} className="bootstrap">
@@ -78,10 +81,14 @@ export default ({
         const exConf = addDefaultExample(activityTypesObj[activityType])[0]
           .config;
         setConfig(exConf);
+        if (showDash && !activityTypesObj[activityType].dashboard) {
+          setShowDash(false);
+        }
         setReloadAPIform(uuid());
         initActivityDocuments(instances, activityType, 0, exConf, true);
         initDashboardDocuments(activityType, true);
         setExample(0);
+        setShowDashExample(false);
         setActivityTypeId(activityType);
       }}
       reload={reloadAPIform}

--- a/frog/imports/ui/Preview/Content.jsx
+++ b/frog/imports/ui/Preview/Content.jsx
@@ -74,7 +74,7 @@ export default ({
   if (!users || !instances) {
     return <p>There is no user</p>;
   }
-  if (config === undefined || config.invalid) {
+  if (!showDashExample && (config === undefined || config.invalid)) {
     return <p>The config is invalid</p>;
   }
 

--- a/frog/imports/ui/Preview/ShowDashExample.js
+++ b/frog/imports/ui/Preview/ShowDashExample.js
@@ -196,63 +196,69 @@ class ShowDashExample extends React.Component<PropsT, StateT> {
     }
     return (
       <React.Fragment>
-        <DashboardSelector
-          selected={this.state.exampleIdx}
-          onChange={x => {
-            this.logsProcessed = 0;
-            this.setState(
-              {
-                oldSlider: 0,
-                data: aT.dashboard[dashNames[x]].initData,
-                example: dashNames[x],
-                exampleIdx: x,
-                logs: [],
-                idx: 0,
-                play: false
-              },
-              () => this.fetchLogs()
-            );
-          }}
-          dashNames={dashNames}
-        />
-        <DashboardSelector
-          selected={this.state.idx}
-          onChange={x => {
-            this.logsProcessed = 0;
-            this.setState(
-              {
-                oldSlider: 0,
-                data: aT.dashboard[this.state.example].initData,
-                logs: [],
-                idx: x,
-                play: false
-              },
-              () => this.fetchLogs()
-            );
-          }}
-          dashNames={examples}
-        />
-        <DashboardSelector
-          onChange={x => {
-            if (this.state.play === x) {
-              this.setState({ play: false });
-            } else {
+        <div style={{ height: '30px' }}>
+          <DashboardSelector
+            selected={this.state.exampleIdx}
+            onChange={x => {
+              this.logsProcessed = 0;
+              this.setState(
+                {
+                  oldSlider: 0,
+                  data: aT.dashboard[dashNames[x]].initData,
+                  example: dashNames[x],
+                  exampleIdx: x,
+                  logs: [],
+                  idx: 0,
+                  play: false
+                },
+                () => this.fetchLogs()
+              );
+            }}
+            dashNames={dashNames}
+          />
+        </div>
+        <div style={{ height: '30px' }}>
+          <DashboardSelector
+            selected={this.state.idx}
+            onChange={x => {
+              this.logsProcessed = 0;
               this.setState(
                 {
                   oldSlider: 0,
                   data: aT.dashboard[this.state.example].initData,
-                  play: x
+                  logs: [],
+                  idx: x,
+                  play: false
                 },
-                () => {
-                  this.logsProcessed = 0;
-                  this.clusterBySecond();
-                }
+                () => this.fetchLogs()
               );
-            }
-          }}
-          dashNames={['1x', '2x', '4x', '8x', '16x', '32x']}
-          selected={this.state.play || 0}
-        />
+            }}
+            dashNames={examples}
+          />
+        </div>
+        <div style={{ height: '30px' }}>
+          <DashboardSelector
+            onChange={x => {
+              if (this.state.play === x) {
+                this.setState({ play: false });
+              } else {
+                this.setState(
+                  {
+                    oldSlider: 0,
+                    data: aT.dashboard[this.state.example].initData,
+                    play: x
+                  },
+                  () => {
+                    this.logsProcessed = 0;
+                    this.clusterBySecond();
+                  }
+                );
+              }
+            }}
+            dashNames={['1x', '2x', '4x', '8x', '16x', '32x']}
+            selected={this.state.play || 0}
+          />
+        </div>
         <Slider
           value={this.state.slider[this.state.example] || 0}
           min={0}


### PR DESCRIPTION
This fixes:
- resets showDashExample when switching to an activity that has no examples (caused crashing)
- resets showDash when switching to an activity that has no dashboard (didn't crash, but showed empty window that it was impossible to remove)

For these two, there is now a lot of logic in the onSelect in ConfigPanel. You might want to move this somewhere else, but if it's never used anywhere else, maybe this is OK. 

- repositions the red error ball, the error message was overlapping so it would flitter (on/off), also looks a bit better. The actual error messages are overlaid a bit by the preview, no easy way to fix. Eventually we should stop using SVG and just use a nice Material component to show errors - no reason to use SVG, and would give us more flexibility with size, width, word wrap etc.

- fixes the menus in showDashExample after the DashboardSelector got height: 100%. We should eventually replace these, but for now, it works.

- still shows DashExample even if config is invalid

Closes #982 