### PR TITLE
Add templates to Yarn workspaces

### DIFF
--- a/ac/ac-train/package.json
+++ b/ac/ac-train/package.json
@@ -13,5 +13,5 @@
     "react-dnd-html5-backend": "^2.6.0",
     "react-cursor-position": "^2.4.1"
   },
-  "devDependencies": { "nps": "5.7.1" }
+  "devDependencies": { "nps": "5.9.0" }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "ac/*",
     "op/*",
     "frog-utils",
-    "frog"
+    "frog",
+    "templates/activity",
+    "templates/operator"
   ],
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.39",

--- a/templates/activity/package.json
+++ b/templates/activity/package.json
@@ -11,6 +11,6 @@
     "react-dom": "^16.3.1"
   },
   "devDependencies": {
-    "nps": "5.7.1"
+    "nps": "5.9.0"
   }
 }

--- a/templates/operator/package.json
+++ b/templates/operator/package.json
@@ -12,6 +12,6 @@
     "frog-utils": "1.0.0"
   },
   "devDependencies": {
-    "nps": "5.7.1"
+    "nps": "5.9.0"
   }
 }


### PR DESCRIPTION
This adds the templates (ac/op) to the Yarn workspaces, meaning they will be included in `yarn upgrade-interactive`, and not be left behind. The files do not get compiled (they're not included in `watchAll` etc), and since all the dependencies are pooled at the root level, this does not result in more files being installed.

This immediately revealed that our templates were behind with regards to nps :)

Closes #1011 