### PR TITLE
Made long page titles on the Wiki look more spaced out 

### DIFF
--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -96,6 +96,11 @@ class WikiContentComp extends React.Component<> {
       border: '1px lightgray solid'
     };
 
+    const titleStyle = {
+      lineHeight:'1.2'
+
+    }; 
+
     const docModeButton = (() => {
       if (
         this.state.docMode === 'history' ||
@@ -151,7 +156,7 @@ class WikiContentComp extends React.Component<> {
             this.setState({ showTitleEditButton: false });
           }}
         >
-          <span>{this.state.pageTitleString}</span>
+          <span style = {titleStyle}>{this.state.pageTitleString}</span>
           {this.state.showTitleEditButton && (
             <Edit
               onClick={this.handleEditingTitle}


### PR DESCRIPTION
This PR should address the issue of long titles looking a bit squished on the Wiki. 

**Testing**
Manual testing - enter a long title while creating a new wiki page. It should look nicer and more spaced out as shown in the screenshot below 

**Asana issue closed** 
https://app.asana.com/0/1121313931563676/1126578339300388

<img width="1279" alt="Screen Shot 2019-06-11 at 1 26 00 PM" src="https://user-images.githubusercontent.com/16490844/59268281-aa0ea380-8c4c-11e9-9961-29d4305da8c9.png">
