### PR TITLE
Issue #1574 - Shifted Add Learning Item component to top right 

### DIFF
--- a/ac/ac-gallery/src/ActivityRunner.js
+++ b/ac/ac-gallery/src/ActivityRunner.js
@@ -138,7 +138,7 @@ class ActivityRunner extends Component<
           </div>
         )}
         {activityData.config.allowAny && (
-          <div style={{ position: 'absolute', bottom: '10px', right: '10px' }}>
+          <div style={{ position: 'absolute', top: '50px', right: '59px' }}>
             <dataFn.LearningItem
               stream={this.props.stream}
               meta={{


### PR DESCRIPTION
Hi, 
Based on the description of the issue, I shifted the Add Learning Item component to the top right of the screen as shown below, outside the scroll zone. I felt it was better than keeping it locked to the bottom right as it is more visible to the user and also it doesn't cover the content at some points on scrolling down.
<img width="914" alt="screen shot 2018-12-28 at 8 23 26 pm" src="https://user-images.githubusercontent.com/16490844/50519943-53b90880-0ae3-11e9-966b-5ccf5c1c0941.png">
