### PR TITLE
Fix ci again

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -71,7 +71,7 @@ module.exports = {
     },
     eslint: {
       default: fromRoot(
-        'fastlint --working-copy --print0 origin/develop --glob "**/*.{js,jsx}" | xargs -0 eslint --cache -c .eslintrc-prettier.js --ext .js,.jsx',
+        'fastlint --working-copy --print0 origin/develop --glob "**/*.{js,jsx}" | xargs -0 eslint --cache -c .eslintrc-prettier.js --ext ".js,.jsx"',
         'Running ESLint'
       ),
       fix: fromRoot(

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -75,11 +75,11 @@ module.exports = {
         'Running ESLint'
       ),
       fix: fromRoot(
-        'fastlint --working-copy --print0 origin/develop --glob "**/*.{js,jsx}" | xargs -0 eslint --fix --cache -c .eslintrc-prettier.js --ext .js,.jsx',
+        'fastlint --working-copy --print0 origin/develop --glob "**/*.{js,jsx}" | xargs -0 eslint --fix --cache -c .eslintrc-prettier.js --ext ".js,.jsx"',
         'Running ESLint in Fix mode'
       ),
       normal: fromRoot(
-        'eslint --cache -c .eslintrc-prettier.js --ext .js,.jsx .',
+        'eslint --cache -c .eslintrc-prettier.js --ext ".js,.jsx ."',
         'Running ESLint in normal mode'
       )
     },


### PR DESCRIPTION
@houshuang The CI is Green but Eslint tests are not working.

Error on the CI:
```
path.js:39
    throw new ERR_INVALID_ARG_TYPE('path', 'string', path);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type object
    at assertPath (path.js:39:11)
    at Object.dirname (path.js:1265:5)
    at Object.<anonymous> (/usr/src/frog/node_modules/fastlint/bin/fastlint:39:36)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:283:19)
eslint [options] file.js [file.js] [dir]

Basic configuration:
  --no-eslintrc                Disable use of configuration from .eslintrc.*
  -c, --config path::String    Use this configuration, overriding .eslintrc.* config options if present
  --env [String]               Specify environments
  --ext [String]               Specify JavaScript file extensions - default: .js
  --global [String]            Define global variables
  --parser String              Specify the parser to be used
  --parser-options Object      Specify parser options

Specifying rules and plugins:
  --rulesdir [path::String]    Use additional rules from this directory
  --plugin [String]            Specify plugins
  --rule Object                Specify rules

Fixing problems:
  --fix                        Automatically fix problems
  --fix-dry-run                Automatically fix problems without saving the changes to the file system
  --fix-type Array             Specify the types of fixes to apply (problem, suggestion, layout)

Ignoring files:
  --ignore-path path::String   Specify path of ignore file
  --no-ignore                  Disable use of ignore files and patterns
  --ignore-pattern [String]    Pattern of files to ignore (in addition to those in .eslintignore)

Using stdin:
  --stdin                      Lint code provided on <STDIN> - default: false
  --stdin-filename String      Specify filename to process STDIN as

Handling warnings:
  --quiet                      Report errors only - default: false
  --max-warnings Int           Number of warnings to trigger nonzero exit code - default: -1

Output:
  -o, --output-file path::String  Specify file to write report to
  -f, --format String          Use a specific output format - default: stylish
  --color, --no-color          Force enabling/disabling of color

Inline configuration comments:
  --no-inline-config           Prevent comments from changing config or rules
  --report-unused-disable-directives  Adds reported errors for unused eslint-disable directives

Caching:
  --cache                      Only check changed files - default: false
  --cache-file path::String    Path to the cache file. Deprecated: use --cache-location - default: .eslintcache
  --cache-location path::String  Path to the cache file or directory

Miscellaneous:
  --init                       Run config initialization wizard - default: false
  --debug                      Output debugging information
  -h, --help                   Show help
  -v, --version                Output the version number
  --print-config path::String  Print the configuration for the given file

```

I had a different error locally:
```
[10:33:33] louisfaucon@sysadmin-OptiPlex-990 [FROG] $
> nps eslint
nps is executing `eslint` : echo Running ESLint & cd /home/louisfaucon/FROG/ && PATH=/home/louisfaucon/FROG/node_modules/.bin:$PATH fastlint --working-copy --print0 origin/develop --glob "**/*.{js,jsx}" | xargs -0 eslint --cache -c .eslintrc-prettier.js --ext .js,.jsx
Running ESLint

Oops! Something went wrong! :(

ESLint: 5.11.1.
No files matching the pattern "
" were found.
Please check for typing mistakes in the pattern.

The script called "eslint" which runs "echo Running ESLint & cd /home/louisfaucon/FROG/ && PATH=/home/louisfaucon/FROG/node_modules/.bin:$PATH fastlint --working-copy --print0 origin/develop --glob "**/*.{js,jsx}" | xargs -0 eslint --cache -c .eslintrc-prettier.js --ext .js,.jsx" failed with exit code 123 https://github.com/kentcdodds/nps/blob/v5.9.0/other/ERRORS_AND_WARNINGS.md#failed-with-exit-code
```
This error I fixed by adding `" "` around `.js,.jsx`, but it did not fix the other error on the CI
