### PR TITLE
Wiki final fixes

### DIFF
--- a/frog-utils/src/ReactiveRichText/main.js
+++ b/frog-utils/src/ReactiveRichText/main.js
@@ -711,7 +711,7 @@ class ReactiveRichText extends Component<
                               valueObj.plane === 1 &&
                               searchTerm.indexOf('/') > -1
                             ) {
-                              const parts = searchTerm.split('/');
+                              const parts = searchLower.split('/');
                               const pageTitle = parts[0];
                               const searchInstanceName = parts[1];
                               if (text.indexOf(pageTitle) > -1) {
@@ -727,6 +727,7 @@ class ReactiveRichText extends Component<
                                       JSON.stringify(valueObj)
                                     );
                                     pageObj.instanceId = instanceObj.instanceId;
+                                    pageObj.instanceName = instanceName;
                                     pageObj.title =
                                       valueObj.title + '/' + instanceName;
                                     matches.push(pageObj);
@@ -736,7 +737,10 @@ class ReactiveRichText extends Component<
                             }
                           }
 
-                          if (matches.length === 0) {
+                          if (
+                            searchTerm.indexOf('/') === -1 &&
+                            matches.length === 0
+                          ) {
                             matches.push({
                               title: searchTerm,
                               created: true,

--- a/frog-utils/src/ReactiveRichText/main.js
+++ b/frog-utils/src/ReactiveRichText/main.js
@@ -704,8 +704,35 @@ class ReactiveRichText extends Component<
                             const searchLower = (
                               searchTerm || ''
                             ).toLowerCase();
+
                             if (text.indexOf(searchLower) > -1) {
                               matches.push(valueObj);
+                            } else if (
+                              valueObj.plane === 1 &&
+                              searchTerm.indexOf('/') > -1
+                            ) {
+                              const parts = searchTerm.split('/');
+                              const pageTitle = parts[0];
+                              const searchInstanceName = parts[1];
+                              if (text.indexOf(pageTitle) > -1) {
+                                for (const instanceObj of Object.values(
+                                  valueObj.instances
+                                )) {
+                                  const instanceName = instanceObj.instanceName.toLowerCase();
+                                  if (
+                                    instanceName.indexOf(searchInstanceName) >
+                                    -1
+                                  ) {
+                                    const pageObj = JSON.parse(
+                                      JSON.stringify(valueObj)
+                                    );
+                                    pageObj.instanceId = instanceObj.instanceId;
+                                    pageObj.title =
+                                      valueObj.title + '/' + instanceName;
+                                    matches.push(pageObj);
+                                  }
+                                }
+                              }
                             }
                           }
 

--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { WikiContext, values } from 'frog-utils';
-import { toJS } from 'mobx';
+import { WikiContext } from 'frog-utils';
 import 'mousetrap/plugins/global-bind/mousetrap-global-bind.min.js';
 
 import Button from '@material-ui/core/Button';
@@ -13,6 +12,7 @@ import LIDashboard from '../Dashboard/LIDashboard';
 import Revisions from './Revisions';
 import WikiLink from './WikiLink';
 import { LearningItem } from './index';
+import { getPageDetailsForLiId } from './helpers.js';
 
 class WikiContentComp extends React.Component<> {
   constructor(props) {
@@ -181,11 +181,12 @@ class WikiContentComp extends React.Component<> {
               <LIDashboard
                 wikiId={this.props.wikiId}
                 search={this.props.dashboardSearch}
-                onClick={id => {
-                  const pageId = values(toJS(wikiStore.pages)).find(
-                    x => x.liId === id
-                  ).id;
-                  this.props.goToPage(pageId);
+                onClick={liId => {
+                  const { pageId, instanceId } = getPageDetailsForLiId(
+                    wikiStore.pages,
+                    liId
+                  );
+                  this.props.goToPage(pageId, null, null, instanceId);
                   this.setState({ docMode: 'view' });
                 }}
               />

--- a/frog/imports/client/Wiki/WikiLink.js
+++ b/frog/imports/client/Wiki/WikiLink.js
@@ -11,6 +11,7 @@ const WikiLink = observer(
     render() {
       const { data } = this.props;
       const pageObj = wikiStore.pages[data.id];
+      const instanceId = data.instanceId;
 
       const style = {
         textDecoration: 'underline',
@@ -76,7 +77,7 @@ const WikiLink = observer(
           ((side === 'left' && !e.shiftKey) || (side === 'right' && e.shiftKey))
             ? 'left'
             : 'right';
-        window.wiki.goToPage(pageId, null, sideToSend);
+        window.wiki.goToPage(pageId, null, sideToSend, instanceId);
       };
       style.color = 'blue';
 

--- a/frog/imports/client/Wiki/WikiLink.js
+++ b/frog/imports/client/Wiki/WikiLink.js
@@ -26,7 +26,7 @@ const WikiLink = observer(
       const pageId = pageObj.id;
       const pageTitle = pageObj.title;
       const displayTitle =
-        pageTitle + (data.instance ? '/' + data.instance : '');
+        pageTitle + (data.instanceName ? '/' + data.instanceName : '');
 
       if (!pageObj.created) {
         const createLinkFn = e => {

--- a/frog/imports/client/Wiki/helpers.js
+++ b/frog/imports/client/Wiki/helpers.js
@@ -1,5 +1,8 @@
 // @flow
 
+import { values } from 'frog-utils';
+import { toJS } from 'mobx';
+
 const parseDocResults = function(results: Object) {
   const pagesData = results.pages;
   const pages = {};
@@ -62,10 +65,33 @@ const getDifferentPageId = (pages, oldPageId) => {
   return null;
 };
 
+const getPageDetailsForLiId = (wikiPages, liId) => {
+  for (const pageObj of values(toJS(wikiPages))) {
+    const pageId = pageObj.id;
+    if (pageObj.plane === 3 && pageObj.liId === liId) {
+      return {
+        pageId
+      };
+    } else if (pageObj.plane === 1) {
+      for (const instanceObj of values(pageObj.instances)) {
+        const instanceId = instanceObj.instanceId;
+        if (instanceObj.liId === liId)
+          return {
+            pageId,
+            instanceId
+          };
+      }
+    }
+  }
+
+  return {};
+};
+
 export {
   parseDocResults,
   parseSearch,
   getPageTitle,
   checkNewPageTitle,
-  getDifferentPageId
+  getDifferentPageId,
+  getPageDetailsForLiId
 };

--- a/frog/imports/client/Wiki/helpers.js
+++ b/frog/imports/client/Wiki/helpers.js
@@ -52,7 +52,7 @@ const checkNewPageTitle = (parsedPages, newPageTitle) => {
   const parsedTitle = newPageTitle.toLowerCase().trim();
   if (parsedTitle === '') return 'Title cannot be empty';
   if (parsedTitle.includes('/')) return 'Title cannot contain /';
-  if (parsedPages[parsedTitle].valid) return 'Title already used';
+  if (parsedPages[parsedTitle]?.valid) return 'Title already used';
 
   return null;
 };

--- a/frog/imports/client/Wiki/store.js
+++ b/frog/imports/client/Wiki/store.js
@@ -1,4 +1,4 @@
-import { extendObservable, action } from 'mobx';
+import { extendObservable, action, toJS } from 'mobx';
 import { values } from 'frog-utils';
 
 class WikiStore {
@@ -25,7 +25,7 @@ class WikiStore {
       },
 
       get pagesArrayOnlyValid(): Array {
-        return values(wikiStore.pages).filter(x => x.valid && x.created);
+        return values(toJS(wikiStore.pages)).filter(x => x.valid && x.created);
       }
     });
   }


### PR DESCRIPTION
If you click on a page in the All pages view: doesn't switch if that page is an instance - FIXED
Instances don't immediately show up when they are created in other windows - FIXED
When you type in a search query in modal find, and press enter, it opens all pages, but it does not enter the search query into the search bar (this was working in my branch). - FIXED
It should be really easy to enable shift+link to open in the opposite window, or shift+link to open two pane display if only single pane display? - ADDED

Trying to export FROG graph to wiki, the wiki fails to load - Removed the cause of error, needs testing

You can no longer link to other instances - FIXED/IMPLEMENTED

Creating activity (frog activity) doesn't work at all? - I mentioned this previously and I really think that this functionality needs to be better thought out and implemented properly with the new code and database structure (especially concerning deleting and restoring), hence I removed it so that the next person working can start with a clean slate and do it properly. Unfortunately, I think this will require quite a bit of time to do because of any possible differences from activity pages compared to standard ones.