### PR TITLE
Implemented Integrated Voting Counter

### DIFF
--- a/ac/ac-brainstorm/src/ActivityRunner.js
+++ b/ac/ac-brainstorm/src/ActivityRunner.js
@@ -3,11 +3,14 @@
 import * as React from 'react';
 import { values, type ActivityRunnerPropsT } from 'frog-utils';
 import FlipMove from '@houshuang/react-flip-move';
-import Badge from '@material-ui/core/Badge';
+import Avatar from '@material-ui/core/Avatar';
 import Grid from '@material-ui/core/Grid';
 import List from '@material-ui/core/List';
 import Card from '@material-ui/core/Card';
-import ThumbDownIcon from '@material-ui/icons/ThumbDown';
+import Chip from '@material-ui/core/Chip';
+import IconButton from '@material-ui/core/IconButton';
+import KeyboardArrowUp from '@material-ui/icons/KeyboardArrowUp';
+import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
 import ThumbUpIcon from '@material-ui/icons/ThumbUp';
 import PencilIcon from '@material-ui/icons/Edit';
 import DeleteIcon from '@material-ui/icons/Delete';
@@ -92,6 +95,7 @@ class Idea extends React.Component<
       children
     } = this.props;
     const { focus } = this.state;
+    const { score } = meta;
     return (
       <Card
         raised={focus}
@@ -100,9 +104,50 @@ class Idea extends React.Component<
       >
         <CardContent
           style={{
-            minWidth: '400px'
+            minWidth: '400px',
+            minHeight: '120px'
           }}
         >
+          <div
+            style={{
+              position: 'absolute',
+              display: 'flex',
+              flexDirection: 'column',
+              top: '5px',
+              right: '5px'
+            }}
+          >
+            {config.allowVoting && (
+              <Button
+                size="small"
+                onClick={() => vote(meta.id, 1)}
+                style={{
+                  minHeight: '13px',
+                  padding: '3px 4px'
+                }}
+              >
+                <KeyboardArrowUp fontSize="small" />
+              </Button>
+            )}
+            <Chip
+              label={score}
+              style={{
+                height: 'unset'
+              }}
+            />
+            {config.allowVoting && (
+              <Button
+                size="small"
+                onClick={() => vote(meta.id, -1)}
+                style={{
+                  minHeight: '13px',
+                  padding: '3px 4px'
+                }}
+              >
+                <KeyboardArrowDown fontSize="small" />
+              </Button>
+            )}
+          </div>
           <Grow in={focus}>
             <div
               style={{
@@ -111,20 +156,10 @@ class Idea extends React.Component<
                 minWidth: '108px',
                 display: 'flex',
                 flexDirection: 'row',
-                bottom: '15px',
-                right: '15px'
+                bottom: '10px',
+                right: '10px'
               }}
             >
-              {config.allowVoting && (
-                <div>
-                  <Button size="small" onClick={() => vote(meta.id, -1)}>
-                    <ThumbDownIcon fontSize="small" />
-                  </Button>
-                  <Button size="small" onClick={() => vote(meta.id, 1)}>
-                    <ThumbUpIcon fontSize="small" />
-                  </Button>
-                </div>
-              )}
               <div>
                 <font size={4}>
                   {config.allowDelete && (
@@ -180,11 +215,10 @@ const IdeaListRaw = ({
               borderRadius: '5px'
             }}
           >
-            <Badge
-              badgeContent={x.score}
-              color="primary"
-              classes={{ badge: classes.badge }}
-              style={{ display: 'block' }}
+            <div
+              style={{
+                position: 'relative'
+              }}
             >
               <LearningItem
                 type={
@@ -221,7 +255,7 @@ const IdeaListRaw = ({
                 )}
                 id={x.li}
               />
-            </Badge>
+            </div>
           </div>
         ))}
       </FlipMove>


### PR DESCRIPTION
I have made a basic prototype of the integrated voting counter as suggested by @houshuang .
There are 2 options for the counter: shaded (default) or outlined, please let me know which one looks better.
![Shaded-Design](https://user-images.githubusercontent.com/30972152/50381356-1ef41e00-06ab-11e9-8f8b-2b60d2937aa6.png) ![Outlined-Design](https://user-images.githubusercontent.com/30972152/50381355-0f74d500-06ab-11e9-832c-eef00a1af491.png)

The other buttons (delete, edit etc.) are still visible only on hover, I was wondering if it would be suitable to shift them on the bottom-left instead of bottom-right in order to reduce height requirement (for scannability) but, in this case they would always overlap with the content.
![buttons-left](https://user-images.githubusercontent.com/30972152/50381481-2c5ed780-06ae-11e9-9e3d-1567a6b900ca.png)
(Proposed)
![Buttons-Right](https://user-images.githubusercontent.com/30972152/50381385-d5f09980-06ab-11e9-8728-cba5620b4ccf.png)
(Original)