### PR TITLE
Fix undo operation when renaming activities

### DIFF
--- a/frog/imports/ui/GraphEditor/Rename.js
+++ b/frog/imports/ui/GraphEditor/Rename.js
@@ -45,10 +45,12 @@ export const RenameField = connect(
       return (
         <TextInput
           value={renameOpen.title}
-          onChange={renameOpen.rename}
           onFocus={e => e.target.select()}
           onCancel={onSubmit}
-          onSubmit={onSubmit}
+          onSubmit={(value: string) => {
+            renameOpen.rename(value);
+            onSubmit();
+          }}
         />
       );
     } else {


### PR DESCRIPTION
This PR changes the behaviour of the undo button when an activity has been renamed in the graph editor or in the activity configuration panel. Instead of undoing a single key press, it undoes the entire renaming action.

This is achieved by calling the `rename` method on the Activity object once, when the rename field is submitted, rather than on every key press.

Closes #1587 