### PR TITLE
Fix ac-stat error

### DIFF
--- a/ac/ac-stat/src/Components/DataForm.js
+++ b/ac/ac-stat/src/Components/DataForm.js
@@ -179,7 +179,7 @@ class Data extends React.Component<*, *> {
       <Paper className={classes.root}>
         <div className={classes.header}>
           <DatasetSelector {...this.props} />
-          <RefreshDataset {...this.props} />
+          {editable && <RefreshDataset {...this.props} />}
         </div>
         <div className={classes.table}>
           <Table>


### PR DESCRIPTION
You should not be able to reload dataset, if you cannot edit - this was causing a crash.