### PR TITLE
Fixing undo in graph editor

### DIFF
--- a/frog/imports/ui/GraphEditor/store/activityStore.js
+++ b/frog/imports/ui/GraphEditor/store/activityStore.js
@@ -1,5 +1,5 @@
 import { extendObservable, action } from 'mobx';
-import { omit, maxBy, isEmpty } from 'lodash';
+import { maxBy, isEmpty } from 'lodash';
 
 import Activity from './activity';
 import { duplicateActivity } from '../../../api/activities';
@@ -263,7 +263,13 @@ export default class ActivityStore {
       },
 
       get history(): Array<any> {
-        return this.all.map(x => ({ ...omit(x, 'over') }));
+        return this.all.map(x => ({
+          title: x.title,
+          plane: x.plane,
+          startTime: x.startTime,
+          length: x.length,
+          id: x.id
+        }));
       },
 
       get furthestActivity(): number {

--- a/frog/imports/ui/GraphEditor/store/operatorStore.js
+++ b/frog/imports/ui/GraphEditor/store/operatorStore.js
@@ -1,5 +1,5 @@
 import { extendObservable, action } from 'mobx';
-import { omit, maxBy } from 'lodash';
+import { maxBy } from 'lodash';
 
 import { store } from './index';
 import Operator from './operator';
@@ -46,7 +46,13 @@ export default class OperatorStore {
       },
 
       get history(): Array<any> {
-        return this.all.map(x => ({ ...omit(x, 'over') }));
+        return this.all.map(x => ({
+          time: x.time,
+          y: x.y,
+          type: x.type,
+          id: x.id,
+          title: x.id
+        }));
       },
 
       get furthestOperator(): number {

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -1,4 +1,4 @@
-import { isEqual, sortBy } from 'lodash';
+import { isEmpty, isEqual, sortBy } from 'lodash';
 import { extendObservable, action } from 'mobx';
 import Stringify from 'json-stable-stringify';
 
@@ -65,6 +65,7 @@ const getOneId = (coll: Coll, id: string): ?Elem =>
 export default class Store {
   browserHistory: any;
   url: string;
+  history: any[];
 
   constructor() {
     extendObservable(this, {
@@ -75,7 +76,6 @@ export default class Store {
       session: new Session(),
       ui: new UI(),
       graphId: '',
-      history: [],
       graphErrors: [],
       valid: undefined,
       _graphDuration: 120,
@@ -252,13 +252,15 @@ export default class Store {
         });
       }),
 
-      get canUndo(): boolean {
-        return Boolean(this.history.length > 0);
-      },
-
       undo: action(() => {
-        const [connections, activities, operators] =
-          this.history.length > 1 ? this.history.pop() : this.history[0];
+        const last = this.history.slice(this.history.length - 2);
+        if (this.history.length > 1) {
+          this.history.pop();
+        }
+        if (isEmpty(last)) {
+          return;
+        }
+        const [connections, activities, operators] = last[0];
         this.activityStore.all = activities.map(
           x => new Activity(x.plane, x.startTime, x.title, x.length, x.id)
         );


### PR DESCRIPTION
This should fix undo in the graph editor. I think it broke when we changed the way we define the mobx store, and suddenly the history contents became Reactive, which they shouldn't be. 

I also fixed that we had to click undo twice to undo. Should be quite robust now, but please test in different settings.

Closes #733 
