### PR TITLE
Warn if teacher presses next.activity twice within 10 seconds

### DIFF
--- a/frog/imports/ui/TeacherView/utils/buttonUtils.js
+++ b/frog/imports/ui/TeacherView/utils/buttonUtils.js
@@ -18,11 +18,27 @@ import downloadLog from './downloadLog';
 import { runSession, nextActivity } from '../../../api/engine';
 import { exportSession } from './exportComponent';
 
+let lastNext = null;
+
+const throttledNext = sessionId => {
+  if (lastNext && new Date() - lastNext < 10000) {
+    // eslint-disable-next-line no-alert
+    const response = window.confirm(
+      'You very recently pressed next activity. Do you want to advance once more?'
+    );
+    if (!response) {
+      return;
+    }
+  }
+  lastNext = new Date();
+  nextActivity(sessionId);
+};
+
 export const OrchestrationButtonsModel = (session, classes) => ({
   start: {
     tooltip: {
       id: 'tooltip-top',
-      title: 'Star the current session',
+      title: 'Start the current session',
       placement: 'top'
     },
     button: {
@@ -84,7 +100,7 @@ export const OrchestrationButtonsModel = (session, classes) => ({
     },
     button: {
       color: blue[700],
-      onClick: () => nextActivity(session._id),
+      onClick: () => throttledNext(session._id),
       variant: 'raised'
     },
     icon: <SkipNext className={classes.icon} />
@@ -97,7 +113,10 @@ export const OrchestrationButtonsModel = (session, classes) => ({
     },
     button: {
       color: red[700],
-      onClick: () => restartSession(session),
+      onClick: () => {
+        lastNext = null;
+        restartSession(session);
+      },
       variant: 'raised'
     },
     icon: <Refresh className={classes.icon} />


### PR DESCRIPTION
This is to avoid accidental double-clicking (or even fear of such, when you for example first have to focus the page and then click). If the teacher clicks next activity twice within 10 seconds, a confirmation will appear, and it's easy to cancel. 