### PR TITLE
Set min-width for the social plane selector

### DIFF
--- a/frog/imports/client/Wiki/ModalCreate.js
+++ b/frog/imports/client/Wiki/ModalCreate.js
@@ -53,7 +53,8 @@ const styles = () => ({
     margin: 8
   },
   selectSocialPlane: {
-    width: '7vw'
+    width: '7vw',
+    minWidth: '135px'
   },
   modalInner: {
     height: '45vh',


### PR DESCRIPTION
Social plane does not cause text to overflow in case of small window size