### PR TITLE
Add operator by clicking S/P/C while a connection is selected

### DIFF
--- a/frog/imports/ui/GraphEditor/store/operatorStore.js
+++ b/frog/imports/ui/GraphEditor/store/operatorStore.js
@@ -3,6 +3,7 @@ import { maxBy } from 'lodash';
 
 import { store } from './index';
 import Operator from './operator';
+import Connection from './connection';
 
 export type OperatorTypes = 'product' | 'social' | 'control';
 
@@ -28,7 +29,22 @@ export default class OperatorStore {
       }),
 
       place: action((type: OperatorTypes) => {
-        if (store.state.mode === 'normal') {
+        if (store.ui.selected?.klass === 'connection') {
+          const source = store.ui.selected.source;
+          const target = store.ui.selected.target;
+          const y = (source.dragPointFrom.Y + target.dragPointTo.Y) / 2;
+          const time =
+            ((source.klass === 'activity'
+              ? source.startTime + source.length
+              : source.time) +
+              (target.klass === 'activity' ? target.startTime : target.time)) /
+            2;
+          const newOp = new Operator(time, y, type);
+          this.all.push(newOp);
+          store.ui.selected.remove(false);
+          store.connectionStore.all.push(new Connection(source, newOp));
+          store.connectionStore.all.push(new Connection(newOp, target));
+        } else if (store.state.mode === 'normal') {
           store.state = { mode: 'placingOperator', operatorType: type };
         }
       }),


### PR DESCRIPTION
This goes in the category of "can't believe I didn't think of that before" alternatively "can't believe how easy it was". Select a connection, click S/P/C, and a social/product/control operator is placed in the middle of the connection, the connection is removed, and the source is connected to the operator, and the operator to the target.

<img width="1257" alt="screen shot 2018-05-14 at 11 05 32" src="https://imgur.com/download/1lYmNVB">
