### PR TITLE
Deal with failing sessionStorage in Preview

### DIFF
--- a/frog/imports/ui/Preview/ErrorWrapper.js
+++ b/frog/imports/ui/Preview/ErrorWrapper.js
@@ -1,0 +1,35 @@
+// @flow
+
+import * as React from 'react';
+
+class ErrorWrapper extends React.Component<
+  { children: any },
+  { error: any, retries: number }
+> {
+  state = { retries: 0, error: null };
+
+  componentDidCatch(error: any) {
+    this.setState(prevState => ({
+      retries: prevState.retries + 1,
+      error
+    }));
+    console.error(
+      'Crashed on previewstate, removing and trying again',
+      sessionStorage.getItem('previewState')
+    );
+    sessionStorage.removeItem('previewstate');
+  }
+
+  render() {
+    const { error, retries } = this.state;
+    const { children } = this.props;
+
+    return error && retries > 2 ? (
+      <h1>Preview failed, try reloading, or opening in another tab</h1>
+    ) : (
+      children
+    );
+  }
+}
+
+export default ErrorWrapper;

--- a/frog/imports/ui/Preview/index.js
+++ b/frog/imports/ui/Preview/index.js
@@ -7,6 +7,7 @@ import { defaultConfig } from 'frog-utils';
 import Preview from './Preview';
 import { activityTypesObj } from '../../activityTypes';
 import { getUserId } from './Controls';
+import ErrorWrapper from './ErrorWrapper';
 
 export const addDefaultExample = (activityType: Object) => [
   {
@@ -105,4 +106,8 @@ class PreviewPage extends React.Component<any, any> {
 
 PreviewPage.displayName = 'PreviewPage';
 
-export default PreviewPage;
+export default (props: any) => (
+  <ErrorWrapper>
+    <PreviewPage {...props} />
+  </ErrorWrapper>
+);


### PR DESCRIPTION
This wraps the Preview dashboard in a custom failure component, which keeps track of how many times it fails. The first time it tries to reset previewState in session storage, and mount the component again. The second time, it fails.

Test by opening preview, go to graph editor, manually edit session storage to say for example activityType: 'something'. Normally this would lead the Preview to fail, but now when going back to Preview, you will just see the Activity Chooser (you can see the error in console). 

Errors can happen when we switch between branches (a branch that has an activity type vs a branch that hasn't), or when there is a bug that causes an incorrect state, even when fixing the bug, the incorrect state is still there.

Closes #1118  