### PR TITLE
Rich text enhancements

### DIFF
--- a/frog-utils/src/ReactiveRichText.js
+++ b/frog-utils/src/ReactiveRichText.js
@@ -90,7 +90,8 @@ const LIComponentRaw = ({ id, authorId, classes, liView, liZoomState }) => {
                     </IconButton>
                   )}
                   {get(LiTypeObject, 'ThumbViewer') &&
-                    get(LiTypeObject, 'Viewer') && (
+                    get(LiTypeObject, 'Viewer') &&
+                    liView !== LiViewTypes.EDIT && (
                       <IconButton
                         disableRipple
                         style={{ float: 'right' }}

--- a/frog-utils/src/ReactiveRichText.js
+++ b/frog-utils/src/ReactiveRichText.js
@@ -651,6 +651,9 @@ class ReactiveRichText extends Component<
       // processing those initial deltas.
       setTimeout(() => {
         editor.on('text-change', this.handleChange);
+        // In case the loaded document had LIs without correct spacing
+        this.ensureSpaceAroundLis();
+
         editor.on('selection-change', this.handleSelectionChange);
       }, 100);
 
@@ -729,6 +732,8 @@ class ReactiveRichText extends Component<
           } else if (get(next, 'statics.blotName') === 'learning-item') {
             editor.insertText(nextIndex, '\n', Quill.sources.USER);
             return;
+          } else if (i === editorLength - 1) {
+            editor.insertText(i + 1, '\n', Quill.sources.USER);
           }
         }
       }


### PR DESCRIPTION
- Hide zoom button when in edit mode
- Ensure space after LI at end of doc
- Scroll to bottom if pasted content, newline or LI drop/insert at the end of doc