### PR TITLE
Letting you deep-link to different components in Preview exampleData

### DIFF
--- a/ac/ac-train/src/ActivityRunner.jsx
+++ b/ac/ac-train/src/ActivityRunner.jsx
@@ -51,7 +51,8 @@ const ActivityEnded = () => (
 
 type PropsT = {
   dataFn: any,
-  data: Object
+  data: Object,
+  activityData: { config: Object }
 };
 
 class Main extends React.Component<PropsT> {
@@ -76,7 +77,14 @@ class Main extends React.Component<PropsT> {
 
   render() {
     const { step, guidelines } = this.props.data;
-
+    if (this.props.activityData.config.interface) {
+      return (
+        <Interface
+          whichInterface={this.props.activityData.config.interface}
+          {...this.props}
+        />
+      );
+    }
     if (step < 5 && guidelines) {
       return (
         <SpecificGuideline

--- a/ac/ac-train/src/index.js
+++ b/ac/ac-train/src/index.js
@@ -6,6 +6,7 @@ import dashboards from './Dashboards';
 
 const interfaceExample = int => ({
   title: `${int} interface`,
+  type: 'deeplink',
   config: {
     timeOfEachIteration: 600000,
     iterationPerInterface: 5,

--- a/ac/ac-train/src/index.js
+++ b/ac/ac-train/src/index.js
@@ -4,6 +4,17 @@ import { type ActivityPackageT } from 'frog-utils';
 import ActivityRunner from './ActivityRunner';
 import dashboards from './Dashboards';
 
+const interfaceExample = int => ({
+  title: `${int} interface`,
+  config: {
+    timeOfEachIteration: 600000,
+    iterationPerInterface: 5,
+    ticketStatusDisplayTime: 10000,
+    interface: int
+  },
+  data: {}
+});
+
 const meta = {
   name: 'Train Activity',
   shortDesc: 'New activity, no description available',
@@ -35,7 +46,10 @@ const meta = {
         ticketStatusDisplayTime: 500
       },
       data: {}
-    }
+    },
+    ...['dragdrop', 'form', 'command', 'graphical'].map(x =>
+      interfaceExample(x)
+    )
   ]
 };
 

--- a/frog-utils/src/types.js
+++ b/frog-utils/src/types.js
@@ -123,7 +123,12 @@ export type ActivityPackageT = {
     shortName?: string,
     shortDesc: string,
     description: string,
-    exampleData?: { title: string, config?: Object, data?: any }[]
+    exampleData?: {
+      title: string,
+      config?: Object,
+      data?: any,
+      type?: 'deeplink'
+    }[]
   },
   config: Object,
   configUI?: Object,

--- a/frog/imports/ui/Preview/Controls.jsx
+++ b/frog/imports/ui/Preview/Controls.jsx
@@ -178,6 +178,7 @@ export default (props: Object) => {
             <NavItem
               key={x.title}
               className="examples"
+              style={x.type === 'deeplink' ? { fontStyle: 'italic' } : {}}
               eventKey={i}
               onClick={() => {
                 const exConf = addDefaultExample(activityType)[i].config;

--- a/frog/imports/ui/Preview/index.js
+++ b/frog/imports/ui/Preview/index.js
@@ -12,7 +12,8 @@ export const addDefaultExample = (activityType: Object) => [
   {
     title: 'Default config',
     data: undefined,
-    config: defaultConfig(activityType)
+    config: defaultConfig(activityType),
+    type: undefined
   },
   ...(activityType.meta.exampleData || [])
 ];


### PR DESCRIPTION
I had this idea that it would be nice to be able to work specifically on one component, without having to go through the whole random ordering every time you reload. I filed an issue, thinking it would be a lot of work. Then I realized that we can just pass a parameter from the exampleData, which does not exist in the config (ie. could never happen in a graph), and check for this in the ActivityRunner. Turns out it works perfectly! I added an optional type for exampleData, and render these special examples in italic, so users realize that these are not "valid configurations", but to test out something specific. I find it incredibly useful!

![screen shot 2018-04-22 at 14 30 26](https://user-images.githubusercontent.com/61575/39095020-ba66f02a-4639-11e8-9b2f-021491bdf211.png)


Closes #1022 
