### PR TITLE
Enables restart session to also refresh operator

### DIFF
--- a/frog/imports/api/graphs.js
+++ b/frog/imports/api/graphs.js
@@ -51,7 +51,7 @@ export const addGraph = (graphObj?: Object): string => {
   const copyOp = graphObj.operators.map(op => {
     const id = uuid();
     matching[op._id] = id;
-    return { ...op, _id: id, graphId };
+    return { ...op, _id: id, graphId, state: undefined };
   });
 
   // Here we change the configured ids of activities and operators which


### PR DESCRIPTION
Without this PR, operators in restarted sessions are still marked as "computed", and will not get recomputed, thus breaking the graph execution.

Closes #999 