### PR TITLE
Init data problem in Preview

### DIFF
--- a/frog/imports/ui/Preview/ConfigPanel.jsx
+++ b/frog/imports/ui/Preview/ConfigPanel.jsx
@@ -25,6 +25,7 @@ class ConfigPanel extends React.Component<*, *> {
     if (e.errors && e.errors.length === 0) {
       const aT = activityTypesObj[e.activityType];
       this.props.setConfig(e.config);
+      console.log('init from config');
       initActivityDocuments(this.props.instances, aT, -1, e.config, true);
       initDashboardDocuments(aT, true);
     } else {
@@ -103,6 +104,7 @@ class ConfigPanel extends React.Component<*, *> {
                 setShowDash(false);
               }
               setReloadAPIform(uuid());
+              console.log('init from select');
               initActivityDocuments(instances, activityType, 0, exConf, true);
               initDashboardDocuments(activityType, true);
               setExample(0);

--- a/frog/imports/ui/Preview/Content.jsx
+++ b/frog/imports/ui/Preview/Content.jsx
@@ -33,6 +33,7 @@ export const initActivityDocuments = (
   config: Object,
   refresh: boolean
 ) => {
+  console.log('init', instances, activityType, example, config, refresh);
   instances.forEach(instance => {
     const runMergeFunction = _doc => {
       const mergeFunction = activityType.mergeFunction;
@@ -92,7 +93,7 @@ const ContentController = ({
   const RunComp = activityType.ActivityRunner;
   RunComp.displayName = activityType.id;
 
-  const examples = activityType.meta.exampleData || [];
+  const examples = addDefaultExample(activityType);
   const exData = examples[example] && cloneDeep(examples[example]);
   const data = exData && (exData.data ? exData.data : undefined);
   const activityData = { data, config };

--- a/frog/imports/ui/Preview/Controls.jsx
+++ b/frog/imports/ui/Preview/Controls.jsx
@@ -59,6 +59,7 @@ export default (props: Object) => {
   const examples = addDefaultExample(activityType);
 
   const refresh = () => {
+    console.log('init from refresh');
     initActivityDocuments(instances, activityType, example, config, true);
     // resets the reactive documents for the dashboard
     initDashboardDocuments(activityType, true);
@@ -182,6 +183,7 @@ export default (props: Object) => {
                 const exConf = ex.config;
                 setConfig(exConf);
                 setReloadAPIform(uuid());
+                console.log('init from nav');
                 initActivityDocuments(instances, activityType, i, exConf, true);
                 initDashboardDocuments(activityType, true);
                 setExample(i);

--- a/frog/imports/ui/Preview/Preview.js
+++ b/frog/imports/ui/Preview/Preview.js
@@ -12,7 +12,7 @@ import { activityTypesObj } from '../../activityTypes';
 import { Logs } from './dashboardInPreviewAPI';
 import ShowLogs from './ShowLogs';
 import Controls from './Controls';
-import Content, { initActivityDocuments } from './Content';
+import Content from './Content';
 import ConfigPanel from './ConfigPanel';
 import styles from './previewStyles';
 
@@ -23,14 +23,11 @@ const StatelessPreview = (props: Object) => {
   const {
     activityTypeId,
     modal,
-    config,
     dismiss,
-    example,
     showLogs,
     fullWindow,
     showDashExample,
-    classes,
-    instances
+    classes
   } = props;
 
   const activityType = activityTypesObj[activityTypeId];
@@ -41,8 +38,6 @@ const StatelessPreview = (props: Object) => {
       </div>
     );
   }
-
-  initActivityDocuments(instances, activityType, example, config, false);
 
   const PreviewContent =
     showLogs && !showDashExample ? (


### PR DESCRIPTION
Louis, do you want to take a shot on this, you might understand the logic flow better than me.

I fixed the out-of-sync ShowInfo problem (line 95 in  frog/imports/ui/Preview/Content.jsx) - I think we were also passing the wrong activityData to activities, but because most activities don't use activityData (they just use reactiveData and config), this was not discovered.

I've left the console.logs so it's easier to debug.

Note that in general we should be very careful about calling stateful functions (like initActivityData) from stateless functions like StatelessPreview, because we cannot control how often they get re-rendered, especially in this case, where it's subscribing to a million different props... Probably, this should be a class, which sets up initActivityData on componentDidMount or something, and then it can rely on Control/Content etc to explicitly reload activityData on user actions (it can still be "stateless" in the sense that it relies on external props and setters for all of it's data, but we would be able to move that function out of the render() function). 

<img width="1389" alt="screen shot 2018-04-24 at 10 48 08" src="https://user-images.githubusercontent.com/61575/39176860-25a960be-47ae-11e8-9e4e-11de05d372ec.png">
