### PR TITLE
Add option for enable/disable analysis

### DIFF
--- a/ac/ac-videochat/src/config.js
+++ b/ac/ac-videochat/src/config.js
@@ -55,6 +55,11 @@ export const config = {
       title: 'Mute participants by default',
       default: false
     },
+    useAnalysis: {
+      type: 'boolean',
+      title: 'Use analysis',
+      default: true
+    },
     teacherNames: {
       type: 'string',
       title: 'Comma-separated list of user names of admins'


### PR DESCRIPTION
Disabling analysis in config will disable all usages of analysis:
- dashboard won't show any data
- participants in a state.participants will always have "isSpeaking" on false 