### PR TITLE
Does not run mergeLog on the client

### DIFF
--- a/frog/imports/api/mergeLogData.js
+++ b/frog/imports/api/mergeLogData.js
@@ -122,6 +122,10 @@ const archiveDashboardState = activityId => {
 };
 
 Meteor.methods({
-  'merge.log': mergeLog,
+  'merge.log': (rawLog, logExtra, suppliedActivity) => {
+    if (Meteor.isServer) {
+      mergeLog(rawLog, logExtra, suppliedActivity);
+    }
+  },
   'archive.dashboard.state': archiveDashboardState
 });


### PR DESCRIPTION
In session mode, mergeLog would run on the student's browsers because of Meteor's optimistic UI feature.