### PR TITLE
Adding types for Mongo Collections - first beginning

### DIFF
--- a/frog-utils/src/index.js
+++ b/frog-utils/src/index.js
@@ -53,6 +53,9 @@ export {
 } from './dataStructureTools';
 export type {
   ActivityDbT,
+  DashboardDataDbT,
+  MongoT,
+  CursorT,
   OperatorDbT,
   studentStructureT,
   socialStructureT,

--- a/frog-utils/src/types.js
+++ b/frog-utils/src/types.js
@@ -259,6 +259,8 @@ export type MongoT<T> = {
   findOne: (string | $Shape<T>, ?Object) => ?T,
   update: (string | $Shape<T>, UpdateQueryT<T>) => void,
   insert: (T, ?(T) => void) => string
+};
+
 type LIRenderPropsT = {|
   children: React.Element<*>,
   editable: Boolean,

--- a/frog-utils/src/types.js
+++ b/frog-utils/src/types.js
@@ -2,18 +2,24 @@
 
 import * as React from 'react';
 
-export type ActivityDbT = {
+export type ActivityDbT = {|
   _id: string,
   data: Object,
   title?: string,
   groupingKey?: string,
-  plane: number,
+  plane?: number,
   startTime: number,
   length: number,
   activityType: string,
   actualStartingTime?: Date,
-  actualClosingTime?: Date
-};
+  actualClosingTime?: Date,
+  parentId?: string
+|};
+
+export type DashboardDataDbT = {|
+  dashId: string,
+  data: any
+|};
 
 export type OperatorDbT = {
   _id: string,
@@ -228,3 +234,27 @@ export type operatorPackageT =
   | socialOperatorT
   | productOperatorT
   | controlOperatorT;
+
+export type CursorT<T> = {
+  fetch: () => T[],
+  map: T => void,
+  forEach: T => void,
+  observe: Object => void,
+  observeChanges: Object => void
+};
+
+type UpdateQueryT<T> = {
+  $set?: $Shape<T>,
+  $inc?: { [key: $Keys<T>]: number },
+  $unset?: { [key: $Keys<T>]: any }
+};
+
+export type MongoT<T> = {
+  find: (
+    string | $Shape<T> | { [$Keys<T>]: { $in: any } },
+    ?Object
+  ) => CursorT<T>,
+  findOne: (string | $Shape<T>, ?Object) => ?T,
+  update: (string | $Shape<T>, UpdateQueryT<T>) => void,
+  insert: (T, ?(T) => void) => string
+};

--- a/frog/imports/api/activities.js
+++ b/frog/imports/api/activities.js
@@ -2,7 +2,7 @@
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import { omitBy, isNil } from 'lodash';
-import { uuid } from 'frog-utils';
+import { uuid, type MongoT, type DashboardDataDbT } from 'frog-utils';
 
 import { operatorTypesObj } from '../operatorTypes';
 import { Graphs } from './graphs';
@@ -12,7 +12,9 @@ import { Sessions } from './sessions';
 export const Activities = new Mongo.Collection('activities');
 export const Operators = new Mongo.Collection('operators');
 export const Connections = new Mongo.Collection('connections');
-export const DashboardData = new Mongo.Collection('dashboard_data');
+export const DashboardData: MongoT<DashboardDataDbT> = new Mongo.Collection(
+  'dashboard_data'
+);
 
 export const addActivity = (
   activityType: string,

--- a/frog/imports/api/engine.js
+++ b/frog/imports/api/engine.js
@@ -29,7 +29,7 @@ export const updateNextOpenActivities = (
   const nextActivities = futureOpen.map(x => ({
     activityId: x._id,
     description: `${x.title || ''} (${
-      x.plane === 4 ? 'teacher task' : 'p' + x.plane
+      x.plane === 4 ? 'teacher task' : 'p' + (x.plane || '')
     })`
   }));
   Sessions.update(sessionId, {


### PR DESCRIPTION
As discussed in #1096, it would be great if we could define types for Mongo collections and have them enforced everywhere. Turns out this is possible. 

In this PR, I'm adding a number of generic type definitions for Mongo collections (these are by no means complete, but they should cover the things we currently do). Some things are hard to type, like ensuring that $set: {name: 111} fails, because name has been declared a string. I think this is possible, but I need to ask for help.

The most important thing is that when you get an object from find.fetch() or findOne, it's already fully typed!

However, this causes a lot of Flow errors, so it has to be introduced slowly - I started with a very simple Collection, DashboardData, which is only used in a few places. I intend to gradually introduce typing for the other elements.

For Activities, we might need to have separate types for activities in graphs and activities in sessions - in a session, we should be able to expect that an activity has a plane, start time/end time etc, but not for an activity in a graph/activity library... 