### PR TITLE
fix: allow mongodb connection strings with options

### DIFF
--- a/frog/server/share-db-manager.js
+++ b/frog/server/share-db-manager.js
@@ -14,9 +14,9 @@ const server = http.createServer();
 
 const dbUrl =
   (Meteor.settings && Meteor.settings.sharedb_dburl) ||
-  'mongodb://localhost:3001';
+  'mongodb://localhost:3001/sharedb';
 
-const db = ShareDBMongo(`${dbUrl}/sharedb`);
+const db = ShareDBMongo(dbUrl);
 
 let options = { db };
 if (Meteor.settings.sharedb_redis) {


### PR DESCRIPTION
Added the default ShareDB name `sharedb` to the default host connection string in order to allow for custom connection strings that have appended options.

closes #1240