### PR TITLE
Dashboard for text answers in quiz

### DIFF
--- a/ac/ac-quiz/src/Dashboard/ReactiveCountDashboard.js
+++ b/ac/ac-quiz/src/Dashboard/ReactiveCountDashboard.js
@@ -14,11 +14,15 @@ const reactiveToDisplay = (reactive: any, activity: ActivityDbT) => {
     (q.answers || []).map(a => ({ x: a.choice, y: 0 }))
   );
 
+  const questionTexts = questions.map(() => []);
   values(reactive).forEach(instanceData =>
     entries(instanceData.form || {}).forEach(([qIdx, answer]) => {
       entries(answer || {}).forEach(([aIdx, aValue]) => {
         if (aValue === true) {
           questionStats[qIdx][aIdx].y += 1;
+        }
+        if (answer && answer.text) {
+          questionTexts[qIdx].push(answer.text);
         }
       });
     })
@@ -28,7 +32,7 @@ const reactiveToDisplay = (reactive: any, activity: ActivityDbT) => {
     .map((v, k) => [questions[k].question, reverse(v), k])
     .filter(([_, v]) => v && v.length > 0);
 
-  return result;
+  return { result, questionTexts, questions };
 };
 
 export default {

--- a/ac/ac-quiz/src/Dashboard/ViewerCount.js
+++ b/ac/ac-quiz/src/Dashboard/ViewerCount.js
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-disable react/no-array-index-key */
 import * as React from 'react';
 import {
   VictoryBar,
@@ -28,6 +29,19 @@ const styles = () => ({
     marginBottom: '8px'
   }
 });
+
+const TextQ = withStyles(styles)(({ question, answers, classes }) => (
+  <Paper className={classes.question}>
+    <Typography align="center" variant="button" gutterBottom>
+      <HTML html={question} />
+    </Typography>
+    <ul>
+      {answers.map((x, i) => (
+        <li key={i}>{x}</li>
+      ))}
+    </ul>
+  </Paper>
+));
 
 const Question = withStyles(styles)(({ question, answers, classes }) => (
   <Paper className={classes.question}>
@@ -70,8 +84,11 @@ const Question = withStyles(styles)(({ question, answers, classes }) => (
 const Viewer = withStyles(styles)(
   ({ state, classes }: { state: Object, classes: Object }) => (
     <div className={classes.root}>
-      {state.map(([k, v, idx]) => (
+      {state.result.map(([k, v, idx]) => (
         <Question key={idx} question={k} answers={v} />
+      ))}
+      {state.questionTexts.map((k, idx) => (
+        <TextQ key={idx} question={state.questions[idx].question} answers={k} />
       ))}
     </div>
   )


### PR DESCRIPTION
This is not a perfect solution, but it does provide a dashboard for showing multiple text answers. Right now the rendering logic is separate from the other stuff, I guess it should be mixed, but didn't want to mess with the graphs... At least it works for a class that just want to answer a few text answers, and show the answers.

(we should also remove the justification dashboard, which doesn't make much sense stand-alone anymore).