### PR TITLE
Only calculate product when needed

### DIFF
--- a/frog/imports/api/engine.js
+++ b/frog/imports/api/engine.js
@@ -51,7 +51,6 @@ export const runNextActivity = (sessionId: string) => {
       return act.startTime + act.length < newTimeInGraph;
     });
     justClosedActivities.forEach(act => {
-      Meteor.call('reactive.to.product', act);
       Meteor.call('archive.dashboard.state', act);
     });
     const openActivityIds = openActivities.map(x => x._id);

--- a/frog/server/reactiveToProduct.js
+++ b/frog/server/reactiveToProduct.js
@@ -104,17 +104,19 @@ export const getActivityDataFromReactive = (
 };
 
 const ensure = (activityId: string) => {
+  const product = getActivityDataFromReactive(activityId);
   Products.update(
     activityId,
     {
       $set: {
-        activityData: getActivityDataFromReactive(activityId),
+        activityData: product,
         type: 'product'
       }
     },
     { upsert: true }
   );
   Activities.update(activityId, { $set: { state: 'computed' } });
+  return product;
 };
 
 Meteor.methods({ 'reactive.to.product': id => ensure(id) });


### PR DESCRIPTION
Activities whose data is not needed, does not get their data calculated, to speed up next.activity. All uncalculated activities get calculated for export session.

Note this also means that data that is needed only gets calculated when needed, not immediately upon next.activity.