### PR TITLE
Changes to lock files when running a clean install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "yarn": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.7.0.tgz",
-      "integrity": "sha1-AHa5/eYBDgGVBSamCbxTvBde+SU="
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.9.4.tgz",
+      "integrity": "sha1-O4LYRGtlJ3VyOQC0cNlmhhl2kks="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@babel/plugin-proposal-decorators": "7.0.0-beta.55",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.55",
     "@babel/plugin-proposal-optional-chaining": "7.0.0-beta.55",
-    "@babel/plugin-proposal-class-properties": "7.0.0-beta.55",
     "@babel/plugin-proposal-nullish-coalescing-operator": "7.0.0-beta.55",
     "@babel/plugin-syntax-dynamic-import": "7.0.0-beta.55",
     "@babel/plugin-proposal-json-strings": "7.0.0-beta.55",
@@ -61,6 +60,6 @@
   },
   "license": "ISC",
   "dependencies": {
-    "yarn": "^1.7.0"
+    "yarn": "^1.9.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12775,9 +12775,9 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
-yarn@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.7.0.tgz#0076b9fde6010e01950526a609bc53bc175ef925"
+yarn@^1.9.4:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.9.4.tgz#3b82d8446b652775723900b470d966861976924b"
 
 yauzl@^2.4.2:
   version "2.10.0"


### PR DESCRIPTION
When opening the app which works fine, this appears in the browser console:
![screen shot 2018-08-29 at 10 51 33](https://user-images.githubusercontent.com/8818081/44776973-a7d5cf80-ab79-11e8-962d-cad691aef9e3.png)

Maybe your local installation and the package.json are slightly out of sync @houshuang 

