### PR TITLE
Force reloading of side panel

### DIFF
--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
@@ -214,6 +214,7 @@ const RawEditActivity = ({
         )}
       </div>
       <ConfigForm
+        key={activity._id}
         node={activity}
         nodeType={activityType}
         valid={props.store.valid}

--- a/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/EditOperator.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/EditOperator.jsx
@@ -87,6 +87,7 @@ export default ({
     <div style={{ height: '100%', overflowY: 'scroll', position: 'relative' }}>
       <TopPanel {...{ operator, graphOperator, errorColor, operatorType }} />
       <ConfigForm
+        key={operator._id}
         node={operator}
         nodeType={operatorType}
         valid={valid}


### PR DESCRIPTION
Jenny had problems with sometimes text from one activity being "stuck" when switching to another activity of the same type in side panel. Keying the component to the activity._id should force a complete reload (ie. constructor being run etc) whenever we're switching activity types.

Eventually we might use this technique to clean up a lot of the reload uuids we're passing down, but for now, this seems like a quick fix that should clear up her problem (awaiting confirmation).