### PR TITLE
Conditional dashboards

### DIFF
--- a/ac/ac-quiz/src/Dashboard/index.js
+++ b/ac/ac-quiz/src/Dashboard/index.js
@@ -13,6 +13,6 @@ export default {
   counts: ReactiveCountDashboard,
   progress: ProgressDashboard,
   leaderboard: LeaderBoard,
-  coordinates: CoordinatesDashboard,
+  coordinates: { ...CoordinatesDashboard, displayCondition: 'argueWeighting' },
   justification: JustificationDashboard
 };

--- a/frog-utils/src/types.js
+++ b/frog-utils/src/types.js
@@ -167,6 +167,7 @@ export type ActivityPackageT = {
 };
 
 export type DashboardT = {
+  displayCondition?: string | ((obj: Object) => boolean),
   Viewer: React.ComponentType<DashboardViewerPropsT>,
   mergeLog: (state: any, log: LogDbT, activity: ActivityDbT) => void,
   prepareDataForDisplay?: (state: any, activity: ActivityDbT) => any,

--- a/frog/imports/ui/Dashboard/MultiWrapper.jsx
+++ b/frog/imports/ui/Dashboard/MultiWrapper.jsx
@@ -110,7 +110,8 @@ const MultiWrapper = (props: {
   dashboardData?: Object,
   session?: Object,
   object: Object,
-  ready?: boolean
+  ready?: boolean,
+  config?: Object
 }) => {
   const {
     dashboardData,
@@ -127,7 +128,24 @@ const MultiWrapper = (props: {
     return <CircularProgress />;
   }
   const aT = activityTypesObj[activity.activityType];
-  const dashNames = names || Object.keys(aT.dashboards || {});
+  const aTDash = aT.dashboards;
+  if (!aTDash || (isEmpty(aTDash) && !names)) {
+    return null;
+  }
+
+  const dashNames =
+    names ||
+    Object.keys(aTDash).filter(name => {
+      const cond = aTDash[name].displayCondition;
+      if (!cond) {
+        return true;
+      }
+      if (typeof cond === 'string') {
+        return !!activity.data[cond];
+      }
+      return cond(activity.data);
+    });
+
   if (isEmpty(dashNames)) {
     return null;
   }


### PR DESCRIPTION
The dashboard object takes an optional value called displayCondition, which is similar to how configUI works - it can either take a string, the key of a config field which is turned into a boolean check, or a function which takes formdata as input and returns true/false.

Currently I've only made the coordinates dashboard for ac-quiz dependent on whether coordinates are added to questions. We might also check if the right answer has been added, for the Leaderboard, but I guess maybe sometimes we use it just to see who finishes first? Also have to look at the other dashboards to see if there are other things we can make conditional.

(The key objective is to avoid confusion among teachers).

Since we're only modifying the list of dashboards shown, but none of the logic about subscriptions etc, it shouldn't introduce any new bugs :)