### PR TITLE
Fixing restart.session again

### DIFF
--- a/frog/imports/api/sessions.js
+++ b/frog/imports/api/sessions.js
@@ -27,7 +27,7 @@ export const restartSession = (session: Object) => {
 Meteor.methods({
   'sessions.restart': session => {
     if (Meteor.isServer) {
-      const graphId = session && session.fromGraphId;
+      const graphId = session && session.graphId;
       if (!graphId) {
         return;
       }


### PR DESCRIPTION
I changed to make restart.session restart from the current graph (not the original graph), however somehow in the PR to fix ac-ck-board, this change got reversed without anyone noticing (see the bottom here https://github.com/chili-epfl/FROG/pull/934/files). This fixes it _again_. 