### PR TITLE
Make long wiki page titles more 'separate' and visible on the sidebar

### DIFF
--- a/frog/imports/client/Wiki/ModalFind.js
+++ b/frog/imports/client/Wiki/ModalFind.js
@@ -45,7 +45,6 @@ export const PagesLinks = ({
             fontSize: '14px',
             marginTop: '12px',
             backgroundColor: i === index ? 'cornflowerblue' : (currentPageBool ? '#e6e6e6': undefined), 
-            borderBottom: '2px solid #bfc7d0'
       }
       return (
         <li

--- a/frog/imports/client/Wiki/ModalFind.js
+++ b/frog/imports/client/Wiki/ModalFind.js
@@ -41,13 +41,17 @@ export const PagesLinks = ({
         : {
             cursor: 'pointer'
           };
+      const pageLinkStyle = {
+            fontSize: '14px',
+            marginTop: '12px',
+            backgroundColor: i === index ? 'cornflowerblue' : (currentPageBool ? '#e6e6e6': undefined), 
+            borderBottom: '2px solid #bfc7d0'
+      }
       return (
         <li
           key={pageId}
-          style={{
-            fontSize: '14px',
-            backgroundColor: i === index ? 'cornflowerblue' : undefined
-          }}
+          style={pageLinkStyle}
+
         >
           <span
             onClick={e => {


### PR DESCRIPTION
This PR adds a separator between each title on the sidebar, added some margin and added an additional highlight when the current page is selected. Hopefully this makes long titles more distinguishable. See screenshot


**Testing done**
Manual testing 

**Asana issue**
https://app.asana.com/0/1121313931563676/1126579168821756/

**Future work**
- I would potentially want to work on this more and make it look nicer by using Material UI ListItem's 

<img width="1280" alt="Screen Shot 2019-06-12 at 5 02 25 PM" src="https://user-images.githubusercontent.com/16490844/59362989-bd953980-8d34-11e9-90f3-e988e74e6b8f.png">

