### PR TITLE
Fix operator panel

### DIFF
--- a/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/ChooseOperator.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/ChooseOperator.jsx
@@ -5,11 +5,9 @@ import React, { Component } from 'react';
 import Divider from 'material-ui/Divider';
 import Grid from 'material-ui/Grid';
 import Typography from 'material-ui/Typography';
-import Button from 'material-ui/Button';
 import List from 'material-ui/List';
 import { withStyles } from 'material-ui/styles';
 import Search from '@material-ui/icons/Search';
-import Cloud from '@material-ui/icons/Cloud';
 
 import type { operatorPackageT, OperatorDbT } from 'frog-utils';
 import { Operators } from '/imports/api/activities';
@@ -28,7 +26,7 @@ const styles = {
   topPanel: {
     padding: '10px'
   },
-  activityList: {
+  operatorList: {
     height: 'calc(100vh - 112px - 100px)',
     overflowY: 'auto'
   },
@@ -54,13 +52,6 @@ const styles = {
     whiteSpace: 'normal',
     verticalAlign: 'middle',
     fontSize: '1rem'
-  },
-  centerButton: {
-    textAlign: 'center'
-  },
-  cloudIcon: {
-    marginRight: '8px',
-    fontSize: 20
   },
   resultContainer: {
     height: '100%'
@@ -88,21 +79,17 @@ const ChooseOperatorTopPanel = ({ classes, onSearch }) => (
       <Typography variant="title">Select Operator type</Typography>
     </Grid>
     <Grid item xs={12}>
-      <Grid container justify="center">
-        <Grid item xs={8}>
-          <div className={classes.searchContainer}>
-            <div className={classes.searchIcon}>
-              <Search />
-            </div>
-            <input
-              type="text"
-              onChange={onSearch}
-              className={classes.searchInput}
-              aria-describedby="basic-addon1"
-            />
-          </div>
-        </Grid>
-      </Grid>
+      <div className={classes.searchContainer}>
+        <div className={classes.searchIcon}>
+          <Search />
+        </div>
+        <input
+          type="text"
+          onChange={onSearch}
+          className={classes.searchInput}
+          aria-describedby="search-operator"
+        />
+      </div>
     </Grid>
     <Grid item xs={12}>
       <Divider />
@@ -161,7 +148,7 @@ class ChooseOperatorTypeComp extends Component<PropsT, StateT> {
           <StyledChooseOperatorTopPanel onSearch={this.handleSearch} />
         </Grid>
 
-        <Grid item xs={12} className={classes.activityList}>
+        <Grid item xs={12} className={classes.operatorList}>
           {filteredList.length === 0 ? (
             <StyledNoResult />
           ) : (

--- a/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/ChooseOperator.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/ChooseOperator.jsx
@@ -2,6 +2,15 @@
 
 import React, { Component } from 'react';
 
+import Divider from 'material-ui/Divider';
+import Grid from 'material-ui/Grid';
+import Typography from 'material-ui/Typography';
+import Button from 'material-ui/Button';
+import List from 'material-ui/List';
+import { withStyles } from 'material-ui/styles';
+import Search from '@material-ui/icons/Search';
+import Cloud from '@material-ui/icons/Cloud';
+
 import type { operatorPackageT, OperatorDbT } from 'frog-utils';
 import { Operators } from '/imports/api/activities';
 import { operatorTypes, operatorTypesObj } from '/imports/operatorTypes';
@@ -9,37 +18,131 @@ import { type StoreProp } from '../../store';
 import ListComponent from '../ListComponent';
 
 type PropsT = StoreProp & {
+  classes: Object,
   operator: OperatorDbT
 };
 
 type StateT = { expanded: ?string, searchStr: string };
 
-export default class ChooseOperatorTypeComp extends Component<PropsT, StateT> {
+const styles = {
+  topPanel: {
+    padding: '10px'
+  },
+  activityList: {
+    height: 'calc(100vh - 112px - 100px)',
+    overflowY: 'auto'
+  },
+  searchContainer: {
+    position: 'relative',
+    borderRadius: '5px',
+    background: 'rgba(0,0,0,.05)'
+  },
+  searchIcon: {
+    width: '50px',
+    height: '100%',
+    display: 'flex',
+    position: 'absolute',
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  searchInput: {
+    border: '0',
+    width: '100%',
+    padding: '8px 8px 8px 50px',
+    background: 'none',
+    outline: 'none',
+    whiteSpace: 'normal',
+    verticalAlign: 'middle',
+    fontSize: '1rem'
+  },
+  centerButton: {
+    textAlign: 'center'
+  },
+  cloudIcon: {
+    marginRight: '8px',
+    fontSize: 20
+  },
+  resultContainer: {
+    height: '100%'
+  }
+};
+
+const NoResult = ({ classes }) => (
+  <Grid
+    container
+    justify="center"
+    alignItems="center"
+    className={classes.resultContainer}
+  >
+    <Grid item>
+      <Typography variant="body2">No results found</Typography>
+    </Grid>
+  </Grid>
+);
+
+const StyledNoResult = withStyles(styles)(NoResult);
+
+const ChooseOperatorTopPanel = ({ classes, onSearch }) => (
+  <Grid container className={classes.topPanel} alignItems="center" spacing={8}>
+    <Grid item xs={12}>
+      <Typography variant="title">Select Operator type</Typography>
+    </Grid>
+    <Grid item xs={12}>
+      <Grid container justify="center">
+        <Grid item xs={8}>
+          <div className={classes.searchContainer}>
+            <div className={classes.searchIcon}>
+              <Search />
+            </div>
+            <input
+              type="text"
+              onChange={onSearch}
+              className={classes.searchInput}
+              aria-describedby="basic-addon1"
+            />
+          </div>
+        </Grid>
+      </Grid>
+    </Grid>
+    <Grid item xs={12}>
+      <Divider />
+    </Grid>
+  </Grid>
+);
+
+const StyledChooseOperatorTopPanel = withStyles(styles)(ChooseOperatorTopPanel);
+
+class ChooseOperatorTypeComp extends Component<PropsT, StateT> {
   constructor(props: PropsT) {
     super(props);
     this.state = { expanded: null, searchStr: '' };
   }
 
+  handleSelect = operatorType => () => {
+    const graphOperator = this.props.store.operatorStore.all.find(
+      op => op.id === this.props.operator._id
+    );
+    const newName =
+      operatorTypesObj[operatorType.id].meta.shortName ||
+      operatorTypesObj[operatorType.id].meta.name;
+    Operators.update(this.props.operator._id, {
+      $set: { operatorType: operatorType.id }
+    });
+    graphOperator.rename(newName);
+  };
+
+  handleSearch = e => {
+    this.setState({
+      expanded: null,
+      searchStr: e.target.value.toLowerCase()
+    });
+  };
+
+  handleExpand = (x: operatorPackageT) => () => {
+    this.setState({ expanded: x.id });
+  };
+
   render() {
-    const select = operatorType => {
-      const graphOperator = this.props.store.operatorStore.all.find(
-        op => op.id === this.props.operator._id
-      );
-      const newName =
-        operatorTypesObj[operatorType.id].meta.shortName ||
-        operatorTypesObj[operatorType.id].meta.name;
-      Operators.update(this.props.operator._id, {
-        $set: { operatorType: operatorType.id }
-      });
-      graphOperator.rename(newName);
-    };
-
-    const changeSearch = e =>
-      this.setState({
-        expanded: null,
-        searchStr: e.target.value.toLowerCase()
-      });
-
     const filteredList = operatorTypes
       .filter(x => x.type === this.props.operator.type)
       .filter(
@@ -50,74 +153,37 @@ export default class ChooseOperatorTypeComp extends Component<PropsT, StateT> {
       )
       .sort((x: Object, y: Object) => (x.meta.name < y.meta.name ? -1 : 1));
 
+    const { classes } = this.props;
+
     return (
-      <div
-        style={{
-          height: '100%',
-          width: '100%',
-          transform: 'translateY(-40px)'
-        }}
-      >
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'row',
-            width: '95%',
-            height: '35px'
-          }}
-        >
-          <h4>Please select operator type</h4>
-          <div
-            className="input-group"
-            style={{ top: '5px', left: '10px', width: '240px' }}
-          >
-            <span className="input-group-addon" id="basic-addon1">
-              <span className="glyphicon glyphicon-search" aria-hidden="true" />
-            </span>
-            <input
-              type="text"
-              onChange={changeSearch}
-              className="form-control"
-              placeholder="Search for..."
-              aria-describedby="basic-addon1"
-            />
-          </div>
-        </div>
-        <div
-          className="list-group"
-          style={{
-            height: '93%',
-            width: '100%',
-            overflow: 'scroll',
-            transform: 'translateY(10px)'
-          }}
-        >
+      <Grid container>
+        <Grid item xs={12}>
+          <StyledChooseOperatorTopPanel onSearch={this.handleSearch} />
+        </Grid>
+
+        <Grid item xs={12} className={classes.activityList}>
           {filteredList.length === 0 ? (
-            <div
-              style={{
-                marginTop: '20px',
-                marginLeft: '10px',
-                fontSize: '40px'
-              }}
-            >
-              No result
-            </div>
+            <StyledNoResult />
           ) : (
-            filteredList.map((x: operatorPackageT) => (
-              <ListComponent
-                onSelect={() => select(x)}
-                showExpanded={this.state.expanded === x.id}
-                expand={() => this.setState({ expanded: x.id })}
-                key={x.id}
-                onPreview={() => {}}
-                object={x}
-                searchS={this.state.searchStr}
-                eventKey={x.id}
-              />
-            ))
+            <List>
+              {filteredList.map((x: operatorPackageT) => (
+                <ListComponent
+                  onSelect={this.handleSelect(x)}
+                  showExpanded={this.state.expanded === x.id}
+                  expand={this.handleExpand(x)}
+                  key={x.id}
+                  onPreview={() => {}}
+                  object={x}
+                  searchS={this.state.searchStr}
+                  eventKey={x.id}
+                />
+              ))}
+            </List>
           )}
-        </div>
-      </div>
+        </Grid>
+      </Grid>
     );
   }
 }
+
+export default withStyles(styles)(ChooseOperatorTypeComp);


### PR DESCRIPTION
Why do we have separate components for Choose Activity and Choose Operator? 

The render function is visually the same for both these components (there is  a lot of code like the top panel that is repeated): 
* Choose Activity: https://github.com/chili-epfl/FROG/blob/fix-operator-panel/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/ChooseActivity.js#L99-L142
* Choose Operator: https://github.com/chili-epfl/FROG/blob/fix-operator-panel/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/ChooseOperator.jsx#L146-L171

Closes #1137 