### PR TITLE
Li dashboard

### DIFF
--- a/frog/imports/ui/Dashboard/DashboardNav.jsx
+++ b/frog/imports/ui/Dashboard/DashboardNav.jsx
@@ -13,6 +13,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import { Activities } from '../../api/activities';
 import { activityTypesObj } from '../../activityTypes';
 import { DashboardReactiveWrapper } from './index';
+import LIDashboard from './LIDashboard';
 
 const drawerWidth = 220;
 
@@ -60,6 +61,12 @@ const ActivityChoiceMenu = withStyles(styles)(
     >
       <div className={classes.toolbar} />
       <List>
+        <ListItem button onClick={() => setActivityId('LI')}>
+          <ListItemText
+            primary={activityId === 'LI' && 'Learning Items Dashboard'}
+            secondary={activityId !== 'LI' && 'Learning Items Dashboard'}
+          />
+        </ListItem>
         {activities.map(ac => (
           <ActivityChoiceLI
             key={ac._id}
@@ -97,6 +104,8 @@ const DashboardNav = withState('activityId', 'setActivityId', null)(props => {
           activityId={aId}
         />
         <main className={classes.content}>
+          {activityId === 'LI' && <LIDashboard sessionId={session._id} />}
+
           {activityToDash &&
             (activityToDash === 'blank' ? null : (
               <DashboardReactiveWrapper

--- a/frog/imports/ui/Dashboard/ImageBox.js
+++ b/frog/imports/ui/Dashboard/ImageBox.js
@@ -13,18 +13,6 @@ const styles = theme => ({
   })
 });
 
-const getStyle = styleCode =>
-  ({
-    chosen_by_team: {
-      border: 'solid 4px #009900',
-      borderRadius: '5px'
-    },
-    chosen_partially: {
-      border: 'solid 4px #FFFF00',
-      borderRadius: '5px'
-    }
-  }[styleCode] || { border: 'solid 2px #a0a0a0' });
-
 const ImgButton = styled.button`
   position: relative;
   border: none;
@@ -63,6 +51,5 @@ const ImageBox = ({
     </Paper>
   </ImgButton>
 );
-// style={getStyle(styleCode)}
 ImageBox.displayName = 'ImageBox';
 export default withStyles(styles)(ImageBox);

--- a/frog/imports/ui/Dashboard/ImageBox.js
+++ b/frog/imports/ui/Dashboard/ImageBox.js
@@ -1,40 +1,27 @@
 // @flow
 
 import React from 'react';
-import styled from 'styled-components';
 import Paper from '@material-ui/core/Paper';
 import { withStyles } from '@material-ui/core/styles';
 
-const styles = theme => ({
-  root: theme.mixins.gutters({
-    marginLeft: 20,
-    paddingTop: 36,
-    paddingBottom: 16
-  })
+const styles = () => ({
+  root: {
+    height: '100%',
+    width: '100%',
+    padding: '20px'
+  },
+  image: {
+    position: 'relative',
+    border: 'none',
+    background: 'none',
+    maxWidth: '250px',
+    height: '250px',
+    width: '100%',
+    margin: '5px',
+    padding: '0px',
+    flex: '0 1 auto'
+  }
 });
-
-const ImgButton = styled.button`
-  position: relative;
-  border: none;
-  background: none;
-  max-width: 250px;
-  height: 250px;
-  width: 100%;
-  margin: 5px;
-  padding: 0px;
-  flex: 0 1 auto;
-`;
-
-export const CenteredImg = styled.div`
-  position: absolute;
-  max-width: 100%;
-  max-height: 100%;
-  height: 100%;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  padding: 5%;
-`;
 
 const ImageBox = ({
   children,
@@ -45,11 +32,11 @@ const ImageBox = ({
   children: any,
   classes: any
 }) => (
-  <ImgButton onClick={onClick}>
-    <Paper elevation={24} className={classes.root}>
+  <button onClick={onClick} className={classes.image}>
+    <Paper elevation={4} className={classes.root}>
       {children}
     </Paper>
-  </ImgButton>
+  </button>
 );
 ImageBox.displayName = 'ImageBox';
 export default withStyles(styles)(ImageBox);

--- a/frog/imports/ui/Dashboard/ImageBox.js
+++ b/frog/imports/ui/Dashboard/ImageBox.js
@@ -1,0 +1,68 @@
+// @flow
+
+import React from 'react';
+import styled from 'styled-components';
+import Paper from '@material-ui/core/Paper';
+import { withStyles } from '@material-ui/core/styles';
+
+const styles = theme => ({
+  root: theme.mixins.gutters({
+    marginLeft: 20,
+    paddingTop: 36,
+    paddingBottom: 16
+  })
+});
+
+const getStyle = styleCode =>
+  ({
+    chosen_by_team: {
+      border: 'solid 4px #009900',
+      borderRadius: '5px'
+    },
+    chosen_partially: {
+      border: 'solid 4px #FFFF00',
+      borderRadius: '5px'
+    }
+  }[styleCode] || { border: 'solid 2px #a0a0a0' });
+
+const ImgButton = styled.button`
+  position: relative;
+  border: none;
+  background: none;
+  max-width: 250px;
+  height: 250px;
+  width: 100%;
+  margin: 5px;
+  padding: 0px;
+  flex: 0 1 auto;
+`;
+
+export const CenteredImg = styled.div`
+  position: absolute;
+  max-width: 100%;
+  max-height: 100%;
+  height: 100%;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  padding: 5%;
+`;
+
+const ImageBox = ({
+  children,
+  onClick,
+  classes
+}: {
+  onClick: Function,
+  children: any,
+  classes: any
+}) => (
+  <ImgButton onClick={onClick}>
+    <Paper elevation={24} className={classes.root}>
+      {children}
+    </Paper>
+  </ImgButton>
+);
+// style={getStyle(styleCode)}
+ImageBox.displayName = 'ImageBox';
+export default withStyles(styles)(ImageBox);

--- a/frog/imports/ui/Dashboard/LIDashboard.js
+++ b/frog/imports/ui/Dashboard/LIDashboard.js
@@ -1,0 +1,224 @@
+// @flow
+import * as React from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import { Meteor } from 'meteor/meteor';
+import styled from 'styled-components';
+import {
+  Paper,
+  Tooltip,
+  TextField,
+  Button,
+  Menu,
+  MenuItem,
+  Table,
+  TableRow,
+  TableCell,
+  TableBody
+} from '@material-ui/core';
+import { generateReactiveFn } from 'frog-utils';
+
+import { learningItemTypesObj } from '../../activityTypes';
+import { Activities } from '../../api/activities';
+import { Sessions } from '../../api/sessions';
+import ImageBox from './ImageBox';
+import LI from '../LearningItem';
+import { connection } from '../App/connection';
+
+const doc = connection.get('li', 'displayLI');
+const dataFn = generateReactiveFn(doc, LI);
+const LearningItem = dataFn.LearningItem;
+
+class MyMenu extends React.Component<any, any> {
+  state = { open: false };
+
+  render() {
+    return (
+      <React.Fragment>
+        <Button onClick={e => this.setState({ open: e.currentTarget })}>
+          {this.props.title}
+        </Button>
+        {this.state.open && (
+          <Menu open={!!this.state.open} anchorEl={this.state.open}>
+            {this.props.choices.map(x => (
+              <MenuItem
+                key={x.key}
+                onClick={() => {
+                  this.setState({ open: null });
+                  x.onClick();
+                }}
+              >
+                {x.title}
+              </MenuItem>
+            ))}
+          </Menu>
+        )}
+      </React.Fragment>
+    );
+  }
+}
+
+class Dashboard extends React.Component<any, any> {
+  state = {
+    results: [],
+    search: '',
+    filter: undefined,
+    filterTitle: undefined
+  };
+
+  componentDidMount() {
+    const subscription = connection.createSubscribeQuery(
+      'li',
+      { sessionId: this.props.sessionId, draft: { $ne: true } },
+      {},
+      (err, results) =>
+        this.setState({ results: results.map(x => ({ ...x.data, id: x.id })) })
+    );
+    subscription.on('changed', e =>
+      this.setState({ results: e.map(x => ({ ...x.data, id: x.id })) })
+    );
+  }
+
+  render() {
+    let res = this.state.results;
+    if (this.state.filter) {
+      res = this.state.results.filter(
+        x => x.createdInActivity === this.state.filter
+      );
+    }
+    if (this.state.search.trim() !== '') {
+      res = res.filter(x =>
+        JSON.stringify(x.payload).includes(this.state.search.trim())
+      );
+    }
+    const graphId = Sessions.findOne(this.props.sessionId).graphId;
+    return (
+      <div style={{ height: '900px' }}>
+        <div>
+          <MyMenu
+            title={this.state.filterTitle || 'All activities'}
+            choices={[
+              {
+                title: 'All activities',
+                key: 'all',
+                onClick: () =>
+                  this.setState({ filter: undefined, filterTitle: undefined })
+              },
+              ...Activities.find({ graphId })
+                .fetch()
+                .map(x => ({
+                  title: x.title,
+                  key: x._id,
+                  onClick: () =>
+                    this.setState({ filter: x._id, filterTitle: x.title })
+                }))
+            ]}
+          />
+          <TextField
+            id="name"
+            label="Search"
+            onChange={e => this.setState({ search: e.target.value })}
+            margin="normal"
+          />
+        </div>
+        {res.map(x => (
+          <Tooltip key={x.id} id={'tooltip' + x.id} title="Hi">
+            <ImageBox key={x.id} onClick={() => this.setState({ zoom: x.id })}>
+              <LearningItem type="thumbView" id={x.id} clickZoomable />
+            </ImageBox>
+          </Tooltip>
+        ))}
+        {this.state.zoom && (
+          <ZoomView
+            id={this.state.zoom}
+            close={() => this.setState({ zoom: undefined })}
+          />
+        )}
+      </div>
+    );
+  }
+}
+// @flow
+
+const zoomstyles = theme => ({
+  root: theme.mixins.gutters({
+    paddingTop: 36,
+    paddingBottom: 16,
+    height: '100%'
+  })
+});
+
+const ZoomContainer = styled.div`
+  position: absolute;
+  top: 10%;
+  z-index: 1;
+  width: 600px;
+  background: rgba(50, 50, 50, 0.8);
+`;
+
+const ZoomViewRaw = ({ close, id, classes }: Object) => (
+  <ZoomContainer>
+    <LearningItem
+      id={id}
+      type="history"
+      render={props => (
+        <Paper className={classes.root} elevation={24}>
+          <div className="bootstrap">
+            <button
+              onClick={close}
+              className="btn btn-secondary"
+              style={{ position: 'absolute', right: '0px' }}
+            >
+              <span className="glyphicon glyphicon-remove" />
+            </button>
+          </div>
+          <div style={{ layout: 'flex', flexDirection: 'row' }}>
+            <div style={{ marginBottom: '50px' }}>{props.children}</div>
+            <hr />
+            <div>
+              <div>
+                <Table>
+                  <TableBody>
+                    <TableRow>
+                      <TableCell>Learning Item Type</TableCell>
+                      <TableCell>
+                        {learningItemTypesObj[props.liType].name}
+                      </TableCell>
+                      <TableCell>Created by</TableCell>
+                      <TableCell>
+                        {
+                          Meteor.users.findOne(props.data.createdByUser)
+                            ?.username
+                        }
+                      </TableCell>
+                    </TableRow>
+                    <TableRow>
+                      <TableCell>Created by group</TableCell>
+                      <TableCell>
+                        {JSON.stringify(props.data.createdByInstance)}
+                      </TableCell>
+                      <TableCell>Created in activity</TableCell>
+                      <TableCell>
+                        {
+                          Activities.findOne(props.data.createdInActivity)
+                            ?.title
+                        }
+                      </TableCell>
+                    </TableRow>
+                    <TableRow>
+                      <TableCell>Created at</TableCell>
+                      <TableCell>{props.data.createdAt || ''}</TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </div>
+            </div>
+          </div>
+        </Paper>
+      )}
+    />
+  </ZoomContainer>
+);
+
+const ZoomView = withStyles(zoomstyles)(ZoomViewRaw);
+
+export default Dashboard;

--- a/frog/imports/ui/Dashboard/LIDashboard.js
+++ b/frog/imports/ui/Dashboard/LIDashboard.js
@@ -174,44 +174,34 @@ const ZoomViewRaw = ({ close, id, classes }: Object) => (
           <div style={{ layout: 'flex', flexDirection: 'row' }}>
             <div style={{ marginBottom: '50px' }}>{props.children}</div>
             <hr />
-            <div>
-              <div>
-                <Table>
-                  <TableBody>
-                    <TableRow>
-                      <TableCell>Learning Item Type</TableCell>
-                      <TableCell>
-                        {learningItemTypesObj[props.liType].name}
-                      </TableCell>
-                      <TableCell>Created by</TableCell>
-                      <TableCell>
-                        {
-                          Meteor.users.findOne(props.data.createdByUser)
-                            ?.username
-                        }
-                      </TableCell>
-                    </TableRow>
-                    <TableRow>
-                      <TableCell>Created by group</TableCell>
-                      <TableCell>
-                        {JSON.stringify(props.data.createdByInstance)}
-                      </TableCell>
-                      <TableCell>Created in activity</TableCell>
-                      <TableCell>
-                        {
-                          Activities.findOne(props.data.createdInActivity)
-                            ?.title
-                        }
-                      </TableCell>
-                    </TableRow>
-                    <TableRow>
-                      <TableCell>Created at</TableCell>
-                      <TableCell>{props.data.createdAt || ''}</TableCell>
-                    </TableRow>
-                  </TableBody>
-                </Table>
-              </div>
-            </div>
+            <Table>
+              <TableBody>
+                <TableRow>
+                  <TableCell>Learning Item Type</TableCell>
+                  <TableCell>
+                    {learningItemTypesObj[props.liType].name}
+                  </TableCell>
+                  <TableCell>Created by</TableCell>
+                  <TableCell>
+                    {Meteor.users.findOne(props.data.createdByUser)?.username}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Created by group</TableCell>
+                  <TableCell>
+                    {JSON.stringify(props.data.createdByInstance)}
+                  </TableCell>
+                  <TableCell>Created in activity</TableCell>
+                  <TableCell>
+                    {Activities.findOne(props.data.createdInActivity)?.title}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Created at</TableCell>
+                  <TableCell>{props.data.createdAt || ''}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
           </div>
         </Paper>
       )}

--- a/frog/imports/ui/LearningItem/RenderLearningItem.js
+++ b/frog/imports/ui/LearningItem/RenderLearningItem.js
@@ -80,6 +80,7 @@ class RenderLearningItem extends React.Component<any, any> {
     if (render) {
       return render({
         dataFn,
+        data,
         children: Comp,
         editable: liType.Editor,
         zoomable: liType.Viewer,


### PR DESCRIPTION
Adds a default dashboard which shows all LIs that are part of the graph. Currently show only LIs stored as ShareDB documents, which is usually what we want (ie creative works and not tweets etc). When zoomed in, you can view the history of any element, you can do a free-text search (not case insensitive yet), and filter by specific activities (where the LI was created). I'm sure we can do more around this in the future, but it's a good start.