### PR TITLE
Fix URL handling in orchestration view

### DIFF
--- a/frog/imports/ui/App/TeacherContainer.js
+++ b/frog/imports/ui/App/TeacherContainer.js
@@ -42,7 +42,7 @@ const WithTopBar = () => (
       <Switch>
         <Route path="/teacher/preview/:previewId" component={Preview} />
         <Route path="/teacher/preview" component={Preview} />
-        <Route path="/teacher/orchestration/:graphId" component={TeacherView} />
+        <Route path="/teacher/orchestration/:slug" component={TeacherView} />
         <Route path="/teacher/orchestration" component={TeacherView} />
         <Route path="/teacher/graph/:graphId" component={GraphEditor} />
         <Route path="/teacher/graph" component={GraphEditor} />

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -174,7 +174,10 @@ export default class Store {
       // should check for new global version of graph
       setId: action((id: string, readOnly: boolean = false) => {
         const desiredUrl = `${this.url}/${id}`;
-        if (this.browserHistory.location.pathname !== desiredUrl) {
+        if (
+          this.browserHistory &&
+          this.browserHistory.location.pathname !== desiredUrl
+        ) {
           this.browserHistory.push(desiredUrl);
         }
         setCurrentGraph(id);

--- a/frog/imports/ui/GraphEditor/store/store.js
+++ b/frog/imports/ui/GraphEditor/store/store.js
@@ -101,7 +101,7 @@ export default class Store {
   graphErrors: Object[];
   valid: Object;
   setId: (string, ?boolean) => void;
-  setBrowserHistory: (Object, ?string) => void;
+  setBrowserHistory: (?Object, ?string) => void;
   setSession: any => void;
   deleteSelected: (?boolean) => void;
 

--- a/frog/imports/ui/TeacherView/GraphView.jsx
+++ b/frog/imports/ui/TeacherView/GraphView.jsx
@@ -2,9 +2,7 @@
 
 import * as React from 'react';
 import { Provider } from 'mobx-react';
-import { withRouter } from 'react-router';
 import { isEqual } from 'lodash';
-
 import { withStyles } from '@material-ui/core/styles';
 
 import ShowInfo from './ShowInfo';
@@ -13,7 +11,6 @@ import { store } from '../GraphEditor/store';
 
 type GraphViewPropsT = {
   session: Object,
-  history: Object,
   classes: Object
 };
 
@@ -68,6 +65,6 @@ class GraphViewController extends React.Component<GraphViewPropsT, {}> {
   }
 }
 
-const GraphView = withRouter(GraphViewController);
+const GraphView = GraphViewController;
 
 export default withStyles(styles)(GraphView);

--- a/frog/imports/ui/TeacherView/GraphView.jsx
+++ b/frog/imports/ui/TeacherView/GraphView.jsx
@@ -26,7 +26,7 @@ const styles = {
 
 class GraphViewController extends React.Component<GraphViewPropsT, {}> {
   initStore = (session: any) => {
-    store.setBrowserHistory(this.props.history, '/teacher/orchestration');
+    store.setBrowserHistory(null);
     store.setId(session.graphId, true);
     store.setSession(session);
     store.session.setTimes(session);

--- a/frog/imports/ui/TeacherView/SessionList.jsx
+++ b/frog/imports/ui/TeacherView/SessionList.jsx
@@ -6,6 +6,7 @@ import FormHelperText from '@material-ui/core/FormHelperText';
 import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
 import Typography from '@material-ui/core/Typography';
+import { withRouter } from 'react-router';
 import Tooltip from '@material-ui/core/Tooltip';
 import IconButton from '@material-ui/core/IconButton';
 import Grid from '@material-ui/core/Grid';
@@ -54,7 +55,9 @@ class SessionAdmin extends React.Component<
 
   handleSessionCreation = () => {
     if (this.state.graphId !== undefined && this.state.graphId !== '') {
-      addSession(this.state.graphId);
+      addSession(this.state.graphId).then(e =>
+        this.props.history.push('/teacher/orchestration/' + e)
+      );
     }
   };
 
@@ -179,30 +182,32 @@ class SessionAdmin extends React.Component<
   }
 }
 
-const SessionList = ({
-  graphs,
-  sessions,
-  ...props
-}: {
-  graphs: Array<Object>,
-  sessions: Array<Object>,
-  classes: Object
-}) => {
-  const { classes } = props;
-  return (
-    <div>
-      <Grid id="graph-session" item xs={12}>
-        <Card>
-          <CardContent>
-            <Typography type="title" className={classes.title}>
-              Session Controls
-            </Typography>
-            <SessionAdmin sessions={sessions} graphs={graphs} {...props} />
-          </CardContent>
-        </Card>
-      </Grid>
-    </div>
-  );
-};
+const SessionList = withRouter(
+  ({
+    graphs,
+    sessions,
+    ...props
+  }: {
+    graphs: Array<Object>,
+    sessions: Array<Object>,
+    classes: Object
+  }) => {
+    const { classes } = props;
+    return (
+      <div>
+        <Grid id="graph-session" item xs={12}>
+          <Card>
+            <CardContent>
+              <Typography type="title" className={classes.title}>
+                Session Controls
+              </Typography>
+              <SessionAdmin sessions={sessions} graphs={graphs} {...props} />
+            </CardContent>
+          </Card>
+        </Grid>
+      </div>
+    );
+  }
+);
 
 export default withStyles(styles)(SessionList);

--- a/frog/imports/ui/TeacherView/SessionUtils.jsx
+++ b/frog/imports/ui/TeacherView/SessionUtils.jsx
@@ -113,7 +113,7 @@ class UtilsMenuRaw extends React.Component<any, { anchorEl: any }> {
               setTeacherSession(undefined);
             }}
           >
-            Quit session
+            Switch to Other Session
           </MenuItem>
         </Menu>
       </div>

--- a/frog/imports/ui/TeacherView/index.js
+++ b/frog/imports/ui/TeacherView/index.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { Meteor } from 'meteor/meteor';
 import { withTracker } from 'meteor/react-meteor-data';
+import { withRouter } from 'react-router';
 
 import SessionList from './SessionList';
 import OrchestrationView from './OrchestrationView';
@@ -19,35 +20,41 @@ const TeacherView = props => (
   </>
 );
 
-const TeacherViewRunner = withTracker(({ match }) => {
-  const user = Meteor.user();
-  let session;
-  if (match?.params?.graphId) {
-    const graph = Graphs.findOne(match.params.graphId.trim());
-    if (graph.sessionId) {
-      session = Sessions.findOne(graph.sessionId);
-      Meteor.users.findOne(user._id, {
-        $set: { 'profile.controlSession': session._id }
+const TeacherViewRunner = withRouter(
+  withTracker(({ match, history }) => {
+    const user = Meteor.user();
+    let session;
+    if (match?.params?.slug) {
+      session = Sessions.findOne({
+        slug: match.params.slug.trim().toUpperCase()
       });
+      if (session) {
+        Meteor.users.findOne(user._id, {
+          $set: { 'profile.controlSession': session._id }
+        });
+      }
     }
-  }
-  if (!session) {
-    session = user.profile && Sessions.findOne(user.profile.controlSession);
-  }
-  const activities =
-    session && Activities.find({ graphId: session.graphId }).fetch();
-  const students =
-    session && Meteor.users.find({ joinedSessions: session.slug }).fetch();
-  return {
-    sessions: Sessions.find().fetch(),
-    session,
-    graphs: Graphs.find({ broken: { $ne: true } }).fetch(),
-    activities,
-    token: GlobalSettings.findOne('token'),
-    students,
-    user
-  };
-})(TeacherView);
+    if (!session) {
+      session = user.profile && Sessions.findOne(user.profile.controlSession);
+    }
+    if (session && session.slug !== match.params.slug) {
+      history.push('/teacher/orchestration/' + session.slug);
+    }
+    const activities =
+      session && Activities.find({ graphId: session.graphId }).fetch();
+    const students =
+      session && Meteor.users.find({ joinedSessions: session.slug }).fetch();
+    return {
+      sessions: Sessions.find().fetch(),
+      session,
+      graphs: Graphs.find({ broken: { $ne: true } }).fetch(),
+      activities,
+      token: GlobalSettings.findOne('token'),
+      students,
+      user
+    };
+  })(TeacherView)
+);
 
 TeacherViewRunner.displayName = 'TeacherViewRunner';
 export default TeacherViewRunner;


### PR DESCRIPTION
This changes URL handling in orchestration view:
- when controlling session, SLUG of session is in URL bar
- when restarting, old sessions are named successively SLUG-old-1 etc

Check that this works in all different ways of entering orchestration view, creating/switching/reloading etc etc.