### PR TITLE
ConfigComponent in Preview

### DIFF
--- a/ac/ac-video/src/index.js
+++ b/ac/ac-video/src/index.js
@@ -26,6 +26,7 @@ export const meta = {
 
 export const config = {
   type: 'object',
+  required: ['url'],
   properties: {
     url: {
       type: 'string',

--- a/frog/imports/api/__tests__/validGraphFnTest.js
+++ b/frog/imports/api/__tests__/validGraphFnTest.js
@@ -83,6 +83,7 @@ const g2 = {
       startTime: 0,
       length: 5,
       plane: 1,
+      data: { url: 'http://youtube.com' },
       activityType: 'ac-video'
     }
   ],

--- a/frog/imports/internalActivities/ac-h5p/index.js
+++ b/frog/imports/internalActivities/ac-h5p/index.js
@@ -9,14 +9,7 @@ import dashboards from './Dashboard';
 export const meta = {
   name: 'H5P activity',
   shortDesc: 'Upload a fully configured H5P activity',
-  description: 'Displays H5P activity, and logs xAPI statements',
-  exampleData: [
-    {
-      title: 'Empty',
-      config: { title: 'Example H5P' },
-      data: []
-    }
-  ]
+  description: 'Displays H5P activity, and logs xAPI statements'
 };
 
 export class ActivityRunner extends React.Component<ActivityRunnerT, void> {

--- a/frog/imports/ui/GraphEditor/SidePanel/ApiForm.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ApiForm.js
@@ -178,9 +178,7 @@ class State {
       setShow: action(e => {
         this.showErrors = e;
       }),
-      setValid: action(e => {
-        this.valid = e;
-      })
+      setValid: action(e => (this.valid = e))
     });
   }
 }

--- a/frog/imports/ui/GraphEditor/SidePanel/ConfigForm.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/ConfigForm.jsx
@@ -101,9 +101,24 @@ export default class ConfigForm extends Component<
         this.props.onChange ||
         (data => {
           if (node.operatorType) {
-            addOperator(node.operatorType, data.formData, node._id);
+            addOperator(
+              node.operatorType,
+              {
+                component: this.props.data && this.props.data.component,
+                ...data.formData
+              },
+              node._id
+            );
           } else {
-            addActivity(node.activityType, data.formData, node._id, null);
+            addActivity(
+              node.activityType,
+              {
+                component: this.props.data && this.props.data.component,
+                ...data.formData
+              },
+              node._id,
+              null
+            );
           }
           refreshValidate();
         })

--- a/frog/imports/ui/Preview/ConfigPanel.jsx
+++ b/frog/imports/ui/Preview/ConfigPanel.jsx
@@ -2,8 +2,9 @@
 
 import * as React from 'react';
 import { uuid } from 'frog-utils';
+import { isEqual } from 'lodash';
 
-import ApiForm from '../GraphEditor/SidePanel/ApiForm';
+import ApiForm, { check } from '../GraphEditor/SidePanel/ApiForm';
 import { initActivityDocuments } from './Content';
 import { activityTypesObj } from '../../activityTypes';
 import { initDashboardDocuments } from './dashboardInPreviewAPI';
@@ -20,78 +21,92 @@ const style = {
   preview: { width: '100%', height: 'calc(100% - 50px)', overflow: 'visible' }
 };
 
-export default ({
-  config,
-  reloadAPIform,
-  setConfig,
-  setExample,
-  setShowDashExample,
-  activityTypeId,
-  setReloadAPIform,
-  setActivityTypeId,
-  showDash,
-  setShowDash,
-  instances
-}: Object) => (
-  <div style={style.side} className="bootstrap">
-    {activityTypeId && (
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-          alignContent: 'center'
-        }}
-      >
-        <button
-          onClick={() => {
-            setActivityTypeId(null);
-            setExample(0);
-            setConfig({});
-            setReloadAPIform(uuid());
-          }}
-          className="glyphicon glyphicon-arrow-left"
-          style={{
-            fontSize: '2em',
-            color: 'blue',
-            border: 0,
-            background: 'none',
-            cursor: 'pointer'
-          }}
-        />
-        <h3>{activityTypesObj[activityTypeId].meta.name}</h3>
+class ConfigPanel extends React.Component<*, *> {
+  onConfigChange = (e: any) => {
+    console.log(e);
+    if (e.errors && e.errors.length === 0) {
+      const aT = activityTypesObj[e.activityType];
+      const _c = e.config;
+      this.props.setConfig(_c);
+      initActivityDocuments(this.props.instances, aT, -1, _c, true);
+      initDashboardDocuments(aT, true);
+    } else {
+      this.props.setConfig({ invalid: true });
+    }
+    this.props.setActivityTypeId(e.activityType);
+  };
+
+  render() {
+    const {
+      config,
+      reloadAPIform,
+      setConfig,
+      setExample,
+      setShowDashExample,
+      activityTypeId,
+      setReloadAPIform,
+      setActivityTypeId,
+      showDash,
+      setShowDash,
+      instances
+    } = this.props;
+
+    return (
+      <div style={style.side} className="bootstrap">
+        <div>
+          {activityTypeId && (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                alignContent: 'center'
+              }}
+            >
+              <button
+                onClick={() => {
+                  setActivityTypeId(null);
+                  setExample(0);
+                  setConfig({});
+                  setReloadAPIform(uuid());
+                }}
+                className="glyphicon glyphicon-arrow-left"
+                style={{
+                  fontSize: '2em',
+                  color: 'blue',
+                  border: 0,
+                  background: 'none',
+                  cursor: 'pointer'
+                }}
+              />
+              <h3>{activityTypesObj[activityTypeId].meta.name}</h3>
+            </div>
+          )}
+          <ApiForm
+            hidePreview
+            config={config}
+            activityType={activityTypeId}
+            onConfigChange={this.onConfigChange}
+            onSelect={activityType => {
+              const exConf = addDefaultExample(
+                activityTypesObj[activityType]
+              )[0].config;
+              setConfig(exConf);
+              if (showDash && !activityTypesObj[activityType].dashboard) {
+                setShowDash(false);
+              }
+              setReloadAPIform(uuid());
+              initActivityDocuments(instances, activityType, 0, exConf, true);
+              initDashboardDocuments(activityType, true);
+              setExample(0);
+              setShowDashExample(false);
+              setActivityTypeId(activityType);
+            }}
+            reload={reloadAPIform}
+          />
+        </div>
       </div>
-    )}
-    <ApiForm
-      hidePreview
-      config={config}
-      activityType={activityTypeId}
-      onConfigChange={e => {
-        if (e.errors.length === 0) {
-          const aT = activityTypesObj[e.activityType];
-          const _c = e.config;
-          setConfig(_c);
-          initActivityDocuments(instances, aT, -1, _c, true);
-          initDashboardDocuments(aT, true);
-        } else {
-          setConfig({ invalid: true });
-        }
-        setActivityTypeId(e.activityType);
-      }}
-      onSelect={activityType => {
-        const exConf = addDefaultExample(activityTypesObj[activityType])[0]
-          .config;
-        setConfig(exConf);
-        if (showDash && !activityTypesObj[activityType].dashboard) {
-          setShowDash(false);
-        }
-        setReloadAPIform(uuid());
-        initActivityDocuments(instances, activityType, 0, exConf, true);
-        initDashboardDocuments(activityType, true);
-        setExample(0);
-        setShowDashExample(false);
-        setActivityTypeId(activityType);
-      }}
-      reload={reloadAPIform}
-    />
-  </div>
-);
+    );
+  }
+}
+
+export default ConfigPanel;

--- a/frog/imports/ui/Preview/ConfigPanel.jsx
+++ b/frog/imports/ui/Preview/ConfigPanel.jsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react';
 import { uuid } from 'frog-utils';
-import { isEqual } from 'lodash';
 
 import ApiForm, { check } from '../GraphEditor/SidePanel/ApiForm';
 import { initActivityDocuments } from './Content';
@@ -23,17 +22,26 @@ const style = {
 
 class ConfigPanel extends React.Component<*, *> {
   onConfigChange = (e: any) => {
-    console.log(e);
     if (e.errors && e.errors.length === 0) {
       const aT = activityTypesObj[e.activityType];
-      const _c = e.config;
-      this.props.setConfig(_c);
-      initActivityDocuments(this.props.instances, aT, -1, _c, true);
+      this.props.setConfig(e.config);
+      initActivityDocuments(this.props.instances, aT, -1, e.config, true);
       initDashboardDocuments(aT, true);
     } else {
-      this.props.setConfig({ invalid: true });
+      this.props.setConfig({ ...e.config, invalid: true });
     }
     this.props.setActivityTypeId(e.activityType);
+  };
+
+  componentDidUpdate = () => {
+    if (this.props.activityTypeId && this.props.config.invalid === undefined) {
+      check(
+        this.props.activityTypeId,
+        this.props.config,
+        () => {},
+        this.onConfigChange
+      );
+    }
   };
 
   render() {


### PR DESCRIPTION
Sorry about a pretty complex PR. The main idea is to add support for ConfigComponents, currently only used in the h5p activity. This however meant some wiring up to get all the valid checks to work across components. It now should work - I've tested with H5P, with other components that have required fields, I also temporarily made the Prompt field in H5P obligatory, to see how this would work, and I tested in the graph editor to ensure no regressions.

It should work under all conditions, let me know if it doesn't.

There is no doubt that our whole config stuff is becoming more and more byzantine, and I'd love to rewrite it from scratch. I think even beginning with drawing up some graphs about for example what are the component hierarchy that calls ConfigForm from Preview, where does state get passed down, where is the valid check run, etc. Moving all of the state in Preview to a store, or even having an app-wide MobX store, could probably help a lot. As could using more key={activity.id} to avoid a lot of the `shouldComponentUpdate`, `componentWillReceiveProps`, and thus the need for passing `reload` props etc.

But that will take a lot of time! :) So in the meantime, I think we should merge this. After all, it should be fairly easy to check that it's working well.