### PR TITLE
Ability to reset type of activities and operators

### DIFF
--- a/frog/imports/api/activities.js
+++ b/frog/imports/api/activities.js
@@ -15,7 +15,7 @@ export const Connections = new Mongo.Collection('connections');
 export const DashboardData = new Mongo.Collection('dashboard_data');
 
 export const addActivity = (
-  activityType: string,
+  activityType?: string,
   data: ?Object = {},
   id: string,
   groupingKey: ?string,
@@ -34,6 +34,14 @@ export const addActivity = (
       createdAt: new Date()
     });
   }
+};
+
+export const removeActivityType = (id: string) => {
+  Activities.update(id, { $unset: { activityType: null, data: null } });
+};
+
+export const removeOperatorType = (id: string) => {
+  Operators.update(id, { $unset: { operatorType: null, data: null } });
 };
 
 export const setParticipation = (

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
@@ -199,7 +199,10 @@ const RawEditActivity = ({
             <DeleteButton
               tooltip="Reset activity"
               msg="Do you really want to remove the activity type, and loose all the configuration data?"
-              onConfirmation={() => removeActivityType(activity._id)}
+              onConfirmation={() => {
+                removeActivityType(activity._id);
+                props.store.refreshValidate();
+              }}
             />
           </FlexView>
         </div>

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import FlexView from 'react-flexview';
 import ReactTooltip from 'react-tooltip';
-import { FormGroup, FormControl, Button } from 'react-bootstrap';
+import { FormGroup, FormControl } from 'react-bootstrap';
 import { yellow, red, lightGreen } from 'material-ui/colors';
 import copy from 'copy-to-clipboard';
 import { withState, compose } from 'recompose';
@@ -13,6 +13,7 @@ import { compact } from 'lodash';
 import { activityTypesObj } from '/imports/activityTypes';
 import {
   addActivity,
+  removeActivityType,
   setStreamTarget,
   setParticipation
 } from '/imports/api/activities';
@@ -23,7 +24,9 @@ import { RenameField } from '../../Rename';
 import FileForm from '../fileUploader';
 import ExportButton from './ExportButton';
 import { SelectAttributeWidget } from '../FormUtils';
+import { IconButton } from '../index';
 import ConfigForm from '../ConfigForm';
+import DeleteButton from '../DeleteButton';
 
 const StreamSelect = ({ activity, targets, onChange }) => (
   <FormGroup controlId="selectGrouping">
@@ -193,6 +196,11 @@ const RawEditActivity = ({
                 <ExportButton {...{ activity, madeChanges }} />
               </div>
             )}
+            <DeleteButton
+              tooltip="Reset activity"
+              msg="Do you really want to remove the activity type, and loose all the configuration data?"
+              onConfirmation={() => removeActivityType(activity._id)}
+            />
           </FlexView>
         </div>
         {activity.plane === 2 && (
@@ -271,18 +279,6 @@ const RawEditActivity = ({
     </div>
   );
 };
-
-export const IconButton = ({ icon, onClick, tooltip }: Object) => (
-  <div className="bootstrap">
-    <Button
-      style={{ width: '35px', height: '25px' }}
-      data-tip={tooltip}
-      onClick={onClick}
-    >
-      <span className={icon} style={{ verticalAlign: 'top' }} />
-    </Button>
-  </div>
-);
 
 const EditActivity = compose(
   withState('advancedOpen', 'setAdvancedOpen', false),

--- a/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/ExportButton.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/ActivityPanel/ExportButton.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { withState } from 'recompose';
 import Modal from '../../RemoteControllers/ModalExport';
-import { IconButton } from './EditActivity';
+import { IconButton } from '../index';
 
 const StatelessExportButton = (props: Object) => (
   <div>

--- a/frog/imports/ui/GraphEditor/SidePanel/DeleteButton.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/DeleteButton.js
@@ -1,0 +1,44 @@
+// @flow
+
+import * as React from 'react';
+import Dialog, {
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle
+} from 'material-ui/Dialog';
+import Button from 'material-ui/Button';
+import { withVisibility } from 'frog-utils';
+import { IconButton } from './index';
+
+export default withVisibility(
+  ({ msg, onConfirmation, visible, setVisibility, tooltip }: Object) => (
+    <React.Fragment>
+      <IconButton
+        onClick={() => setVisibility(true)}
+        icon="glyphicon glyphicon-trash"
+        tooltip={tooltip}
+      />
+
+      <Dialog open={visible}>
+        <DialogTitle>Confirmation</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{msg}</DialogContentText>
+        </DialogContent>
+        <div style={{ height: '10px' }} />
+        <DialogActions>
+          <Button onClick={() => setVisibility(false)}>Cancel</Button>
+          <Button
+            color="secondary"
+            onClick={() => {
+              setVisibility(false);
+              onConfirmation();
+            }}
+          >
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </React.Fragment>
+  )
+);

--- a/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/EditOperator.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/EditOperator.jsx
@@ -8,12 +8,20 @@ import { compact } from 'lodash';
 
 import { ChangeableText } from 'frog-utils';
 
+import { removeOperatorType } from '/imports/api/activities';
 import { operatorTypesObj } from '/imports/operatorTypes';
 import { ErrorList, ValidButton } from '../../Validator';
 import { type StoreProp } from '../../store';
 import ConfigForm from '../ConfigForm';
+import DeleteButton from '../DeleteButton';
 
-const TopPanel = ({ operator, graphOperator, errorColor, operatorType }) => (
+const TopPanel = ({
+  refreshValidate,
+  operator,
+  graphOperator,
+  errorColor,
+  operatorType
+}) => (
   <div style={{ backgroundColor: '#eee' }}>
     <div style={{ position: 'absolute', left: -40 }}>
       <ErrorList activityId={operator._id} />
@@ -28,8 +36,23 @@ const TopPanel = ({ operator, graphOperator, errorColor, operatorType }) => (
           />
         </h3>
       </div>
-      <FlexView marginLeft="auto">
+      <FlexView
+        marginLeft="auto"
+        style={{
+          flexDirection: 'column',
+          position: 'absolute',
+          right: '2px'
+        }}
+      >
         <ValidButton activityId={operator._id} errorColor={errorColor} />
+        <DeleteButton
+          tooltip="Reset operator"
+          msg="Do you really want to remove the operator type, and loose all the configuration data?"
+          onConfirmation={() => {
+            removeOperatorType(operator._id);
+            refreshValidate();
+          }}
+        />
       </FlexView>
     </FlexView>
     <font size={-3}>
@@ -85,7 +108,15 @@ export default ({
   );
   return (
     <div style={{ height: '100%', overflowY: 'scroll', position: 'relative' }}>
-      <TopPanel {...{ operator, graphOperator, errorColor, operatorType }} />
+      <TopPanel
+        {...{
+          refreshValidate,
+          operator,
+          graphOperator,
+          errorColor,
+          operatorType
+        }}
+      />
       <ConfigForm
         key={operator._id}
         node={operator}

--- a/frog/imports/ui/GraphEditor/SidePanel/index.js
+++ b/frog/imports/ui/GraphEditor/SidePanel/index.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { withStyles } from 'material-ui/styles';
 import Grid from 'material-ui/Grid';
 import Typography from 'material-ui/Typography';
+import { Button } from 'react-bootstrap';
 
 import { connect } from '../store';
 import ActivityPanel from './ActivityPanel';
@@ -37,6 +38,18 @@ const SideBarHelperText = ({ classes }) => (
       </Typography>
     </div>
   </Grid>
+);
+
+export const IconButton = ({ icon, onClick, tooltip }: Object) => (
+  <div className="bootstrap">
+    <Button
+      style={{ width: '35px', height: '25px' }}
+      data-tip={tooltip}
+      onClick={onClick}
+    >
+      <span className={icon} style={{ verticalAlign: 'top' }} />
+    </Button>
+  </div>
 );
 
 const StyledSideBarHelperText = withStyles(styles)(SideBarHelperText);


### PR DESCRIPTION
Add small icon in side panel for activities and operators that allows to reset type - useful to avoid having to wire up connections again etc. Asks for confirmation first.