### PR TITLE
Fix long links in Reactive Rich Text

### DIFF
--- a/frog-utils/src/ReactiveRichText/WikiLink/quill.mention.css
+++ b/frog-utils/src/ReactiveRichText/WikiLink/quill.mention.css
@@ -1,30 +1,28 @@
 .ql-mention-list-container {
   width: 270px;
-  border: 1px solid #F0F0F0;
+  border: 1px solid #f0f0f0;
   border-radius: 4px;
-  background-color: #FFFFFF;
+  background-color: #ffffff;
   box-shadow: 0 2px 12px 0 rgba(30, 30, 30, 0.08);
   z-index: 9001;
 }
 
 .ql-mention-list {
+  max-height: 300px;
   list-style: none;
   margin: 0;
-  padding: 0;
-  overflow: hidden;
+  padding: 5px 0;
+  overflow: scroll;
 }
 
 .ql-mention-list-item {
   cursor: pointer;
-  height: 44px;
-  line-height: 44px;
-  font-size: 16px;
-  padding: 0 20px;
-  vertical-align: middle;
+  font-size: 14px;
+  padding: 5px 20px;
 }
 
 .ql-mention-list-item.selected {
-  background-color: #D3E1EB;
+  background-color: #d3e1eb;
   text-decoration: none;
 }
 
@@ -32,10 +30,10 @@
   height: 24px;
   width: 65px;
   border-radius: 6px;
-  background-color: #D3E1EB;
+  background-color: #d3e1eb;
   padding: 3px 0;
 }
 
-.mention>span {
+.mention > span {
   margin: 0 3px;
 }


### PR DESCRIPTION
This PR fixes the issue with Reactive Rich Text in which mention items with long text overlaped with other items. 

The fix now allows each mention element to take the height it needs to display its text content.

Font was reduced to increase the number of elements that can be displayed and max height of the mention panel was limited to 300px to avoid it going outside the bounds of the screen.

**Testing done**
Manual testing

**Issues completed**
https://app.asana.com/0/1121331595459324/1126732819188826