### PR TITLE
Adding help to package-scripts

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -2,6 +2,25 @@ const { sync } = require('find-up');
 const { dirname } = require('path');
 const { readdirSync } = require('fs');
 
+const help = `echo '
+       FROG scripts:
+
+       watch - watch and rebuild all files outside of frog/frog
+        test - run all tests
+      eslint - run ESLint
+  eslint.fix - run ESLint --fix, will format with Prettier
+        flow - run Flow
+  flow.quiet - run Flow --quiet
+        jest - run Jest
+  jest.watch - run Jest in watch mode
+       setup - run initial setup
+ setup.clean - clean all files (will delete files not added to Git) and run setup
+      server - run server (can be run from any directory)
+       build - build current directory
+   build.all - build all directories
+     '
+`;
+
 let dir;
 const findDir = sync('.git');
 if (findDir) {
@@ -47,8 +66,12 @@ module.exports = {
       all: buildAll(),
       ci: buildAll(true)
     },
-    watch: fromRoot('node watch.js watch'),
-    test: fromRoot('nps flow.quiet eslint jest'),
+    watch: fromRoot(
+      `echo 'Watching and transpiling files' & node watch.js watch`
+    ),
+    test: fromRoot(
+      `echo 'Running Flow, ESLint and Jest' & nps -s flow.quiet eslint jest`
+    ),
     eslint: {
       default: fromRoot('eslint -c .eslintrc-prettier.js --ext .js,.jsx .'),
       fix: fromRoot('eslint --fix -c .eslintrc-prettier.js --ext .js,.jsx .')
@@ -60,7 +83,8 @@ module.exports = {
     jest: {
       default: fromRoot('jest'),
       watch: fromRoot('jest --watch')
-    }
+    },
+    help
   },
   options: {
     silent: true

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start": "nps",
-    "test": "nps test",
+    "start": "nps -s",
+    "test": "nps -s test",
     "create-package": "node createPackage.js"
   },
   "workspaces": [


### PR DESCRIPTION
`npm start help` now shows a nice overview of the commands

```
       FROG scripts:

       watch - watch and rebuild all files outside of frog/frog
        test - run all tests
      eslint - run ESLint
  eslint.fix - run ESLint --fix, will format with Prettier
        flow - run Flow
  flow.quiet - run Flow --quiet
        jest - run Jest
  jest.watch - run Jest in watch mode
       setup - run initial setup
 setup.clean - clean all files (will delete files not added to Git) and run setup
      server - run server (can be run from any directory)
       build - build current directory
   build.all - build all directories
```

Also made `nps` quiet by default, so we don't see all the long lists of commands it's running. Added some small prompts. 