### PR TITLE
Several fixes around graph editor

### DIFF
--- a/frog-utils/src/TextInput.js
+++ b/frog-utils/src/TextInput.js
@@ -9,7 +9,7 @@ type TextInputPropsT = {
   onSubmit?: Function,
   onCancel?: Function,
   onFocus?: Function,
-  style?: string
+  style?: Object
 };
 
 export class TextInput extends React.Component<
@@ -84,7 +84,7 @@ export class TextInput extends React.Component<
 export class ChangeableText extends React.Component<
   TextInputPropsT & {
     EditComponent?: React.ComponentType<*>,
-    onlyHover?: Boolean
+    onlyHover?: boolean
   },
   {
     edit: boolean,
@@ -94,7 +94,7 @@ export class ChangeableText extends React.Component<
   constructor(
     props: TextInputPropsT & {
       EditComponent?: React.ComponentType<*>,
-      onlyHover?: Boolean
+      onlyHover?: boolean
     }
   ) {
     super(props);

--- a/frog/imports/api/graphs.js
+++ b/frog/imports/api/graphs.js
@@ -164,7 +164,7 @@ export const setCurrentGraph = (graphId: string) => {
   });
 };
 
-export const assignGraph = (wantedId: ?string) => {
+export const assignGraph = (wantedId?: string) => {
   const user = Meteor.user();
   if (wantedId && Graphs.findOne(wantedId)) {
     return wantedId;

--- a/frog/imports/api/graphs.js
+++ b/frog/imports/api/graphs.js
@@ -164,7 +164,7 @@ export const setCurrentGraph = (graphId: string) => {
   });
 };
 
-export const assignGraph = (wantedId: string) => {
+export const assignGraph = (wantedId: ?string) => {
   const user = Meteor.user();
   if (wantedId && Graphs.findOne(wantedId)) {
     return wantedId;
@@ -174,7 +174,7 @@ export const assignGraph = (wantedId: string) => {
   graphId = user.profile ? user.profile.editingGraph : null;
   graphId = graphId && Graphs.findOne(graphId) ? graphId : null;
   // Assign the id of the first graph of the graph that belongs to the user list if there is one
-  const oneGraph = Graphs.findOne({ ownerId: Meteor.user().username });
+  const oneGraph = Graphs.findOne({ ownerId: Meteor.user()._id });
   if (!graphId) graphId = oneGraph ? oneGraph._id : null;
   // If nothing worked create new graph
   if (!graphId) graphId = addGraph();

--- a/frog/imports/api/remoteGraphs.js
+++ b/frog/imports/api/remoteGraphs.js
@@ -132,11 +132,11 @@ export const sendGraph = (state: Object, props: Object) => {
   });
 };
 
-export const importGraph = (id: string) => {
+export const importGraph = (id: string, title: string) => {
   fetch(RemoteServer + '?uuid=eq.' + id)
     .then(e => e.json())
     .then(e => {
-      const graphId = doImportGraph(e[0].graph);
+      const graphId = doImportGraph(e[0].graph, title);
       Graphs.update({ _id: graphId }, { $set: { parentId: id } });
     });
 };

--- a/frog/imports/ui/GraphEditor/Activities.js
+++ b/frog/imports/ui/GraphEditor/Activities.js
@@ -7,13 +7,24 @@ import { getClickHandler } from './utils';
 
 const Box = ({ x, y, width, selected, strokeColor, color }) => (
   <g>
+    {selected && (
+      <rect
+        x={x - 1}
+        y={y - 1}
+        width={width + 2}
+        stroke="#ff9900"
+        strokeWidth={3}
+        rx={11}
+        height={32}
+      />
+    )}
     <rect
       x={x}
       y={y}
       width={width}
       fill={color}
-      stroke={selected ? '#ff9900' : strokeColor}
-      strokeWidth={selected ? 2 : 1}
+      stroke={strokeColor}
+      strokeWidth={1}
       rx={10}
       height={30}
     />

--- a/frog/imports/ui/GraphEditor/Activities.js
+++ b/frog/imports/ui/GraphEditor/Activities.js
@@ -12,22 +12,11 @@ const Box = ({ x, y, width, selected, strokeColor, color }) => (
       y={y}
       width={width}
       fill={color}
-      stroke={strokeColor}
+      stroke={selected ? '#ff9900' : strokeColor}
+      strokeWidth={selected ? 2 : 1}
       rx={10}
       height={30}
     />
-    ;
-    {selected && (
-      <rect
-        x={x - 2}
-        y={y - 2}
-        width={width + 2}
-        stroke="#ff9900"
-        fill="transparent"
-        rx={10}
-        height={34}
-      />
-    )}
   </g>
 );
 

--- a/frog/imports/ui/GraphEditor/ChangelogModal.js
+++ b/frog/imports/ui/GraphEditor/ChangelogModal.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
+import CloseIcon from '@material-ui/icons/Close';
+import Slide from '@material-ui/core/Slide';
+import List from '@material-ui/core/List';
+import IconButton from '@material-ui/core/IconButton';
+import changelog, { updateChangelogVersion } from '/imports/api/changelog';
+import { withStyles } from '@material-ui/core/styles';
+
+const Transition = props => <Slide direction="up" {...props} />;
+
+const styles = {
+  paper: {
+    width: '750px',
+    height: '1000px'
+  }
+};
+
+class HelpModal extends React.Component<*, *> {
+  componentDidUpdate() {
+    if (
+      Meteor.user().profile &&
+      Meteor.user().profile.lastVersionChangelog !== changelog.length - 1
+    )
+      updateChangelogVersion();
+  }
+
+  render() {
+    const version = Meteor.user().profile
+      ? Meteor.user().profile.lastVersionChangelog
+      : undefined;
+    return (
+      <Dialog
+        open={this.props.show}
+        onClose={this.props.hide}
+        TransitionComponent={Transition}
+        classes={this.props.classes}
+      >
+        <DialogTitle id="scroll-dialog-title">
+          <AppBar>
+            <Toolbar>
+              <IconButton
+                color="inherit"
+                onClick={this.props.hide}
+                aria-label="Close"
+              >
+                <CloseIcon />
+              </IconButton>
+              <Typography variant="title" color="inherit">
+                What is new in FROG:
+              </Typography>
+            </Toolbar>
+          </AppBar>
+        </DialogTitle>
+        <List style={{ top: '50px' }}>
+          {version === changelog.length - 1
+            ? changelog.sort((a, b) => (a.date > b.date ? -1 : 1)).map(log => (
+                <div key={log.date} style={{ padding: '10px' }}>
+                  {Object.keys(log)
+                    .filter(y => y !== 'date')
+                    .map(x => (
+                      <div key={x}>
+                        <h4>
+                          {x} ({log.date.toDateString()})
+                        </h4>
+                        {log[x].split('<br/>').map(y => (
+                          <p key={y}>{y}</p>
+                        ))}
+                      </div>
+                    ))}
+                </div>
+              ))
+            : changelog
+                .slice(version + 1)
+                .sort((a, b) => (a.date > b.date ? -1 : 1))
+                .map(log => (
+                  <div
+                    key={log.date}
+                    style={{ border: '1px solid', padding: '10px' }}
+                  >
+                    {Object.keys(log)
+                      .filter(y => y !== 'date')
+                      .map(x => (
+                        <div key={x}>
+                          <h4>
+                            {x} ({log.date.toDateString()})
+                          </h4>
+                          {log[x].split('<br/>').map(y => (
+                            <p key={y}>{y}</p>
+                          ))}
+                        </div>
+                      ))}
+                  </div>
+                ))}
+        </List>
+      </Dialog>
+    );
+  }
+}
+
+export default withStyles(styles)(HelpModal);

--- a/frog/imports/ui/GraphEditor/ChangelogModal.js
+++ b/frog/imports/ui/GraphEditor/ChangelogModal.js
@@ -67,7 +67,9 @@ class HelpModal extends React.Component<*, *> {
                         <h4>
                           {x} ({log.date.toDateString()})
                         </h4>
-                        {log[x].split('<br/>').map(y => <p key={y}>{y}</p>)}
+                        {log[x].split('<br/>').map(y => (
+                          <p key={y}>{y}</p>
+                        ))}
                       </div>
                     ))}
                 </div>
@@ -87,7 +89,9 @@ class HelpModal extends React.Component<*, *> {
                           <h4>
                             {x} ({log.date.toDateString()})
                           </h4>
-                          {log[x].split('<br/>').map(y => <p key={y}>{y}</p>)}
+                          {log[x].split('<br/>').map(y => (
+                            <p key={y}>{y}</p>
+                          ))}
                         </div>
                       ))}
                   </div>

--- a/frog/imports/ui/GraphEditor/ChangelogModal.js
+++ b/frog/imports/ui/GraphEditor/ChangelogModal.js
@@ -51,7 +51,7 @@ class HelpModal extends React.Component<*, *> {
                 <CloseIcon />
               </IconButton>
               <Typography variant="title" color="inherit">
-                What is new in FROG:
+                What is new in FROG
               </Typography>
             </Toolbar>
           </AppBar>
@@ -67,9 +67,7 @@ class HelpModal extends React.Component<*, *> {
                         <h4>
                           {x} ({log.date.toDateString()})
                         </h4>
-                        {log[x].split('<br/>').map(y => (
-                          <p key={y}>{y}</p>
-                        ))}
+                        {log[x].split('<br/>').map(y => <p key={y}>{y}</p>)}
                       </div>
                     ))}
                 </div>
@@ -89,9 +87,7 @@ class HelpModal extends React.Component<*, *> {
                           <h4>
                             {x} ({log.date.toDateString()})
                           </h4>
-                          {log[x].split('<br/>').map(y => (
-                            <p key={y}>{y}</p>
-                          ))}
+                          {log[x].split('<br/>').map(y => <p key={y}>{y}</p>)}
                         </div>
                       ))}
                   </div>

--- a/frog/imports/ui/GraphEditor/EditorContainer.js
+++ b/frog/imports/ui/GraphEditor/EditorContainer.js
@@ -15,6 +15,7 @@ import Graph from './Graph';
 import { RenameBox } from './Rename';
 import SidePanel from './SidePanel';
 import HelpModal from './HelpModal';
+import ChangelogModal from './ChangelogModal';
 import ModalExport from './RemoteControllers/ModalExport';
 import ModalImport from './RemoteControllers/ModalImport';
 import ModalDelete from './RemoteControllers/ModalDelete';
@@ -80,7 +81,7 @@ class Editor extends React.Component<Object, StateT> {
   }
 
   render() {
-    const { classes } = this.props;
+    const { classes, store } = this.props;
     const show = this.props.store.ui.showPreview;
     if (show && show.activityTypeId) {
       return (
@@ -88,7 +89,7 @@ class Editor extends React.Component<Object, StateT> {
           modal
           activityTypeId={show.activityTypeId}
           config={show.config}
-          dismiss={() => this.props.store.ui.setShowPreview(false)}
+          dismiss={() => store.ui.setShowPreview(false)}
         />
       );
     }
@@ -111,11 +112,10 @@ class Editor extends React.Component<Object, StateT> {
               exportType="graph"
               modalOpen={this.state.exportOpen}
               setModal={val => this.setState({ exportOpen: val })}
-              graphId={this.props.store.graphId}
-              graphName={this.props.store}
+              graphId={store.graphId}
+              graphName={store}
               metadatas={LibraryStates.graphList.find(
-                x =>
-                  x.uuid === Graphs.findOne(this.props.store.graphId).parentId
+                x => x.uuid === Graphs.findOne(store.graphId).parentId
               )}
               madeChanges={() => this.setState({ locallyChanged: true })}
             />
@@ -155,8 +155,12 @@ class Editor extends React.Component<Object, StateT> {
           </Grid>
         </Grid>
         <HelpModal
-          show={this.props.store.ui.showModal}
-          hide={() => this.props.store.ui.setModal(false)}
+          show={store.ui.showHelpModal}
+          hide={() => store.ui.setShowHelpModal(false)}
+        />
+        <ChangelogModal
+          show={store.ui.showChangelogModal}
+          hide={() => store.ui.setShowChangelogModal(false)}
         />
         {show &&
           show.operatorTypeId && (

--- a/frog/imports/ui/GraphEditor/EditorContainer.js
+++ b/frog/imports/ui/GraphEditor/EditorContainer.js
@@ -28,28 +28,25 @@ import TopBar from '../App/TopBar';
 const styles = () => ({
   root: {
     marginTop: '48px',
-    height: 'calc(100vh - 48px)'
+    height: 'calc(100vh - 48px)',
+    overflowX: 'auto'
   },
-  sheet: {
-    background: 'white'
-  }
+  editor: { height: 600 },
+  editorWithPanMap: { height: 150 }
 });
 
-const EditorPanel = () => (
-  <div className="bootstrap" style={styles.sheet}>
-    <div style={{ height: '600px' }}>
+const EditorPanel = withStyles(styles)(({ classes }) => (
+  <React.Fragment>
+    <div className={classes.editor}>
       <ReactTooltip delayShow={500} />
       <Graph scaled hasTimescale isEditable />
     </div>
     <RenameBox />
-    <div
-      className="bootstrap"
-      style={{ margin: 2, height: 150, border: '1px solid black' }}
-    >
+    <div className={classes.editorWithPanMap}>
       <Graph hasPanMap />
     </div>
-  </div>
-);
+  </React.Fragment>
+));
 
 type StateT = {
   exportOpen: boolean,

--- a/frog/imports/ui/GraphEditor/HelpModal.js
+++ b/frog/imports/ui/GraphEditor/HelpModal.js
@@ -3,25 +3,44 @@
 import * as React from 'react';
 
 import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import CloseIcon from '@material-ui/icons/Close';
 import List from '@material-ui/core/List';
 import IconButton from '@material-ui/core/IconButton';
+import Slide from '@material-ui/core/Slide';
+import { withStyles } from '@material-ui/core/styles';
 
-const HelpModal = ({ show, hide }: Object) => (
-  <Dialog open={show} onClose={hide}>
-    <AppBar>
-      <Toolbar>
-        <IconButton color="inherit" onClick={hide} aria-label="Close">
-          <CloseIcon />
-        </IconButton>
-        <Typography variant="title" color="inherit">
-          Help for the graph editor
-        </Typography>
-      </Toolbar>
-    </AppBar>
+const Transition = props => <Slide direction="up" {...props} />;
+
+const styles = {
+  paper: {
+    width: '750px',
+    height: '1000px'
+  }
+};
+
+const HelpModal = ({ show, hide, classes }: Object) => (
+  <Dialog
+    open={show}
+    onClose={hide}
+    TransitionComponent={Transition}
+    classes={classes}
+  >
+    <DialogTitle id="scroll-dialog-title">
+      <AppBar>
+        <Toolbar>
+          <IconButton color="inherit" onClick={hide} aria-label="Close">
+            <CloseIcon />
+          </IconButton>
+          <Typography variant="title" color="inherit">
+            Help for the graph editor
+          </Typography>
+        </Toolbar>
+      </AppBar>
+    </DialogTitle>
     <List style={{ margin: '10px' }}>
       <h4>Adding activities</h4>
       Double-click on one of the three plane lines to add activities. Choose the
@@ -75,4 +94,4 @@ const HelpModal = ({ show, hide }: Object) => (
   </Dialog>
 );
 
-export default HelpModal;
+export default withStyles(styles)(HelpModal);

--- a/frog/imports/ui/GraphEditor/HelpModal.js
+++ b/frog/imports/ui/GraphEditor/HelpModal.js
@@ -1,107 +1,78 @@
-import React from 'react';
+// @flow
+
+import * as React from 'react';
+
 import Dialog from '@material-ui/core/Dialog';
-import DialogTitle from '@material-ui/core/DialogTitle';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import CloseIcon from '@material-ui/icons/Close';
-import Slide from '@material-ui/core/Slide';
 import List from '@material-ui/core/List';
 import IconButton from '@material-ui/core/IconButton';
-import changelog, { updateChangelogVersion } from '/imports/api/changelog';
-import { withStyles } from '@material-ui/core/styles';
 
-const Transition = props => <Slide direction="up" {...props} />;
+const HelpModal = ({ show, hide }: Object) => (
+  <Dialog open={show} onClose={hide}>
+    <AppBar>
+      <Toolbar>
+        <IconButton color="inherit" onClick={hide} aria-label="Close">
+          <CloseIcon />
+        </IconButton>
+        <Typography variant="title" color="inherit">
+          Help for the graph editor
+        </Typography>
+      </Toolbar>
+    </AppBar>
+    <List style={{ margin: '10px' }}>
+      <h4>Adding activities</h4>
+      Double-click on one of the three plane lines to add activities. Choose the
+      kind of activity, and configure it, in the right sidebar.
+      <h4>Renaming activities</h4>
+      Double-click on an activity to rename it.
+      <h4>Moving or resizing activities</h4>
+      Move the cursor over an activity until the mouse cursor turns into a
+      cross. Click and drag the activity to where you want it. You will see
+      indicators showing you the time between the activity you are dragging, and
+      the previous or next activity, or the beginning/end of the class.
+      <p />
+      To resize, move the cursor to the end of the activity, until it turns into
+      a two-ways arrow, and click and hold while dragging to resize the
+      activity.
+      <p />
+      To change the plane, first select the activity, then press Shift+up if you
+      want the activity to go to a higher plane or Shift-down to make it go to a
+      lower plane.
+      <p />
+      To copy an activity, press + while an activity is selected. A copy will be
+      placed on top (or below) of the selected activity. You can now change
+      planes, or drag it somewhere else in the graph.
+      <h4>Inserting operators</h4>
+      To insert an operator, click S for a social operator, P for a product
+      operator, or C for a control operator (the mouse must be over the main
+      graph view). An operator will appear attached to the mouse. Move the mouse
+      to where you want to locate the operator, and click to place it. When you
+      select an operator, you can configure it in the right sidebar. Shift+click
+      and drag on the operator to reposition it.
+      <h4>Connections</h4>
+      To create a connection from an activity, move the mouse cursor to the
+      small circle at the right side of the box, until the mouse cursor becomes
+      a crosshair. Click, and drag to the activity or operator you want to
+      connect. To begin a connection from an operator, click on an operator and
+      drag to the operator or activity you wish to connect.
+      <h4>Deleting elements</h4>
+      To delete an element, select it (it will change color to red), and press
+      the backspace key, while your cursor is over the main graph window.
+      <h4>Undo</h4>
+      All your actions are immediately stored in the database. To undo, click
+      the undo button at the bottom of the graph.
+      <h4>Resizing automatically</h4>
+      <b>r</b> jumps between two states: resize all activities to be five
+      minutes long, and restore their original sizes
+      <h4>Organizing automatically</h4>
+      <b>z</b> jumps between three states: move all activities next to each
+      other, put five minutes distance between all activities, and restore
+      original positions
+    </List>
+  </Dialog>
+);
 
-const styles = {
-  paper: {
-    width: '750px',
-    height: '1000px'
-  }
-};
-
-class HelpModal extends React.Component<*, *> {
-  componentDidUpdate() {
-    if (
-      Meteor.user().profile &&
-      Meteor.user().profile.lastVersionChangelog !== changelog.length - 1
-    )
-      updateChangelogVersion();
-  }
-
-  render() {
-    const version = Meteor.user().profile
-      ? Meteor.user().profile.lastVersionChangelog
-      : undefined;
-    return (
-      <Dialog
-        open={this.props.show}
-        onClose={this.props.hide}
-        TransitionComponent={Transition}
-        classes={this.props.classes}
-      >
-        <DialogTitle id="scroll-dialog-title">
-          <AppBar>
-            <Toolbar>
-              <IconButton
-                color="inherit"
-                onClick={this.props.hide}
-                aria-label="Close"
-              >
-                <CloseIcon />
-              </IconButton>
-              <Typography variant="title" color="inherit">
-                {version === changelog.length - 1
-                  ? 'Help for the graph editor'
-                  : 'What is new in FROG'}
-              </Typography>
-            </Toolbar>
-          </AppBar>
-        </DialogTitle>
-        <List style={{ top: '50px' }}>
-          {version === changelog.length - 1
-            ? changelog.sort((a, b) => (a.date > b.date ? -1 : 1)).map(log => (
-                <div key={log.date} style={{ padding: '10px' }}>
-                  {Object.keys(log)
-                    .filter(y => y !== 'date')
-                    .map(x => (
-                      <div key={x}>
-                        <h4>
-                          {x} ({log.date.toDateString()})
-                        </h4>
-                        {log[x].split('<br/>').map(y => (
-                          <p key={y}>{y}</p>
-                        ))}
-                      </div>
-                    ))}
-                </div>
-              ))
-            : changelog
-                .slice(version + 1)
-                .sort((a, b) => (a.date > b.date ? -1 : 1))
-                .map(log => (
-                  <div
-                    key={log.date}
-                    style={{ border: '1px solid', padding: '10px' }}
-                  >
-                    {Object.keys(log)
-                      .filter(y => y !== 'date')
-                      .map(x => (
-                        <div key={x}>
-                          <h4>
-                            {x} ({log.date.toDateString()})
-                          </h4>
-                          {log[x].split('<br/>').map(y => (
-                            <p key={y}>{y}</p>
-                          ))}
-                        </div>
-                      ))}
-                  </div>
-                ))}
-        </List>
-      </Dialog>
-    );
-  }
-}
-
-export default withStyles(styles)(HelpModal);
+export default HelpModal;

--- a/frog/imports/ui/GraphEditor/Operator.js
+++ b/frog/imports/ui/GraphEditor/Operator.js
@@ -1,3 +1,5 @@
+// @flow
+
 import React from 'react';
 import { DraggableCore } from 'react-draggable';
 
@@ -16,7 +18,7 @@ export default ({
   onStop,
   transparent,
   title
-}) => {
+}: Object) => {
   const stroke = selected ? '#ff9900' : 'transparent';
   let icon;
   switch (type) {

--- a/frog/imports/ui/GraphEditor/RemoteControllers/RemoteLibrary.jsx
+++ b/frog/imports/ui/GraphEditor/RemoteControllers/RemoteLibrary.jsx
@@ -150,7 +150,7 @@ class Library extends Component<Object, { searchStr: string }> {
                       this.props.onSelect
                     );
                   } else if (libraryType === 'graph') {
-                    importGraph(x.uuid);
+                    importGraph(x.uuid, x.title);
                     this.props.setModal(false);
                   }
                 }}

--- a/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/ChooseOperator.jsx
+++ b/frog/imports/ui/GraphEditor/SidePanel/OperatorPanel/ChooseOperator.jsx
@@ -115,7 +115,9 @@ class ChooseOperatorTypeComp extends Component<PropsT, StateT> {
     Operators.update(this.props.operator._id, {
       $set: { operatorType: operatorType.id }
     });
-    graphOperator.rename(newName);
+    if (graphOperator) {
+      graphOperator.rename(newName);
+    }
   };
 
   handleSearch = e => {

--- a/frog/imports/ui/GraphEditor/TopPanel/GraphConfigPanel.jsx
+++ b/frog/imports/ui/GraphEditor/TopPanel/GraphConfigPanel.jsx
@@ -1,3 +1,5 @@
+// @flow
+
 import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import { ChangeableText } from 'frog-utils';
@@ -27,7 +29,7 @@ const Config = ({ graph }) => (
       <ChangeableText
         onlyHover
         style={{ width: '60px' }}
-        value={graph ? graph.duration : 30}
+        value={(graph ? graph.duration : 30).toString()}
         onSubmit={e => store.changeDuration(parseInt(e, 10))}
       />{' '}
       mins.

--- a/frog/imports/ui/GraphEditor/TopPanel/Settings.js
+++ b/frog/imports/ui/GraphEditor/TopPanel/Settings.js
@@ -1,4 +1,8 @@
+// @flow
+
 import React from 'react';
+import { Meteor } from 'meteor/meteor';
+
 import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -96,9 +100,10 @@ const MenuItemDeleteFromServer = ({
     </MenuItem>
   ) : null;
 
-class GraphActionMenu extends React.Component {
+class GraphActionMenu extends React.Component<*, *> {
   state = {
-    open: false
+    open: false,
+    anchorEl: null
   };
 
   handleClick = event => {

--- a/frog/imports/ui/GraphEditor/TopPanel/index.js
+++ b/frog/imports/ui/GraphEditor/TopPanel/index.js
@@ -1,43 +1,25 @@
 // @flow
 
 import React from 'react';
-import Grid from '@material-ui/core/Grid';
 import { withStyles } from '@material-ui/core/styles';
-import GraphMenu from './GraphMenu';
 
+import GraphMenu from './GraphMenu';
 import { UndoButton, ConfigMenu } from './Settings';
 import ExpandButton from '../SidePanel/ExpandButton';
 
 const styles = {
   root: {
-    flexGrow: 1
+    display: 'flex',
+    flexDirection: 'row'
   }
 };
 
-const TopPanel = (props: Object) => (
-  <div id="topPanel">
-    <Grid container justify="space-between" spacing={0}>
-      <Grid item>
-        <Grid container>
-          <Grid item>
-            <ConfigMenu {...props} />
-          </Grid>
-          <Grid item>
-            <GraphMenu />
-          </Grid>
-        </Grid>
-      </Grid>
-      <Grid item>
-        <Grid container>
-          <Grid item>
-            <UndoButton />
-          </Grid>
-          <Grid item>
-            <ExpandButton />
-          </Grid>
-        </Grid>
-      </Grid>
-    </Grid>
+const TopPanel = ({ classes, ...props }: Object) => (
+  <div className={classes.root}>
+    <ConfigMenu {...props} />
+    <GraphMenu />
+    <UndoButton />
+    <ExpandButton />
   </div>
 );
 

--- a/frog/imports/ui/GraphEditor/components/ScrollFields.js
+++ b/frog/imports/ui/GraphEditor/components/ScrollFields.js
@@ -5,9 +5,9 @@ import * as React from 'react';
 import { connect, store, type StoreProp } from '../store';
 
 const scrollInterval = direction => {
-  if (!store.scrollIntervalID) {
+  if (!store.ui.scrollIntervalID) {
     store.ui.storeInterval(
-      window.setInterval(() => store.ui.panDelta(3 * direction), 20)
+      setInterval(() => store.ui.panDelta(3 * direction), 20)
     );
   }
 };

--- a/frog/imports/ui/GraphEditor/components/fixedComponents.js
+++ b/frog/imports/ui/GraphEditor/components/fixedComponents.js
@@ -14,14 +14,14 @@ export const PanMap = connect(
   }: StoreProp) => (
     <DraggableCore onDrag={(_, { deltaX }) => panDelta(deltaX)}>
       <rect
-        x={panx}
-        y={0}
+        x={1 + panx}
+        y={1}
         fill="transparent"
         stroke="black"
-        strokeWidth={4}
+        strokeWidth={2}
         rx={10}
-        width={graphWidth / scale}
-        height={150}
+        width={graphWidth / scale - 2}
+        height={148}
       />
     </DraggableCore>
   )

--- a/frog/imports/ui/GraphEditor/index.js
+++ b/frog/imports/ui/GraphEditor/index.js
@@ -1,5 +1,6 @@
-import React, { Component } from 'react';
 // @flow
+
+import * as React from 'react';
 import { Provider } from 'mobx-react';
 import Mousetrap from 'mousetrap';
 import { withRouter } from 'react-router';
@@ -8,7 +9,7 @@ import { store } from './store';
 import { assignGraph } from '../../api/graphs';
 import EditorContainer from './EditorContainer';
 
-class AppClass extends Component<$FlowFixMeProps> {
+class AppClass extends React.Component<*, *> {
   componentWillMount() {
     store.setBrowserHistory(this.props.history);
     this.updateGraphId(this.props.match && this.props.match.params.graphId);
@@ -62,7 +63,8 @@ const bindKeys = () => {
   });
   Mousetrap.bind('backspace', () => store.deleteSelected(false));
   Mousetrap.bind('shift+backspace', () => store.deleteSelected(true));
-  Mousetrap.bind('?', () => store.ui.setModal(true));
+  Mousetrap.bind('?', () => store.ui.setShowHelpModal(true));
+  Mousetrap.bind('!', () => store.ui.setShowChangelogModal(true));
   Mousetrap.bind('s', () => store.operatorStore.place('social'));
   Mousetrap.bind('+', () => store.activityStore.duplicateActivity());
   Mousetrap.bind('c', () => store.operatorStore.place('control'));

--- a/frog/imports/ui/GraphEditor/store/activityStore.js
+++ b/frog/imports/ui/GraphEditor/store/activityStore.js
@@ -106,7 +106,7 @@ export default class ActivityStore {
           this.organizeNextState = 'compress';
         } else {
           let expand = 0;
-          const last = [0, {}];
+          const last = [-1, {}];
           if (this.organizeNextState === 'compress') {
             this.organizeNextState = 'expand';
           } else {

--- a/frog/imports/ui/GraphEditor/store/activityStore.js
+++ b/frog/imports/ui/GraphEditor/store/activityStore.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { extendObservable, action } from 'mobx';
 import { maxBy, isEmpty } from 'lodash';
 
@@ -41,8 +43,30 @@ export const calculateBounds = (
 
 export default class ActivityStore {
   all: Activity[];
-
-  activitySequence: { [id: string]: number };
+  sizes: Object;
+  positions: Object;
+  organizeNextState: string;
+  activitySequence: any;
+  setActivitySequence: any => void;
+  duplicateActivity: () => void;
+  setOrganizeNextState: any => void;
+  emptySizes: () => void;
+  organize: () => void;
+  resize: () => void;
+  addActivity: (number, number, boolean) => void;
+  newActivityAbove: number => void;
+  swapActivities: (left: Activity, right: Activity) => void;
+  moveDelete: Activity => void;
+  startResizing: Activity => void;
+  movePlane: number => void;
+  stopMoving: () => void;
+  stopResizing: () => void;
+  mongoAdd: (x: Activity) => void;
+  mongoChange: (any, any) => void;
+  mongoRemove: ({ _id: string }) => void;
+  history: Array<Object>;
+  furthestActivity: number;
+  activityOffsets: Object;
 
   constructor() {
     extendObservable(this, {
@@ -82,7 +106,7 @@ export default class ActivityStore {
           this.organizeNextState = 'compress';
         } else {
           let expand = 0;
-          const last = [null, null];
+          const last = [0, {}];
           if (this.organizeNextState === 'compress') {
             this.organizeNextState = 'expand';
           } else {
@@ -94,7 +118,7 @@ export default class ActivityStore {
             if (this.organizeNextState === 'expand') {
               this.positions[act.id] = act.startTime;
             }
-            if (act.startTime === last[0]) {
+            if (act.startTime === last[0] && last[1]) {
               act.setStart(last[1].startTime);
               if (last[1].length < act.length) {
                 index += act.length - last[1].length;
@@ -193,10 +217,11 @@ export default class ActivityStore {
       }),
 
       movePlane: action((increment: number) => {
-        if (store.ui.selected instanceof Activity) {
-          const oldplane = store.ui.selected.plane;
-          store.ui.selected.plane = between(1, 4, oldplane + increment);
-          if (oldplane !== store.ui.selected.plane) {
+        const { selected } = store.ui;
+        if (selected && selected instanceof Activity) {
+          const oldplane = selected.plane;
+          selected.plane = between(1, 4, oldplane + increment);
+          if (oldplane !== selected.plane) {
             store.addHistory();
           }
         }

--- a/frog/imports/ui/GraphEditor/store/activityStore.js
+++ b/frog/imports/ui/GraphEditor/store/activityStore.js
@@ -163,9 +163,9 @@ export default class ActivityStore {
             this.all
           );
           const maxLength = rightBoundTime - time;
-          length = Math.min(maxLength, 5);
+          length = Math.min(maxLength, 10);
         } else {
-          length = 5;
+          length = 10;
         }
         if (length >= 1) {
           const newActivity = new Activity(plane, time, 'Unnamed', length);

--- a/frog/imports/ui/GraphEditor/store/activityStore.js
+++ b/frog/imports/ui/GraphEditor/store/activityStore.js
@@ -54,7 +54,7 @@ export default class ActivityStore {
   organize: () => void;
   resize: () => void;
   addActivity: (number, number, boolean) => void;
-  newActivityAbove: number => void;
+  newActivityAbove: (?number) => void;
   swapActivities: (left: Activity, right: Activity) => void;
   moveDelete: Activity => void;
   startResizing: Activity => void;

--- a/frog/imports/ui/GraphEditor/store/connection.js
+++ b/frog/imports/ui/GraphEditor/store/connection.js
@@ -1,3 +1,5 @@
+// @flow
+
 import cuid from 'cuid';
 import { extendObservable } from 'mobx';
 
@@ -20,6 +22,11 @@ const getType = item => {
 type ConnectableT = Activity | Operator;
 
 export default class Connection extends Elem {
+  pathScaled: string;
+  path: string;
+  source: ConnectableT;
+  target: ConnectableT;
+
   constructor(source: ConnectableT, target: ConnectableT, id: ?string) {
     super();
 

--- a/frog/imports/ui/GraphEditor/store/connectionStore.js
+++ b/frog/imports/ui/GraphEditor/store/connectionStore.js
@@ -16,7 +16,14 @@ type MongoConnectionT = {
 };
 
 export default class ConnectionStore {
-  all: Object[];
+  all: Connection[];
+  history: Object[];
+  startDragging: (Activity | Operator) => void;
+  stopDragging: () => void;
+  dragPath: string;
+  mongoAdd: MongoConnectionT => void;
+  mongoRemove: MongoConnectionT => void;
+  cleanDangling: () => void;
 
   constructor() {
     extendObservable(this, {

--- a/frog/imports/ui/GraphEditor/store/elemClass.js
+++ b/frog/imports/ui/GraphEditor/store/elemClass.js
@@ -1,8 +1,18 @@
-//
+// @flow
+
 import { extendObservable, action } from 'mobx';
 import { store } from './index';
+import Activity from './activity';
 
 export default class Elem {
+  selected: boolean;
+  color: string;
+  select: () => void;
+  klass: 'activity' | 'operator' | 'connection';
+  id: string;
+  wasMoved: boolean;
+  remove: boolean => void;
+
   constructor() {
     extendObservable(this, {
       select: action(() => {
@@ -19,18 +29,18 @@ export default class Elem {
       }),
 
       remove: action(shift => {
-        let thisstore;
+        const { activityStore, operatorStore, connectionStore } = store;
+        const filter = x => x !== this;
         if (this.klass === 'activity') {
-          thisstore = store.activityStore;
+          activityStore.all = activityStore.all.filter(filter);
         } else if (this.klass === 'operator') {
-          thisstore = store.operatorStore;
+          operatorStore.all = operatorStore.all.filter(filter);
         } else {
-          thisstore = store.connectionStore;
+          connectionStore.all = connectionStore.all.filter(filter);
         }
-        if (this.klass === 'activity' && shift) {
-          store.activityStore.moveDelete(this);
+        if (shift && this instanceof Activity) {
+          activityStore.moveDelete(this);
         }
-        thisstore.all = thisstore.all.filter(x => x !== this);
         store.connectionStore.cleanDangling();
         store.addHistory();
       }),

--- a/frog/imports/ui/GraphEditor/store/operator.js
+++ b/frog/imports/ui/GraphEditor/store/operator.js
@@ -1,3 +1,5 @@
+// @flow
+
 import cuid from 'cuid';
 import { extendObservable, action } from 'mobx';
 import { store } from './index';
@@ -6,12 +8,46 @@ import { pxToTime, timeToPx } from '../utils';
 import type { AnchorT } from '../utils/path';
 
 export default class Operator extends Elem {
+  rename: string => void;
+  onOver: () => void;
+  onLeave: () => void;
+  startDragging: ({ shiftKey: boolean }) => void;
+  onDrag: ({ shiftKey: boolean }, { deltaX: number, deltaY: number }) => void;
+  moveX: number => void;
+  push: number => void;
+  stopDragging: () => void;
+  update: ($Shape<Operator>) => void;
+  x: number;
+  xScaled: number;
+  coordsScaled: [number, number];
+  coords: [number, number];
+  object: {
+    _id: string,
+    time: number,
+    y: number,
+    type: string,
+    title: ?string
+  };
+  dragPointTo: AnchorT;
+  dragPointToScaled: AnchorT;
+  dragPointFrom: AnchorT;
+  dragPointFromScaled: AnchorT;
+  time: number;
+  title: string;
+  over: boolean;
+  data: Object;
+  operatorType: string;
+  y: number;
+  type: string;
+  strokeColor: string;
+  highlighted: boolean;
+
   constructor(
     time: number,
     y: number,
     type: string,
-    data: Object,
-    operatorType: string,
+    data: ?Object,
+    operatorType: ?string,
     id: ?string,
     title: ?string,
     state: ?string

--- a/frog/imports/ui/GraphEditor/store/session.js
+++ b/frog/imports/ui/GraphEditor/store/session.js
@@ -1,7 +1,24 @@
+// @flow
+
 import { extendObservable, action } from 'mobx';
 
 export default class Session {
-  constructor(session) {
+  id: string;
+  timeInClass: number;
+  timeInGraph: number;
+  startedAt: number;
+  interval: any;
+  setTimes: Object => void;
+  updateTimeInGraph: number => void;
+  updateTimeInClass: (?number) => void;
+
+  constructor(
+    session: ?{
+      _id: string,
+      timeInGraph: number,
+      startedAt: number
+    }
+  ) {
     extendObservable(this, {
       id: '',
       timeInClass: 0,

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -284,8 +284,18 @@ export default class Store {
           return;
         }
         const [connections, activities, operators] = last[0];
+
         this.activityStore.all = activities.map(
-          x => new Activity(x.plane, x.startTime, x.title, x.length, x.id)
+          x =>
+            new Activity(
+              x.plane,
+              x.startTime,
+              x.title,
+              x.length,
+              x.data,
+              x.activityType,
+              x.id
+            )
         );
         this.operatorStore.all = operators.map(
           x => new Operator(x.time, x.y, x.type, x.id, x.title)

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -101,8 +101,9 @@ export default class Store {
   graphErrors: Object[];
   valid: Object;
   setId: (string, ?boolean) => void;
-  setBrowserHistory: (Object, string) => void;
+  setBrowserHistory: (Object, ?string) => void;
   setSession: any => void;
+  deleteSelected: (?boolean) => void;
 
   constructor() {
     extendObservable(this, {

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -235,10 +235,12 @@ export default class Store {
               !source ||
               !target
             ) {
-              throw 'Cannot find connection source/target, or source/target is a connection';
+              // throw 'Cannot find connection source/target, or source/target is a connection';
+              return undefined;
             }
             return new Connection(source, target, x._id);
-          });
+          })
+          .filter(x => !!x);
 
         this.ui.selected = null;
         this.history = [];
@@ -306,6 +308,10 @@ export default class Store {
         if (isEmpty(last)) {
           return;
         }
+
+        console.log(connections);
+        console.log(this.connectionStore.all);
+
         const [connections, activities, operators] = last[0];
 
         this.activityStore.all = activities.map(
@@ -323,19 +329,22 @@ export default class Store {
         this.operatorStore.all = operators.map(
           x => new Operator(x.time, x.y, x.type, x.id, x.title)
         );
-        this.connectionStore.all = connections.map(x => {
-          const source = this.findId(x.source);
-          const target = this.findId(x.target);
-          if (
-            source instanceof Connection ||
-            target instanceof Connection ||
-            !source ||
-            !target
-          ) {
-            throw 'Cannot find connection source/target, or source/target is a connection';
-          }
-          return new Connection(source, target, x._id);
-        });
+        this.connectionStore.all = connections
+          .map(x => {
+            const source = this.findId(x.source);
+            const target = this.findId(x.target);
+            if (
+              source instanceof Connection ||
+              target instanceof Connection ||
+              !source ||
+              !target
+            ) {
+              // throw 'Cannot find connection source/target, or source/target is a connection';
+              return undefined;
+            }
+            return new Connection(source, target, x._id);
+          })
+          .filter(x => !!x);
 
         mergeGraph(this.objects);
       }),

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -145,8 +145,10 @@ export default class Store {
         if (duration && duration >= 30 && duration <= 1200) {
           const oldPanTime = this.ui.panTime;
           // changes the scale on duration change
+          this.ui.setScaleValue(
+            (this.ui.scale * duration) / this._graphDuration
+          );
           this._graphDuration = duration;
-          this.ui.setScaleValue(this.ui.scale / this.graphDuration);
           const needPanDelta = timeToPx(oldPanTime - this.ui.panTime, 1);
           this.ui.panDelta(needPanDelta);
           Graphs.update(this.graphId, {

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -235,7 +235,9 @@ export default class Store {
               !source ||
               !target
             ) {
-              // throw 'Cannot find connection source/target, or source/target is a connection';
+              console.error(
+                'Cannot find connection source/target, or source/target is a connection'
+              );
               return undefined;
             }
             return new Connection(source, target, x._id);
@@ -309,9 +311,6 @@ export default class Store {
           return;
         }
 
-        console.log(connections);
-        console.log(this.connectionStore.all);
-
         const [connections, activities, operators] = last[0];
 
         this.activityStore.all = activities.map(
@@ -327,7 +326,16 @@ export default class Store {
             )
         );
         this.operatorStore.all = operators.map(
-          x => new Operator(x.time, x.y, x.type, x.id, x.title)
+          x =>
+            new Operator(
+              x.time,
+              x.y,
+              x.type,
+              x.data,
+              x.operatorType,
+              x.id,
+              x.title
+            )
         );
         this.connectionStore.all = connections
           .map(x => {
@@ -339,7 +347,9 @@ export default class Store {
               !source ||
               !target
             ) {
-              // throw 'Cannot find connection source/target, or source/target is a connection';
+              console.error(
+                'Cannot find connection source/target, or source/target is a connection'
+              );
               return undefined;
             }
             return new Connection(source, target, x._id);

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -116,7 +116,7 @@ export default class Store {
       graphId: '',
       graphErrors: [],
       valid: undefined,
-      _graphDuration: 120,
+      _graphDuration: 60,
       readOnly: false,
 
       get graphDuration(): number {
@@ -186,7 +186,7 @@ export default class Store {
         this.readOnly = readOnly;
         this.graphId = id;
 
-        this.changeDuration(graph ? graph.duration || 120 : 120);
+        this.changeDuration(graph ? graph.duration || 60 : 60);
         this.activityStore.all = findActivitiesMongo(
           { graphId: id },
           { reactive: false }

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { isEmpty, isEqual, sortBy } from 'lodash';
 import { extendObservable, action } from 'mobx';
 import Stringify from 'json-stable-stringify';
@@ -44,17 +46,13 @@ export type StateT =
   | {
       mode: 'resizing',
       currentActivity: Activity,
-      bounds: BoundsT,
-      activitiesToPush?: Activity[],
-      operatorsToPush?: Operator[]
+      bounds: BoundsT
     }
   | {
       mode: 'moving',
       currentActivity: Activity,
       mouseOffset: number,
-      initialStartTime: number,
-      activitiesToPush?: Activity[],
-      operatorsToPush?: Operator[]
+      initialStartTime: number
     }
   | { mode: 'waitingDrag' }
   | { mode: 'movingOperator', currentOperator: Operator }
@@ -66,7 +64,7 @@ export type StateT =
 
 const getOne = (coll: Coll, crit: Function): ?Elem => {
   const found = coll.filter(crit);
-  if (found.size === 0) {
+  if (found.length === 0) {
     return undefined;
   }
   return found[0];
@@ -77,10 +75,34 @@ const getOneId = (coll: Coll, id: string): ?Elem =>
 
 export default class Store {
   browserHistory: any;
-
   url: string;
-
   history: any[];
+  objects: {
+    connections: Elem[],
+    activities: Elem[],
+    operators: Elem[],
+    graphId: string,
+    graphDuration: number
+  };
+  state: StateT;
+  connectionStore: ConnectionStore;
+  activityStore: ActivityStore;
+  operatorStore: OperatorStore;
+  ui: UI;
+  overlapAllowed: boolean;
+  graphId: string;
+  _graphDuration: number;
+  graphDuration: number;
+  readOnly: boolean;
+  changeDuration: number => void;
+  addHistory: () => void;
+  refreshValidate: () => void;
+  session: Session;
+  graphErrors: Object[];
+  valid: Object;
+  setId: (string, ?boolean) => void;
+  setBrowserHistory: (Object, string) => void;
+  setSession: any => void;
 
   constructor() {
     extendObservable(this, {

--- a/frog/imports/ui/GraphEditor/store/uiStore.js
+++ b/frog/imports/ui/GraphEditor/store/uiStore.js
@@ -68,7 +68,7 @@ export default class uiStore {
     extendObservable(this, {
       sidepanelOpen: false,
       svgRef: null,
-      scale: 2,
+      scale: 1,
       windowWidth: 1000,
       graphWidth: 1000,
       socialCoordsTime: [0, 0],

--- a/frog/imports/ui/GraphEditor/store/uiStore.js
+++ b/frog/imports/ui/GraphEditor/store/uiStore.js
@@ -68,7 +68,7 @@ export default class uiStore {
     extendObservable(this, {
       sidepanelOpen: false,
       svgRef: null,
-      scale: 4,
+      scale: 2,
       windowWidth: 1000,
       graphWidth: 1000,
       socialCoordsTime: [0, 0],
@@ -230,7 +230,7 @@ export default class uiStore {
       }),
 
       setScaleValue: action((newScale: number) => {
-        this.scale = between(1, store.graphDuration / 15, newScale);
+        this.scale = between(1, store.graphDuration / 10, newScale);
         this.panDelta(0);
       }),
 

--- a/frog/imports/ui/GraphEditor/store/uiStore.js
+++ b/frog/imports/ui/GraphEditor/store/uiStore.js
@@ -53,11 +53,15 @@ export default class uiStore {
   toggleSidepanelOpen: () => void;
   setLibraryOpen: boolean => void;
   libraryOpen: boolean;
-  setModal: boolean => void;
-  showModal: boolean;
+  setShowChangelogModal: boolean => void;
+  showChangelogModal: boolean;
+  setShowHelpModal: boolean => void;
+  showHelpModal: boolean;
   updateGraphWidth: () => void;
   setGraphWidth: number => void;
   graphWidth: number;
+  cancelAll: () => void;
+  unselect: () => void;
 
   constructor() {
     const user = Meteor.user();
@@ -76,10 +80,11 @@ export default class uiStore {
       showPreview: false,
       libraryOpen: false,
       showInfo: false,
-      showModal:
+      showChangelogModal:
         user?.profile !== undefined &&
         user?.profile.lastVersionChangelog !== undefined &&
         user?.profile.lastVersionChangelog < changelog.length - 1,
+      showHelpModal: false,
       setIsSvg: action((isSvg: boolean) => {
         this.isSvg = isSvg;
         if (isSvg) {
@@ -202,8 +207,12 @@ export default class uiStore {
         this.selected = null;
       }),
 
-      setModal: action((set: boolean) => {
-        this.showModal = set;
+      setShowChangelogModal: action((set: boolean) => {
+        this.showChangelogModal = set;
+      }),
+
+      setShowHelpModal: action((set: boolean) => {
+        this.showHelpModal = set;
       }),
 
       cancelAll: action(() => {

--- a/frog/imports/ui/GraphEditor/store/uiStore.js
+++ b/frog/imports/ui/GraphEditor/store/uiStore.js
@@ -1,11 +1,64 @@
+// @flow
+
+import { Meteor } from 'meteor/meteor';
 import { extendObservable, action, reaction } from 'mobx';
+
+import { type ActivityDbT } from 'frog-utils';
 
 import { getActivitySequence } from '/imports/api/graphSequence';
 import changelog from '/imports/api/changelog';
 import { between, timeToPx, pxToTime } from '../utils';
 import { store } from './index';
+import Elem from './elemClass';
 
 export default class uiStore {
+  setLibraryOpen: boolean => void;
+  selected: ?Elem;
+  setIsSvg: boolean => void;
+  isSvg: boolean;
+  panx: number;
+  panBoxSize: number;
+  scale: number;
+  socialPan: number => void;
+  socialCoordsTime: [number, number];
+  panDelta: number => void;
+  scrollIntervalID: any;
+  updateWindow: () => void;
+  windowWidth: number;
+  storeInterval: any => void;
+  cancelScroll: () => void;
+  setShowInfo: ('activity' | 'operator', string) => void;
+  showInfo: ?{ klass: 'activity' | 'operator', id: string };
+  svgRef: any;
+  setShowErrors: boolean | (string => void);
+  showErrors: boolean | string;
+  socialCoords: [number, number];
+  socialCoordsScaled: [number, number];
+  panTime: number;
+  rightEdgeTime: number;
+  furthestObject: number;
+  setScaleDelta: number => void;
+  setScaleValue: number => void;
+  canvasClick: () => void;
+  endRename: () => void;
+  socialMove: (number, number) => void;
+  scrollEnabled: boolean;
+  panOffset: number;
+  setSvgRef: any => void;
+  svgRef: any;
+  setShowPreview: (?Object) => void;
+  showPreview: ?Object;
+  setSidepanelOpen: boolean => void;
+  sidepanelOpen: boolean;
+  toggleSidepanelOpen: () => void;
+  setLibraryOpen: boolean => void;
+  libraryOpen: boolean;
+  setModal: boolean => void;
+  showModal: boolean;
+  updateGraphWidth: () => void;
+  setGraphWidth: number => void;
+  graphWidth: number;
+
   constructor() {
     const user = Meteor.user();
     extendObservable(this, {
@@ -32,7 +85,16 @@ export default class uiStore {
         if (isSvg) {
           store.activityStore.setActivitySequence(
             getActivitySequence(
-              store.activityStore.all.map(x => ({ ...x, _id: x.id }))
+              store.activityStore.all.map(x => {
+                const acObj: ActivityDbT = {
+                  data: x.data,
+                  startTime: x.startTime,
+                  length: x.length,
+                  activityType: x.activityType,
+                  _id: x.id
+                };
+                return acObj;
+              })
             )
           );
         }
@@ -178,7 +240,7 @@ export default class uiStore {
 
       cancelScroll: action(() => {
         if (this.scrollIntervalID) {
-          window.clearInterval(this.scrollIntervalID);
+          clearInterval(this.scrollIntervalID);
         }
         this.scrollIntervalID = undefined;
       }),

--- a/frog/imports/ui/GraphEditor/utils/export.js
+++ b/frog/imports/ui/GraphEditor/utils/export.js
@@ -38,10 +38,13 @@ export const exportGraph = () => {
 export const duplicateGraph = graphId =>
   doImportGraph({ target: { result: graphToString(graphId) } });
 
-export const doImportGraph = graphStr => {
+export const doImportGraph = (graphStr: string, title?: string) => {
   try {
     const graph = graphStr.target ? graphStr.target.result : graphStr;
     const graphObj = JSON.parse(graph);
+    if (title) {
+      graphObj.graph.name = title;
+    }
     const graphId = addGraph(graphObj);
     store.setId(graphId);
     return graphId;

--- a/frog/imports/ui/GraphEditor/utils/exportPicture.js
+++ b/frog/imports/ui/GraphEditor/utils/exportPicture.js
@@ -8,7 +8,7 @@ import { store } from '../store';
 import { timeToPx } from '.';
 import Graph from '../Graph';
 
-export default (dataCB: string => void) => {
+export default (dataCB: ?(string) => void) => {
   const canvas = document.createElement('canvas');
 
   const oldScale = store.ui.scale;

--- a/frog/imports/ui/GraphEditor/utils/exportPicture.js
+++ b/frog/imports/ui/GraphEditor/utils/exportPicture.js
@@ -8,7 +8,7 @@ import { store } from '../store';
 import { timeToPx } from '.';
 import Graph from '../Graph';
 
-export default (dataCB: ?(string) => void) => {
+export default (dataCB?: string => void) => {
   const canvas = document.createElement('canvas');
 
   const oldScale = store.ui.scale;

--- a/frog/imports/ui/TeacherView/SessionUtils.jsx
+++ b/frog/imports/ui/TeacherView/SessionUtils.jsx
@@ -10,6 +10,7 @@ import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
+import { withRouter } from 'react-router';
 
 import { setTeacherSession } from '../../api/sessions';
 
@@ -44,7 +45,7 @@ const DashToggle = ({
   </ToolTipComponent>
 );
 
-class UtilsMenu extends React.Component<any, { anchorEl: any }> {
+class UtilsMenuRaw extends React.Component<any, { anchorEl: any }> {
   state = {
     anchorEl: null
   };
@@ -106,7 +107,12 @@ class UtilsMenu extends React.Component<any, { anchorEl: any }> {
               Projector View in New Tab
             </a>
           </MenuItem>
-          <MenuItem onClick={() => setTeacherSession(undefined)}>
+          <MenuItem
+            onClick={() => {
+              this.props.history.push('/teacher/orchestration');
+              setTeacherSession(undefined);
+            }}
+          >
             Quit session
           </MenuItem>
         </Menu>
@@ -114,6 +120,8 @@ class UtilsMenu extends React.Component<any, { anchorEl: any }> {
     );
   }
 }
+
+const UtilsMenu = withRouter(UtilsMenuRaw);
 
 const SessionUtils = ({
   classes,

--- a/frog/imports/ui/TeacherView/index.js
+++ b/frog/imports/ui/TeacherView/index.js
@@ -19,9 +19,21 @@ const TeacherView = props => (
   </>
 );
 
-const TeacherViewRunner = withTracker(() => {
+const TeacherViewRunner = withTracker(({ match }) => {
   const user = Meteor.user();
-  const session = user.profile && Sessions.findOne(user.profile.controlSession);
+  let session;
+  if (match?.params?.graphId) {
+    const graph = Graphs.findOne(match.params.graphId.trim());
+    if (graph.sessionId) {
+      session = Sessions.findOne(graph.sessionId);
+      Meteor.users.findOne(user._id, {
+        $set: { 'profile.controlSession': session._id }
+      });
+    }
+  }
+  if (!session) {
+    session = user.profile && Sessions.findOne(user.profile.controlSession);
+  }
   const activities =
     session && Activities.find({ graphId: session.graphId }).fetch();
   const students =


### PR DESCRIPTION
The problem with Undo was that the constructor for the activities in graphEditor was changed so it was not being used correctly and it was sending new activity ids for all activities. That lead to deleting everything and recreating the activities (losing activityTypes and config in the process). As this could have been caught by flow, I also made the effort of adding flow everywhere. 

Fixed the GraphName component in the process.

Adding back the HelpModal. The ChangeLog is accessible with "!" 