### PR TITLE
Fixing "Each child should have a key" in session with two activities open

### DIFF
--- a/frog/imports/ui/StudentView/Runner.jsx
+++ b/frog/imports/ui/StudentView/Runner.jsx
@@ -93,7 +93,7 @@ const Runner = ({ path, activity, sessionId, object, single }) => {
   } else {
     return (
       <MosaicWindow
-        toolbarControls={[<div />]}
+        toolbarControls={[<div key={1} />]}
         draggable={false}
         key={activity._id}
         path={path}


### PR DESCRIPTION
It only takes one div, but it has to be an array, and things in an array have to have a key.

Closes #1383 
