### PR TITLE
Enabling op/ac config to specify any activity/target/source

### DIFF
--- a/frog/imports/internalActivities/ac-dash/index.js
+++ b/frog/imports/internalActivities/ac-dash/index.js
@@ -37,7 +37,7 @@ export default ({
     required: ['activityId'],
     properties: {
       activityId: {
-        type: 'activity',
+        type: 'anyActivity',
         title: 'Applies to which activity'
       },
       names: {

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
@@ -221,7 +221,11 @@ const RawEditActivity = ({
         connectedActivities={otherActivityIds}
         connectedSourceActivities={connectedSourceActivities}
         connectedTargetActivities={connectedTargetActivities}
-        reload={reload + otherActivityIds.join('')}
+        reload={
+          reload +
+          connectedSourceActivities.map(x => x.id).join('') +
+          connectedTargetActivities.map(x => x.id).join('')
+        }
       />
       {activityType.ConfigComponent && (
         <activityType.ConfigComponent

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
@@ -223,8 +223,8 @@ const RawEditActivity = ({
         connectedTargetActivities={connectedTargetActivities}
         reload={
           reload +
-          connectedSourceActivities.map(x => x.id).join('') +
-          connectedTargetActivities.map(x => x.id).join('')
+          (connectedSourceActivities || []).map(x => x.id).join('') +
+          (connectedTargetActivities || []).map(x => x.id).join('')
         }
       />
       {activityType.ConfigComponent && (

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
@@ -8,6 +8,7 @@ import { yellow, red, lightGreen } from 'material-ui/colors';
 import copy from 'copy-to-clipboard';
 import { withState, compose } from 'recompose';
 import { ChangeableText, A, uuid } from 'frog-utils';
+import { compact } from 'lodash';
 
 import { activityTypesObj } from '/imports/activityTypes';
 import {
@@ -90,6 +91,19 @@ const RawEditActivity = ({
   );
   const outgoingConnections = props.store.connectionStore.all.filter(
     conn => conn.source.id === activity._id
+  );
+  const incomingConnections = props.store.connectionStore.all.filter(
+    conn => conn.target.id === activity._id
+  );
+  const connectedTargetActivities = compact(
+    outgoingConnections.map(x =>
+      props.store.activityStore.all.find(act => act.id === x.target.id)
+    )
+  );
+  const connectedSourceActivities = compact(
+    incomingConnections.map(x =>
+      props.store.activityStore.all.find(act => act.id === x.source.id)
+    )
   );
 
   // if no grouping key, and incoming social role, automatically assign first one
@@ -205,7 +219,9 @@ const RawEditActivity = ({
         valid={props.store.valid}
         refreshValidate={props.store.refreshValidate}
         connectedActivities={otherActivityIds}
-        reload={reload + (outgoingConnections || []).map(x => x.id).join('')}
+        connectedSourceActivities={connectedSourceActivities}
+        connectedTargetActivities={connectedTargetActivities}
+        reload={reload + otherActivityIds.join('')}
       />
       {activityType.ConfigComponent && (
         <activityType.ConfigComponent

--- a/frog/imports/ui/GraphEditor/SidePanel/ConfigForm.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/ConfigForm.jsx
@@ -13,7 +13,9 @@ import {
 
 import {
   SelectFormWidget,
-  SelectActivityWidget,
+  SelectAnyActivityWidget,
+  SelectSourceActivityWidget,
+  SelectTargetActivityWidget,
   addSocialFormSchema
 } from './FormUtils';
 
@@ -21,6 +23,8 @@ type ConfigFormPropsT = {
   node: Object,
   nodeType: any,
   connectedActivities?: any,
+  connectedSourceActivities?: any,
+  connectedTargetActivities?: any,
   valid: any,
   refreshValidate: Function,
   reload?: any,
@@ -80,6 +84,8 @@ export default class ConfigForm extends Component<
       nodeType,
       valid,
       connectedActivities,
+      connectedSourceActivities,
+      connectedTargetActivities,
       refreshValidate
     } = this.props;
     const props = {
@@ -88,13 +94,17 @@ export default class ConfigForm extends Component<
       widgets: {
         ...this.props.widgets,
         socialAttributeWidget: SelectFormWidget,
-        activityWidget: SelectActivityWidget
+        anyActivityWidget: SelectAnyActivityWidget,
+        targetActivityWidget: SelectSourceActivityWidget,
+        sourceActivityWidget: SelectTargetActivityWidget
       },
       reload: this.props.reload,
       id: node._id,
       formContext: {
         options: valid.social[node._id] || [],
         connectedActivities,
+        connectedSourceActivities,
+        connectedTargetActivities,
         groupingKey: node.groupingKey
       },
       onChange:

--- a/frog/imports/ui/GraphEditor/SidePanel/ConfigForm.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/ConfigForm.jsx
@@ -95,8 +95,8 @@ export default class ConfigForm extends Component<
         ...this.props.widgets,
         socialAttributeWidget: SelectFormWidget,
         anyActivityWidget: SelectAnyActivityWidget,
-        targetActivityWidget: SelectSourceActivityWidget,
-        sourceActivityWidget: SelectTargetActivityWidget
+        targetActivityWidget: SelectTargetActivityWidget,
+        sourceActivityWidget: SelectSourceActivityWidget
       },
       reload: this.props.reload,
       id: node._id,

--- a/frog/imports/ui/GraphEditor/SidePanel/FormUtils/SelectActivity.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/FormUtils/SelectActivity.jsx
@@ -3,27 +3,51 @@
 import React from 'react';
 import { FormControl } from 'react-bootstrap';
 
-export default ({ formContext, onChange, value = '' }: any) => {
-  const options = formContext.connectedActivities;
-  return (
-    <span>
-      {options && options.length > 0 ? (
-        <FormControl
-          onChange={e => onChange(e.target.value)}
-          componentClass="select"
-          value={value}
-        >
-          {['', ...options].map(x => (
-            <option value={x.id || ''} key={x.id || 'choose'}>
-              {x === '' ? 'Choose an activity' : x.title}
-            </option>
-          ))}
-        </FormControl>
-      ) : (
-        <span style={{ color: 'red' }}>
-          No activities connected, please connect to an activity
-        </span>
-      )}
-    </span>
-  );
-};
+const SelectActivityWidget = ({
+  choices,
+  onChange,
+  value = '',
+  emptyErr
+}: any) => (
+  <span>
+    {choices && choices.length > 0 ? (
+      <FormControl
+        onChange={e => onChange(e.target.value)}
+        componentClass="select"
+        value={value}
+      >
+        {['', ...choices].map(x => (
+          <option value={x.id || ''} key={x.id || 'choose'}>
+            {x === '' ? 'Choose an activity' : x.title}
+          </option>
+        ))}
+      </FormControl>
+    ) : (
+      <span style={{ color: 'red' }}>{emptyErr}</span>
+    )}
+  </span>
+);
+
+export const SelectAnyActivityWidget = ({ formContext, ...rest }: any) => (
+  <SelectActivityWidget
+    choices={formContext.connectedActivities}
+    emptyErr="No other activities in the graph, please add an activity"
+    {...rest}
+  />
+);
+
+export const SelectSourceActivityWidget = ({ formContext, ...rest }: any) => (
+  <SelectActivityWidget
+    choices={formContext.connectedSourceActivities}
+    emptyErr="No activities connected, please connect an activity"
+    {...rest}
+  />
+);
+
+export const SelectTargetActivityWidget = ({ formContext, ...rest }: any) => (
+  <SelectActivityWidget
+    choices={formContext.connectedTargetActivities}
+    emptyErr="Not connected to any activities, please connect to an activity"
+    {...rest}
+  />
+);

--- a/frog/imports/ui/GraphEditor/SidePanel/FormUtils/addSocialSchema.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/FormUtils/addSocialSchema.js
@@ -49,13 +49,13 @@ export default (schema: Object, uiSchema: ?Object): Object => {
 
   const sourceActivityMerges = sourceActivityPaths.map(x =>
     set({}, x.filter(y => y !== 'properties'), {
-      'ui:widget': 'targetActivityWidget'
+      'ui:widget': 'sourceActivityWidget'
     })
   );
 
   const targetActivityMerges = targetActivityPaths.map(x =>
     set({}, x.filter(y => y !== 'properties'), {
-      'ui:widget': 'sourceActivityWidget'
+      'ui:widget': 'targetActivityWidget'
     })
   );
 

--- a/frog/imports/ui/GraphEditor/SidePanel/FormUtils/addSocialSchema.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/FormUtils/addSocialSchema.js
@@ -10,8 +10,14 @@ export default (schema: Object, uiSchema: ?Object): Object => {
 
   const newSchema = cloneDeep(schema);
   const paths = traverse.paths(newSchema).filter(x => x.pop() === 'type');
-  const activityPaths = paths.filter(
-    x => get(schema, [...x, 'type']) === 'activity'
+  const anyActivityPaths = paths.filter(
+    x => get(schema, [...x, 'type']) === 'anyActivity'
+  );
+  const targetActivityPaths = paths.filter(
+    x => get(schema, [...x, 'type']) === 'targetActivity'
+  );
+  const sourceActivityPaths = paths.filter(
+    x => get(schema, [...x, 'type']) === 'sourceActivity'
   );
 
   const socialPaths = paths.filter(
@@ -20,9 +26,13 @@ export default (schema: Object, uiSchema: ?Object): Object => {
 
   const rtePaths = paths.filter(x => get(schema, [...x, 'type']) === 'rte');
 
-  [...activityPaths, ...socialPaths, ...rtePaths].forEach(x =>
-    set(newSchema, [...x, 'type'], 'string')
-  );
+  [
+    ...anyActivityPaths,
+    ...targetActivityPaths,
+    ...sourceActivityPaths,
+    ...socialPaths,
+    ...rtePaths
+  ].forEach(x => set(newSchema, [...x, 'type'], 'string'));
 
   delete newSchema.properties.component;
 
@@ -31,9 +41,21 @@ export default (schema: Object, uiSchema: ?Object): Object => {
       'ui:widget': 'socialAttributeWidget'
     })
   );
-  const activityMerges = activityPaths.map(x =>
+  const anyActivityMerges = anyActivityPaths.map(x =>
     set({}, x.filter(y => y !== 'properties'), {
-      'ui:widget': 'activityWidget'
+      'ui:widget': 'anyActivityWidget'
+    })
+  );
+
+  const sourceActivityMerges = sourceActivityPaths.map(x =>
+    set({}, x.filter(y => y !== 'properties'), {
+      'ui:widget': 'targetActivityWidget'
+    })
+  );
+
+  const targetActivityMerges = targetActivityPaths.map(x =>
+    set({}, x.filter(y => y !== 'properties'), {
+      'ui:widget': 'sourceActivityWidget'
     })
   );
 
@@ -65,7 +87,9 @@ export default (schema: Object, uiSchema: ?Object): Object => {
   const newUiSchema = merge(
     uiSchema,
     ...socialMerges,
-    ...activityMerges,
+    ...anyActivityMerges,
+    ...sourceActivityMerges,
+    ...targetActivityMerges,
     ...rteMerges
   );
   return { uiSchema: newUiSchema, schema: newSchema };

--- a/frog/imports/ui/GraphEditor/SidePanel/FormUtils/index.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/FormUtils/index.js
@@ -1,6 +1,10 @@
 // @flow
 
-export { default as SelectActivityWidget } from './SelectActivity';
+export {
+  SelectAnyActivityWidget,
+  SelectTargetActivityWidget,
+  SelectSourceActivityWidget
+} from './SelectActivity';
 export { default as SelectAttributeWidget } from './SelectAttribute';
 export { default as SelectFormWidget } from './SelectForm';
 export { default as addSocialFormSchema } from './addSocialSchema';

--- a/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/EditOperator.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/EditOperator.jsx
@@ -95,8 +95,8 @@ export default ({
         connectedTargetActivities={connectedTargetActivities}
         refreshValidate={refreshValidate}
         reload={
-          connectedSourceActivities.map(x => x.id).join('') +
-          connectedTargetActivities.map(x => x.id).join('')
+          (connectedSourceActivities || []).map(x => x.id).join('') +
+          (connectedTargetActivities || []).map(x => x.id).join('')
         }
       />
     </div>

--- a/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/EditOperator.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/EditOperator.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import FlexView from 'react-flexview';
 import { yellow, red, lightGreen } from 'material-ui/colors';
+import { compact } from 'lodash';
 
 import { ChangeableText } from 'frog-utils';
 
@@ -70,12 +71,21 @@ export default ({
     errorColor = lightGreen[500];
   }
 
-  const connectedNodesIds = connections
-    .filter(con => con.source.id === operator._id)
-    .map(con => con.target.id);
-  const connectedActivities = activities.filter(act =>
-    connectedNodesIds.includes(act.id)
+  const outgoingConnections = connections.filter(
+    conn => conn.source.id === operator._id
   );
+  const incomingConnections = connections.filter(
+    conn => conn.target.id === operator._id
+  );
+  console.log(outgoingConnections, incomingConnections);
+  const connectedTargetActivities = compact(
+    outgoingConnections.map(x => activities.find(act => act.id === x.target.id))
+  );
+  console.log([...activities]);
+  const connectedSourceActivities = compact(
+    incomingConnections.map(x => activities.find(act => act.id === x.source.id))
+  );
+  console.log(connectedSourceActivities, connectedTargetActivities);
   return (
     <div style={{ height: '100%', overflowY: 'scroll', position: 'relative' }}>
       <TopPanel {...{ operator, graphOperator, errorColor, operatorType }} />
@@ -83,7 +93,9 @@ export default ({
         node={operator}
         nodeType={operatorType}
         valid={valid}
-        connectedActivities={connectedActivities}
+        connectedActivities={activities}
+        connectedSourceActivities={connectedSourceActivities}
+        connectedTargetActivities={connectedTargetActivities}
         refreshValidate={refreshValidate}
       />
     </div>

--- a/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/EditOperator.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/EditOperator.jsx
@@ -77,15 +77,12 @@ export default ({
   const incomingConnections = connections.filter(
     conn => conn.target.id === operator._id
   );
-  console.log(outgoingConnections, incomingConnections);
   const connectedTargetActivities = compact(
     outgoingConnections.map(x => activities.find(act => act.id === x.target.id))
   );
-  console.log([...activities]);
   const connectedSourceActivities = compact(
     incomingConnections.map(x => activities.find(act => act.id === x.source.id))
   );
-  console.log(connectedSourceActivities, connectedTargetActivities);
   return (
     <div style={{ height: '100%', overflowY: 'scroll', position: 'relative' }}>
       <TopPanel {...{ operator, graphOperator, errorColor, operatorType }} />
@@ -97,6 +94,10 @@ export default ({
         connectedSourceActivities={connectedSourceActivities}
         connectedTargetActivities={connectedTargetActivities}
         refreshValidate={refreshValidate}
+        reload={
+          connectedSourceActivities.map(x => x.id).join('') +
+          connectedTargetActivities.map(x => x.id).join('')
+        }
       />
     </div>
   );

--- a/op/op-control-group/src/config.js
+++ b/op/op-control-group/src/config.js
@@ -34,7 +34,7 @@ export const config = {
         required: ['activity', 'who'],
         properties: {
           activity: {
-            type: 'activity',
+            type: 'targetActivity',
             title: 'Applies to which activity'
           },
           includeexclude: {

--- a/op/op-performance-select/src/index.js
+++ b/op/op-performance-select/src/index.js
@@ -24,11 +24,11 @@ const config = {
       title: 'Minimum percentage of answers for high-performers'
     },
     activity_low: {
-      type: 'activity',
+      type: 'targetActivity',
       title: 'Activity for low-performance students'
     },
     activity_high: {
-      type: 'activity',
+      type: 'targetActivity',
       title: 'Activity for high-performance students'
     }
   }


### PR DESCRIPTION
Some activities/operators need to select among all activities (ac-dash), outgoing (op-control-group, op-performance-select), and some among incoming activities (the new op-cs211-ranking or any operator with multiple incoming activities)... We started only letting you choose outgoing, then you guys changed it to all, to make ac-dash work. Instead I split it into three choices, so the config can be specific about what it expects. 

It's possible the code could be a bit more concise, but it works - I tested with all three options both for operator and activities. This is required for the cs211 operator to be editable in the graph editor.