### PR TITLE
FROG graph ignores empty spaces

### DIFF
--- a/frog/imports/api/graphSequence.js
+++ b/frog/imports/api/graphSequence.js
@@ -26,6 +26,9 @@ export const calculateNextOpen = (
       a =>
         a.startTime <= newTimeInGraph && a.startTime + a.length > newTimeInGraph
     );
+    if (openActivities.length === 0) {
+      return calculateNextOpen(newTimeInGraph, activities, sessionId);
+    }
     return [newTimeInGraph, openActivities, false];
   } else {
     if (!sessionId) {


### PR DESCRIPTION
Next activity will now always select the next activity, and skip any empty space. This will give us more flexibility when drawing graphs. 

Should we create a specific "Pause" activity, or just let users add a text activity with the text "Pause"? Maybe useful to have an explicit pause activity that looks slightly different.