### PR TITLE
Fix bug in op-hypothesis

### DIFF
--- a/op/op-hypothesis/src/index.js
+++ b/op/op-hypothesis/src/index.js
@@ -27,7 +27,7 @@ export const config = {
     limit: {
       default: 20,
       type: 'number',
-      title: 'Max number of items to fetch'
+      title: 'Max number of items to fetch (must be less than 1000)'
     },
     afterDate: {
       type: 'string',

--- a/op/op-hypothesis/src/index.js
+++ b/op/op-hypothesis/src/index.js
@@ -43,7 +43,14 @@ const validateConfig = [
   formData =>
     formData.tag || formData.url || formData.search || formData.group
       ? null
-      : { err: 'You need either tag, URL, group, or search term' }
+      : { err: 'You need either tag, URL, group, or search term' },
+  formData =>
+    formData.limit > 1000
+      ? {
+          err:
+            'The limit cannot be above 1000, because of Hypothes.is API limits'
+        }
+      : null
 ];
 
 export default ({

--- a/op/op-hypothesis/src/operatorRunner.js
+++ b/op/op-hypothesis/src/operatorRunner.js
@@ -98,11 +98,10 @@ const operator = (configData: {
       const numFetches = Math.ceil(Math.min(limit, e.total) / 200);
       const fetches = new Array(numFetches).fill().map((_, i) =>
         fetch(
-          `https://hypothes.is/api/search?${query}&limit=${(configData.limit &&
-            configData.limit > 0 &&
-            configData.limit < 200 &&
-            configData.limit) ||
-            200}&offset=${i * 200}`,
+          `https://hypothes.is/api/search?${query}&limit=${Math.min(
+            limit - i * 200,
+            200
+          )}&offset=${i * 200}`,
           configData.token && {
             headers: {
               Authorization: 'Bearer ' + configData.token

--- a/op/op-hypothesis/src/operatorRunner.js
+++ b/op/op-hypothesis/src/operatorRunner.js
@@ -81,7 +81,7 @@ const operator = (configData: {
     url: configData.url,
     any: configData.search,
     group: configData.group,
-    limit: configData.limit || 0
+    limit: 1
   });
   const url = 'https://hypothes.is/api/search?' + query;
   return fetch(

--- a/op/op-hypothesis/src/operatorRunner.js
+++ b/op/op-hypothesis/src/operatorRunner.js
@@ -84,31 +84,27 @@ const operator = (configData: {
     limit: 1
   });
   const url = 'https://hypothes.is/api/search?' + query;
-  return fetch(
-    url,
-    configData.token && {
-      headers: {
-        Authorization: 'Bearer ' + configData.token
-      }
+  const queryHeaders = configData.token && {
+    headers: {
+      Authorization: 'Bearer ' + configData.token
     }
-  )
+  };
+  return fetch(url, queryHeaders)
     .then(e => e.json())
     .then(e => {
       const limit = parseInt(configData.limit, 10) || 9999;
       const numFetches = Math.ceil(Math.min(limit, e.total) / 200);
-      const fetches = new Array(numFetches).fill().map((_, i) =>
-        fetch(
-          `https://hypothes.is/api/search?${query}&limit=${Math.min(
-            limit - i * 200,
-            200
-          )}&offset=${i * 200}`,
-          configData.token && {
-            headers: {
-              Authorization: 'Bearer ' + configData.token
-            }
-          }
-        ).then(x => x.json())
-      );
+      const fetches = new Array(numFetches)
+        .fill()
+        .map((_, i) =>
+          fetch(
+            `https://hypothes.is/api/search?${query}&limit=${Math.min(
+              limit - i * 200,
+              200
+            )}&offset=${i * 200}`,
+            queryHeaders
+          ).then(x => x.json())
+        );
       return Promise.all(fetches);
     })
     .then(z => mapQuery(flatten(z.map(a => a.rows)), configData));

--- a/op/op-hypothesis/src/operatorRunner.js
+++ b/op/op-hypothesis/src/operatorRunner.js
@@ -98,7 +98,6 @@ const operator = (configData: {
         MAX_LIMIT
       );
       const numFetches = Math.ceil(Math.min(limit, e.total) / 200);
-      console.log(e.total, limit, numFetches);
       const fetches = new Array(numFetches)
         .fill()
         .map((_, i) =>

--- a/op/op-hypothesis/src/operatorRunner.js
+++ b/op/op-hypothesis/src/operatorRunner.js
@@ -92,8 +92,13 @@ const operator = (configData: {
   return fetch(url, queryHeaders)
     .then(e => e.json())
     .then(e => {
-      const limit = parseInt(configData.limit, 10) || 9999;
+      const MAX_LIMIT = 1000;
+      const limit = Math.min(
+        parseInt(configData.limit, 10) || MAX_LIMIT,
+        MAX_LIMIT
+      );
       const numFetches = Math.ceil(Math.min(limit, e.total) / 200);
+      console.log(e.total, limit, numFetches);
       const fetches = new Array(numFetches)
         .fill()
         .map((_, i) =>


### PR DESCRIPTION
The problem was that in the first query done by the operator, which I believe is here just to get the total number of items, if limit was above 200 the correct result was not returned thus we had `e.total === undefined`. Unlike the issue said the operator was crashing when limit >200 and not when limit exceeded the total.

Second commit fixes a bug with the limit not being correctly computed. When asking for limit of 201 it would actually query two times 200, instead of one time 200, then 1

Closes #1603 