### PR TITLE
 Fixes the offset issues while dragging operators or connections

### DIFF
--- a/frog/imports/ui/GraphEditor/EditorContainer.js
+++ b/frog/imports/ui/GraphEditor/EditorContainer.js
@@ -1,4 +1,6 @@
-import React, { Component } from 'react';
+// @flow
+
+import * as React from 'react';
 import { withStyles } from 'material-ui/styles';
 import ReactTooltip from 'react-tooltip';
 import Grid from 'material-ui/Grid';
@@ -45,14 +47,14 @@ const EditorPanel = () => (
 );
 
 type StateT = {
-  exportOpen: Boolean,
-  importOpen: Boolean,
-  deleteOpen: Boolean,
-  locallyChanged: Boolean,
+  exportOpen: boolean,
+  importOpen: boolean,
+  deleteOpen: boolean,
+  locallyChanged: boolean,
   idRemove: string
 };
 
-class Editor extends Component<Object, StateT> {
+class Editor extends React.Component<Object, StateT> {
   constructor(props) {
     super(props);
     this.state = {

--- a/frog/imports/ui/GraphEditor/Graph.js
+++ b/frog/imports/ui/GraphEditor/Graph.js
@@ -23,7 +23,8 @@ const scrollMouse = e => {
 };
 
 const mousemove = e => {
-  store.ui.socialMove(e.clientX + 10, e.clientY - 75);
+  // We do -100 here because there is 100px above the graph editor
+  store.ui.socialMove(e.clientX, e.clientY - 100);
 };
 
 const Graph = connect(

--- a/frog/imports/ui/GraphEditor/Operator.js
+++ b/frog/imports/ui/GraphEditor/Operator.js
@@ -78,6 +78,7 @@ export default ({
       viewBox="0 0 900 900"
       xmlSpace="preserve"
       overflow="visible"
+      onMouseUp={onClick}
     >
       <circle
         data-tip={title}

--- a/frog/imports/ui/GraphEditor/Operators.js
+++ b/frog/imports/ui/GraphEditor/Operators.js
@@ -1,4 +1,5 @@
 // @flow
+
 import * as React from 'react';
 import Operator from './Operator';
 import { connect, type StoreProp } from './store';
@@ -6,7 +7,7 @@ import { connect, type StoreProp } from './store';
 export default connect(
   ({
     store: {
-      operatorStore: { all: operators },
+      operatorStore: { all: operators, addOperator },
       ui: { socialCoords, socialCoordsScaled },
       state
     },
@@ -20,8 +21,8 @@ export default connect(
           title={op.title}
           transparent={transparent}
           key={op.id}
-          x={coords[0]}
-          y={coords[1]}
+          x={coords[0] - 25}
+          y={coords[1] - 25}
           color={op.color}
           onLeave={op.onLeave}
           onOver={op.onOver}
@@ -39,8 +40,15 @@ export default connect(
     let dragOp;
     if (state.mode === 'placingOperator') {
       const coords = scaled ? socialCoordsScaled : socialCoords;
+      // This -25, -25 is need so that operator are not dragged from
+      // the top left corner when created
       dragOp = (
-        <Operator type={state.operatorType} x={coords[0]} y={coords[1]} />
+        <Operator
+          type={state.operatorType}
+          x={coords[0] - 25}
+          y={coords[1] - 25}
+          onClick={addOperator}
+        />
       );
     } else {
       dragOp = null;

--- a/frog/imports/ui/GraphEditor/components/fixedComponents.js
+++ b/frog/imports/ui/GraphEditor/components/fixedComponents.js
@@ -39,21 +39,21 @@ export const LevelLines = connect(
     scaled
   }: StoreProp & { scaled: boolean }) => (
     <g>
-      {[1, 2, 3, 4].map(x => (
-        <g key={x}>
+      {[1, 2, 3, 4].map(plane => (
+        <g key={plane}>
           <line
             x1={0}
-            y1={x * 100 + 65}
+            y1={(5 - plane) * 100 + 65}
             x2={graphWidth * (scaled ? scale : 4)}
-            y2={x * 100 + 65}
+            y2={(5 - plane) * 100 + 65}
             stroke="grey"
-            strokeWidth={x === 1 ? 2 : 1}
-            strokeDasharray={x === 1 ? '10,10' : '5,5'}
+            strokeWidth={5 - plane === 1 ? 2 : 1}
+            strokeDasharray={5 - plane === 1 ? '10,10' : '5,5'}
           />
           <rect
-            onDoubleClick={e => onDoubleClick(5 - x, e)}
+            onDoubleClick={e => onDoubleClick(plane, e)}
             x={0}
-            y={x * 100 + 45}
+            y={(5 - plane) * 100 + 45}
             width={graphWidth * (scaled ? scale : 4)}
             fill="transparent"
             height={40}

--- a/frog/imports/ui/GraphEditor/store/activity.js
+++ b/frog/imports/ui/GraphEditor/store/activity.js
@@ -247,8 +247,10 @@ export default class Activity extends Elem {
       },
 
       get dragPointFromScaled(): AnchorT {
+        // + 15 on Y because the activity box is 30px high
+        // - 10 on X to be on top of the activity connection dot
         return {
-          X: this.xScaled + this.widthScaled - 15,
+          X: this.xScaled + this.widthScaled - 10,
           Y: this.y + 15,
           dX: 50,
           dY: 0

--- a/frog/imports/ui/GraphEditor/store/connectionStore.js
+++ b/frog/imports/ui/GraphEditor/store/connectionStore.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { extendObservable, action } from 'mobx';
 
 import { type ElementTypes } from './store';
@@ -7,13 +9,15 @@ import Operator from './operator';
 import Connection from './connection';
 import { drawPath } from '../utils/path';
 
-type MongoConnection = {
+type MongoConnectionT = {
   source: { type: ElementTypes, id: string },
   target: { type: ElementTypes, id: string },
   _id: string
 };
 
 export default class ConnectionStore {
+  all: Object[];
+
   constructor() {
     extendObservable(this, {
       all: [],
@@ -46,7 +50,7 @@ export default class ConnectionStore {
         store.ui.cancelScroll();
       }),
 
-      mongoAdd: action((x: MongoConnection) => {
+      mongoAdd: action((x: MongoConnectionT) => {
         if (!store.findId({ type: 'connection', id: x._id })) {
           this.all.push(
             new Connection(
@@ -58,7 +62,7 @@ export default class ConnectionStore {
         }
       }),
 
-      mongoRemove: action((remact: MongoConnection) => {
+      mongoRemove: action((remact: MongoConnectionT) => {
         this.all = this.all.filter(x => x.id !== remact._id);
       }),
 

--- a/frog/imports/ui/GraphEditor/store/operator.js
+++ b/frog/imports/ui/GraphEditor/store/operator.js
@@ -117,40 +117,36 @@ export default class Operator extends Elem {
       },
 
       get dragPointTo(): AnchorT {
-        // operator has size of 60, finding midpoint
         return {
-          X: this.x + 25,
-          Y: this.y + 25,
+          X: this.x,
+          Y: this.y,
           dX: -150,
           dY: 0
         };
       },
 
       get dragPointToScaled(): AnchorT {
-        // operator has size of 60, finding midpoint
         return {
-          X: this.xScaled + 25,
-          Y: this.y + 25,
+          X: this.xScaled,
+          Y: this.y,
           dX: -150,
           dY: 0
         };
       },
 
       get dragPointFrom(): AnchorT {
-        // operator has size of 60, finding midpoint
         return {
-          X: this.x + 25,
-          Y: this.y + 25,
+          X: this.x,
+          Y: this.y,
           dX: 150,
           dY: 0
         };
       },
 
       get dragPointFromScaled(): AnchorT {
-        // operator has size of 60, finding midpoint
         return {
-          X: this.xScaled + 25,
-          Y: this.y + 25,
+          X: this.xScaled,
+          Y: this.y,
           dX: 150,
           dY: 0
         };

--- a/frog/imports/ui/GraphEditor/store/operatorStore.js
+++ b/frog/imports/ui/GraphEditor/store/operatorStore.js
@@ -33,6 +33,16 @@ export default class OperatorStore {
         }
       }),
 
+      addOperator: action(() => {
+        if (store.state.mode === 'placingOperator') {
+          this.all.push(
+            new Operator(...store.ui.socialCoordsTime, store.state.operatorType)
+          );
+          store.state = { mode: 'normal' };
+          store.addHistory();
+        }
+      }),
+
       get mongoObservers(): {
         added: Function,
         changed: Function,

--- a/frog/imports/ui/GraphEditor/store/uiStore.js
+++ b/frog/imports/ui/GraphEditor/store/uiStore.js
@@ -3,7 +3,6 @@ import { extendObservable, action, reaction } from 'mobx';
 import { getActivitySequence } from '/imports/api/graphSequence';
 import { between, timeToPx, pxToTime } from '../utils';
 import { store } from './index';
-import Operator from './operator';
 
 export default class uiStore {
   constructor() {
@@ -161,14 +160,6 @@ export default class uiStore {
       }),
 
       canvasClick: action(() => {
-        const state = store.state;
-        if (state.mode === 'placingOperator') {
-          store.operatorStore.all.push(
-            new Operator(...this.socialCoordsTime, state.operatorType)
-          );
-          store.state = { mode: 'normal' };
-          store.addHistory();
-        }
         store.state = { mode: 'normal' };
         store.ui.selected = null;
       }),

--- a/frog/imports/ui/GraphEditor/utils/path.js
+++ b/frog/imports/ui/GraphEditor/utils/path.js
@@ -18,11 +18,9 @@ export const drawPath = ({
 }) => {
   // parameters for the curviness of the connections
   const q = 50;
-  // parameter for the over bug (mouse can be over the connection while it is also over the activity, so onleave tiggers wrongly)
-  const o = 5;
 
   if (dragging) {
-    return ['M', source.X, source.Y, 'L', target.X - o, target.Y].join(' ');
+    return ['M', source.X, source.Y, 'L', target.X, target.Y].join(' ');
   }
 
   return ['M', source.X, source.Y, 'C']


### PR DESCRIPTION
Replaces #1084 

I moved around an onclick function for creating operators, because I wanted operators to follow the mouse cursor when being created, so the onClick was not registered on the background anymore. 

Please test usecases I haven't thought of