### PR TITLE
Salient error message for submit in ac-ranking

### DIFF
--- a/ac/ac-ranking/src/ActivityRunner/index.js
+++ b/ac/ac-ranking/src/ActivityRunner/index.js
@@ -178,6 +178,9 @@ const ActivityRunner = (props: ActivityRunnerPropsT) => {
             <hr style={{ height: '5px' }} />
             {config.justify && <Justification {...props} key="justification" />}
             <div>
+              {data.alert ? (
+                <p style={{ color: 'red' }}>{alertMessage()}</p>
+              ) : null}
               <button
                 onClick={onSubmit}
                 key="submit"
@@ -189,7 +192,6 @@ const ActivityRunner = (props: ActivityRunnerPropsT) => {
               >
                 Submit
               </button>
-              {data.alert ? <p>{alertMessage()}</p> : null}
             </div>
           </ListContainer>
         )}


### PR DESCRIPTION
Changed the message to red and moved it above the submit to make it more obvious. 