### PR TITLE
Added top-level menu

### DIFF
--- a/frog/imports/client/Wiki/WikiTopNavbar.js
+++ b/frog/imports/client/Wiki/WikiTopNavbar.js
@@ -4,7 +4,56 @@ import ChromeReaderMode from '@material-ui/icons/ChromeReaderMode';
 import Dashboard from '@material-ui/icons/Dashboard';
 import History from '@material-ui/icons/History';
 import Delete from '@material-ui/icons/Delete';
+import Settings from '@material-ui/icons/Settings';
 import ImportContacts from '@material-ui/icons/ImportContacts';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import IconButton from '@material-ui/core/IconButton';
+
+class SettingsMenu extends React.Component<*, *> {
+  state = {
+    anchorEl: null
+  };
+
+  handleClick = event => {
+    this.setState({ anchorEl: event.currentTarget });
+  };
+
+  handleClose = () => {
+    this.setState({ anchorEl: null });
+  };
+
+  render() {
+    const { anchorEl } = this.state;
+
+    return (
+      <div>
+        <IconButton
+          aria-owns={anchorEl ? 'simple-menu' : null}
+          aria-haspopup="true"
+          onClick={this.handleClick}
+        >
+          <Settings />
+        </IconButton>
+        <Menu
+          id="simple-menu"
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={this.handleClose}
+        >
+          <MenuItem
+            onClick={() => {
+              window.open('https://froglearning.wordpress.com');
+              this.handleClose();
+            }}
+          >
+            Website
+          </MenuItem>
+        </Menu>
+      </div>
+    );
+  }
+}
 
 export default props => {
   const user = Meteor.user();
@@ -108,7 +157,8 @@ export default props => {
         <div />
       )}
       <div style={topNavBarItemStyleName}>
-        {user.isAnonymous ? 'Anonymous Visitor' : user.username}
+        <span>{user.isAnonymous ? 'Anonymous Visitor' : user.username}</span>
+        <SettingsMenu />
       </div>
     </div>
   );


### PR DESCRIPTION
This PR adds a top-level menu in the wiki top bar. For now, this menu includes a link back to the FROG website as an example, but this will be changed in the future.

**Testing done**

Visual testing

**Issues completed**

This completes the following Asana issue:
https://app.asana.com/0/1125930882647543/1125930882647546