### PR TITLE
Conditional import to decrease bundle size

### DIFF
--- a/frog/imports/activityTypes.js
+++ b/frog/imports/activityTypes.js
@@ -1,6 +1,7 @@
 // @flow
 
 import importAll from 'import-all.macro';
+import Loadable from 'react-loadable';
 import { keyBy } from 'lodash';
 import {
   type ActivityPackageT,
@@ -28,20 +29,34 @@ export const activityTypesObj: { [at: string]: ActivityPackageT } = entries(
 
 export const activityTypes: ActivityPackageT[] = values(activityTypesObj);
 
-const activityRunnersRaw = importAll.sync(
+const activityRunnersRaw = importAll.deferred(
   '../node_modules/ac-*/src/ActivityRunner?(.js)'
 );
 export const activityRunnersExt = entries(activityRunnersRaw).reduce(
-  (acc, [k, v]) => ({ ...acc, [k.split('/')[2]]: v.default }),
+  (acc, [k, v]) => ({
+    ...acc,
+    [k.split('/')[2]]: Loadable({
+      loader: v,
+      loading: () => null,
+      serverSideRequirePath: k
+    })
+  }),
   {}
 );
 
-const activityRunnersRawInternal = importAll.sync(
+const activityRunnersRawInternal = importAll.deferred(
   './internalActivities/*/ActivityRunner?(.js)'
 );
 
 export const activityRunners = entries(activityRunnersRawInternal).reduce(
-  (acc, [k, v]) => ({ ...acc, [k.split('/')[2]]: v.default }),
+  (acc, [k, v]) => ({
+    ...acc,
+    [k.split('/')[2]]: Loadable({
+      loader: v,
+      loading: () => null,
+      serverSideRequirePath: k
+    })
+  }),
   activityRunnersExt
 );
 

--- a/frog/imports/internalActivities/ac-dash/index.js
+++ b/frog/imports/internalActivities/ac-dash/index.js
@@ -1,7 +1,14 @@
 // @flow
 
 import type { ActivityPackageT } from 'frog-utils';
-import ConfigComponent from './config.js';
+import Loadable from 'react-loadable';
+import path from 'path';
+
+const ConfigComponent = Loadable({
+  loader: () => import('./config.js'),
+  loading: () => null,
+  serverSideRequirePath: path.resolve(__dirname, './config.js')
+});
 
 export const meta = {
   name: 'Dashboard activity',

--- a/frog/imports/ui/App/index.js
+++ b/frog/imports/ui/App/index.js
@@ -5,6 +5,8 @@ import { InjectData } from 'meteor/staringatlights:inject-data';
 import { Accounts } from 'meteor/accounts-base';
 import * as React from 'react';
 import Modal from 'react-modal';
+import Loadable from 'react-loadable';
+import path from 'path';
 import {
   BrowserRouter as Router,
   Redirect,
@@ -19,8 +21,17 @@ import NotLoggedIn from './NotLoggedIn';
 import { ErrorBoundary } from './ErrorBoundary';
 import StudentView from '../StudentView';
 import StudentLogin from '../StudentView/StudentLogin';
-import APICall from './APICall';
-import TeacherLoadable from './TeacherContainer';
+
+const TeacherContainer = Loadable({
+  loader: () => import('./TeacherContainer'),
+  loading: () => null,
+  serverSideRequirePath: path.resolve(__dirname, './TeacherContainer')
+});
+const APICall = Loadable({
+  loader: () => import('./APICall'),
+  loading: () => null,
+  serverSideRequirePath: path.resolve(__dirname, './APICall')
+});
 
 Accounts._autoLoginEnabled = false;
 Accounts._initLocalStorage();
@@ -175,7 +186,7 @@ const FROGRouter = withRouter(
           return (
             <Switch>
               <Route path="/projector/:slug" component={StudentView} />
-              <Route component={TeacherLoadable} />
+              <Route component={TeacherContainer} />
             </Switch>
           );
         } else {


### PR DESCRIPTION
In #1222, I describe efforts to reduce bundle-size. This PR makes the teacher view dynamic, all the ActivityRunners (but not learning items or dashboards), as well as the API runner... I have tested this in production etc, and it seems to work well. We need to test this more at scale before the fall to make sure it works with hundreds of students.

We can reduce the size more by getting rid of / combining large dependencies. We also have to be careful about what gets imported - a single import from a file that is not dynamically loaded, for example to server/api, can drag with it a whole host of other files.