### PR TITLE
Run formatProduct in Preview

### DIFF
--- a/frog/imports/ui/Preview/Content.jsx
+++ b/frog/imports/ui/Preview/Content.jsx
@@ -153,14 +153,24 @@ const ContentController = ({
       return <h1>No preview available for this activity type</h1>;
     }
     const docId = DocId(activityType.id, instance);
+    const formatProduct = activityType.formatProduct;
+
+    const transform = formatProduct
+      ? x => formatProduct(config || {}, x, instance, name)
+      : undefined;
+
     const ActivityToRun = ReactiveHOC(
       docId,
       connection,
       false,
       undefined,
       undefined,
-      backend
+      backend,
+      undefined,
+      undefined,
+      transform
     )(showData ? ShowInfo : RunComp);
+
     const logger = createLogger(
       'preview',
       instance,


### PR DESCRIPTION
Useless, but can catch bugs, because formatProduct runs in session, and we don't want to wait until then to discover bugs (has happened).

Closes #1370 