### PR TITLE
Small fixes around restart session/no activity

### DIFF
--- a/frog/imports/ui/StudentView/SessionBody.jsx
+++ b/frog/imports/ui/StudentView/SessionBody.jsx
@@ -109,7 +109,15 @@ const StudentView = ({ activities, session, classes }) => (
     <div className={classes.mainContent}>
       {(() => {
         if (!activities || activities.length === 0) {
-          return <h1>No Activity right now</h1>;
+          if (session.state === 'READY' || session.state === 'CREATED') {
+            return <h1>Waiting for teacher to start the session</h1>;
+          }
+          if (session.state === 'STARTED') {
+            return <h1>No activity right now</h1>;
+          }
+          if (session.state === 'FINISHED') {
+            return <h1>Session finished</h1>;
+          }
         }
         if (session.state === 'PAUSED') {
           return <h1>Paused</h1>;

--- a/frog/imports/ui/TeacherView/SessionUtils.jsx
+++ b/frog/imports/ui/TeacherView/SessionUtils.jsx
@@ -63,6 +63,7 @@ class UtilsMenu extends React.Component<any, { anchorEl: any }> {
     const menuItems = [
       buttonsModel.settings,
       buttonsModel.restart,
+      buttonsModel.removeStudents,
       buttonsModel.export,
       buttonsModel.download
     ];

--- a/frog/imports/ui/TeacherView/utils/buttonUtils.js
+++ b/frog/imports/ui/TeacherView/utils/buttonUtils.js
@@ -13,7 +13,11 @@ import Tooltip from '@material-ui/core/Tooltip';
 
 import { TimeSync } from 'meteor/mizzao:timesync';
 
-import { updateSessionState, restartSession } from '/imports/api/sessions';
+import {
+  removeAllUsers,
+  updateSessionState,
+  restartSession
+} from '/imports/api/sessions';
 import { nextActivity } from '/imports/api/engine';
 import downloadLog from './downloadLog';
 import { exportSession } from './exportComponent';
@@ -156,6 +160,13 @@ export const SessionUtilsButtonsModel = (
     button: {
       onClick: () => restartSession(session),
       text: 'Restart Session',
+      color: red[700]
+    }
+  },
+  removeStudents: {
+    button: {
+      onClick: () => removeAllUsers(session),
+      text: 'Remove All Users from Session',
       color: red[700]
     }
   },


### PR DESCRIPTION
The messages when there is no activity are now different whether Teacher has not yet started graph, No activity, or Graph is finished.

(in the future, I'd like to make this prettier. Maybe just a very big icon (Starting, finished) in a soft color, together with the text. 

We could also change the text of No activity to Projector mode (with a big picture of Projector), since that's now the only way we cannot have an activity (given that we now skip empty spaces).

We should also add nicer formatting (similar) to the Pause view.

Also added a separate menu item to remove all students from current graph. This will make all currently logged in student screens spin, and they have to be reloaded (reason I did not enable this by default for restart session). 

Closes #1345
Closes #1344