### PR TITLE
Add blank "dashboard" to dashboard view

### DIFF
--- a/frog/imports/ui/Dashboard/DashboardNav.jsx
+++ b/frog/imports/ui/Dashboard/DashboardNav.jsx
@@ -90,17 +90,18 @@ const DashboardNav = withState('activityId', 'setActivityId', null)(props => {
     <div className={classes.root}>
       <div className={classes.appFrame}>
         <ActivityChoiceMenu
-          activities={acWithDash}
+          activities={[{ title: 'Blank screen', _id: 'blank' }, ...acWithDash]}
           setActivityId={setActivityId}
           activityId={aId}
         />
         <main className={classes.content}>
-          {activityToDash && (
-            <DashboardReactiveWrapper
-              sessionId={session._id}
-              activity={activityToDash}
-            />
-          )}
+          {activityToDash &&
+            (activityToDash === 'blank' ? null : (
+              <DashboardReactiveWrapper
+                sessionId={session._id}
+                activity={activityToDash}
+              />
+            ))}
         </main>
       </div>
     </div>


### PR DESCRIPTION
This adds a fake "Blank" dashboard to the list of activities, an easy way for the teacher to show a clean screen if he doesn't want to show specific data... 

I was also thinking of adding a button at the top next to the dashboard/graph toggle, which would turn on and off display, but I thought this was better for now. Pierre probably won't use it anyway, but we can show him that it's there.