### PR TITLE
Add shift-to-side-panel feature

### DIFF
--- a/frog/imports/client/Wiki/ModalFind.js
+++ b/frog/imports/client/Wiki/ModalFind.js
@@ -51,7 +51,8 @@ export const PagesLinks = ({
         >
           <span
             onClick={e => {
-              onSelect(pageTitle);
+              const sideToSend = e.shiftKey ? 'right' : 'left';
+              onSelect(pageTitle, null, sideToSend);
               e.preventDefault();
             }}
             style={style}

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -446,14 +446,14 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
     );
   };
 
-  goToPageTitle = (pageTitle, instanceName) => {
+  goToPageTitle = (pageTitle, instanceName, side) => {
     const pageTitleLower = pageTitle.toLowerCase();
     const pageId = wikiStore.parsedPages[pageTitleLower].id;
     const instanceId = this.getInstanceIdForName(
       wikiStore.parsedPages[pageTitleLower],
       instanceName
     );
-    this.goToPage(pageId, null, null, instanceId);
+    this.goToPage(pageId, null, side, instanceId);
   };
 
   createLI = (newTitle, plane) => {


### PR DESCRIPTION
This PR introduce the ability to open a wiki page in the side-panel by pressing shift when clicking on a page link in the sidebar. If the side-panel is not active, it will become active when performing this operation.

**Testing done**

Manual testing

**Issue completed**
https://app.asana.com/0/1121331595459324/1125930882647549