### PR TITLE
Ac-ranking -> ac-chat with friendly robot

### DIFF
--- a/ac/ac-chat/src/Chat.jsx
+++ b/ac/ac-chat/src/Chat.jsx
@@ -47,6 +47,9 @@ const styles = {
     fontSize: '10pt',
     paddingBottom: '2px',
     color: '#0606066b'
+  },
+  robot: {
+    fontStyle: 'italic'
   }
 };
 
@@ -55,7 +58,12 @@ const Chatmsg = ({ msg, classes }) => (
     <Typography variant="body2" gutterBottom color="secondary">
       {msg.user}
     </Typography>
-    <Typography gutterBottom>{msg.msg}</Typography>
+    <Typography
+      gutterBottom
+      className={msg.user === 'Friendly robot' ? classes.robot : undefined}
+    >
+      {msg.msg}
+    </Typography>
   </div>
 );
 

--- a/ac/ac-chat/src/index.js
+++ b/ac/ac-chat/src/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { type ActivityPackageT } from 'frog-utils';
+import { type ActivityPackageT, uuid } from 'frog-utils';
 
 import ActivityRunner from './Chat';
 import dashboards from './Dashboard';
@@ -26,6 +26,23 @@ const meta = {
           user: 'Alfons'
         }
       ]
+    },
+    {
+      title: 'Robot prompt through merge',
+      config: { title: 'Chat with robot' },
+      data: [{ msg: 'Nicole uploaded an image' }]
+    },
+    {
+      title: 'Robot prompt through merge and with config',
+      config: {
+        title: 'Chat with robot',
+        hasRobotPrompt: true,
+        robotPrompt: 'Please discuss amongst yourself'
+      },
+      data: [
+        { msg: 'John said Obama is the best' },
+        { msg: 'Peter said John Travolta would be a good president' }
+      ]
     }
   ]
 };
@@ -38,13 +55,31 @@ const config = {
     title: {
       type: 'string',
       title: 'Title'
-    }
+    },
+    hasRobotPrompt: {
+      type: 'boolean',
+      title: 'Insert robot prompt at beginning of chat'
+    },
+    robotPrompt: { type: 'string', title: 'Robot prompt' }
   }
 };
 
+const configUI = { robotPrompt: { conditional: 'hasRobotPrompt' } };
+
+const robotFormat = msg => ({
+  msg,
+  user: 'Friendly robot',
+  id: uuid()
+});
+
 const mergeFunction = (obj, dataFn) => {
+  if (obj.config.hasRobotPrompt) {
+    dataFn.listAppend(robotFormat(obj.config.robotPrompt));
+  }
   if (obj.data) {
-    obj.data.forEach(x => dataFn.listAppend(x));
+    obj.data.forEach(x => {
+      dataFn.listAppend(x.user ? x : robotFormat(x.msg || x));
+    });
   }
 };
 
@@ -53,6 +88,7 @@ export default ({
   type: 'react-component',
   ActivityRunner,
   config,
+  configUI,
   meta,
   dataStructure,
   dashboards,

--- a/ac/ac-ranking/src/index.js
+++ b/ac/ac-ranking/src/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { type ActivityPackageT } from 'frog-utils';
+import { toPairs, sortBy } from 'lodash';
 
 import { config, configUI } from './config';
 import ActivityRunner from './ActivityRunner';
@@ -13,6 +14,23 @@ const dataStructure = {
   group: {}
 };
 
+export const formatProduct = (
+  _config: Object,
+  data: Object,
+  instanceId: string
+) => {
+  const userName = data.group[instanceId];
+  const choices = sortBy(toPairs(data.answers[instanceId] || {}), x => x[1])
+    .map(x => x[0])
+    .join(', ');
+
+  return {
+    msg: `${userName} ranked the interfaces in the following order: ${choices}, with the justification "${
+      data.justification
+    }".`
+  };
+};
+
 export default ({
   id: 'ac-ranking',
   type: 'react-component',
@@ -21,5 +39,6 @@ export default ({
   configUI,
   ActivityRunner,
   dashboards,
-  dataStructure
+  dataStructure,
+  formatProduct
 }: ActivityPackageT);

--- a/frog-utils/src/types.js
+++ b/frog-utils/src/types.js
@@ -133,7 +133,7 @@ export type ActivityPackageT = {
   ActivityRunner: React$Component<ActivityRunnerT>,
   dashboards?: { [name: string]: dashboardT },
   exportData?: (config: Object, product: activityDataT) => string,
-  formatProduct?: (config: Object, item: any) => any,
+  formatProduct?: (config: Object, item: any, instanceId: string) => any,
   ConfigComponent?: React$Component<{
     configData: Object,
     setConfigData: Object => void

--- a/frog/imports/ui/Preview/ShowInfo.js
+++ b/frog/imports/ui/Preview/ShowInfo.js
@@ -1,17 +1,19 @@
+// flow
+
 import React from 'react';
 import { Inspector } from 'frog-utils';
 import { activityTypesObj } from '/imports/activityTypes';
 
-const formatProduct = (data, activityType, config) => {
+const formatProduct = (data, activityType, config, userInfo) => {
   const formatter = activityTypesObj[activityType].formatProduct;
   if (formatter) {
-    return formatter(config, data);
+    return formatter(config, data, userInfo);
   } else {
     return data;
   }
 };
 
-const ShowInfo = ({ activityData, data, activityType }) => (
+const ShowInfo = ({ activityData, data, activityType, userInfo }) => (
   <div style={{ display: 'flex', justifyContent: 'space-around' }}>
     <div style={{ flexBasis: 0, flexGrow: 1 }}>
       <h3>Config</h3>
@@ -24,7 +26,12 @@ const ShowInfo = ({ activityData, data, activityType }) => (
     <div style={{ flexBasis: 0, flexGrow: 1, marginLeft: '50px' }}>
       <h3>Current reactive data</h3>
       <Inspector
-        data={formatProduct(data, activityType, activityData.config)}
+        data={formatProduct(
+          data,
+          activityType,
+          activityData.config,
+          userInfo.id
+        )}
       />
     </div>
   </div>

--- a/frog/server/reactiveToProduct.js
+++ b/frog/server/reactiveToProduct.js
@@ -18,12 +18,13 @@ declare var Promise: any;
 const cleanId = id => id.split('/')[1];
 
 const formatResults = (results, formatProduct, config) => {
-  const format = data => (formatProduct ? formatProduct(config, data) : data);
+  const format = (data, instance) =>
+    formatProduct ? formatProduct(config, data, instance) : data;
   return results.reduce(
     (acc, k) => ({
       ...acc,
       [cleanId(k.id)]: {
-        data: format(k.data)
+        data: format(k.data, cleanId(k.id))
       }
     }),
     {}


### PR DESCRIPTION
We needed to send the individual rankings and reflections to the group activity, and we decided to display it in the chat.

I decided to use the formatProduct function in ac-ranking to generate a text string per instance. That way the logic is contained within ac-ranking, instead of adding a new operator that can only be used with ac-ranking. (This does give us problems if we in the future want to send the actual ranking results to another ranking - we could also add a msg: field to the object, and send the whole object or something).

To get this to work, I had to add instanceId to the signature of formatProduct.

Once we have these strings, we can use op-aggregate-p2 without any changes to aggregate the two messages per group. I then modified ac-chat a bit to support "robot messages" - one can be configured in config (as a prompt), and if you merge in messages without a user, they automatically become robot messages.

The test graph for this functionality can be found in the shared graph database as PR 1036.

Example from the above-mentioned graph:

![screen shot 2018-04-23 at 13 32 15](https://user-images.githubusercontent.com/61575/39124180-c7fe58e2-46fa-11e8-87f2-6c550304a4b5.png)
