### PR TITLE
Config type was not written for new activities in graph

### DIFF
--- a/frog/imports/api/activities.js
+++ b/frog/imports/api/activities.js
@@ -98,7 +98,18 @@ export const addActivity = (
   if (id)
     updateOneActivityMongo(id, {
       $set: omitBy(
-        { activityType, parentId, data, groupingKey, configVersion },
+        {
+          activityType,
+          parentId,
+          data,
+          groupingKey,
+          ...(activityType
+            ? {
+                configVersion:
+                  configVersion || activityTypesObj[activityType].configVersion
+              }
+            : {})
+        },
         isNil
       )
     });
@@ -106,7 +117,12 @@ export const addActivity = (
     insertActivityMongo({
       _id: uuid(),
       parentId,
-      configVersion: configVersion || 1,
+      ...(activityType
+        ? {
+            configVersion:
+              configVersion || activityTypesObj[activityType].configVersion
+          }
+        : {}),
       activityType,
       data,
       groupingKey,


### PR DESCRIPTION
This caused upgrade functions to be run unnecessarily, potentially causing errors (like in ac-stat). 

Closes #1478 	