### PR TITLE
Random username generation for the anonymous user

### DIFF
--- a/frog/imports/client/Wiki/components/TopNavbar/PrimaryButton.js
+++ b/frog/imports/client/Wiki/components/TopNavbar/PrimaryButton.js
@@ -1,4 +1,4 @@
-//@flow
+// @flow
 
 import * as React from 'react';
 
@@ -24,7 +24,7 @@ export default (props: PrimaryButtonPropsT) => {
         alignItems: 'center',
         justifyContent: 'center',
         fontSize: '14px',
-	fontStyle: i ? 'italic' : 'normal',
+        fontStyle: i ? 'italic' : 'normal',
         cursor: callback && 'pointer',
         padding: '20px 0'
       }}

--- a/frog/imports/client/Wiki/components/TopNavbar/PrimaryButton.js
+++ b/frog/imports/client/Wiki/components/TopNavbar/PrimaryButton.js
@@ -6,11 +6,12 @@ type PrimaryButtonPropsT = {
   title: string,
   active?: boolean,
   icon?: React.ComponentType<*>,
-  callback?: () => void
+  callback?: () => void,
+  i?: boolean
 };
 
 export default (props: PrimaryButtonPropsT) => {
-  const { active, title, icon, callback } = props;
+  const { active, title, icon, callback, i } = props;
 
   const Icon = icon;
 
@@ -23,6 +24,7 @@ export default (props: PrimaryButtonPropsT) => {
         alignItems: 'center',
         justifyContent: 'center',
         fontSize: '14px',
+	fontStyle: i ? 'italic' : 'normal',
         cursor: callback && 'pointer',
         padding: '20px 0'
       }}

--- a/frog/imports/client/Wiki/components/TopNavbar/PrimaryButton.js
+++ b/frog/imports/client/Wiki/components/TopNavbar/PrimaryButton.js
@@ -7,11 +7,11 @@ type PrimaryButtonPropsT = {
   active?: boolean,
   icon?: React.ComponentType<*>,
   callback?: () => void,
-  i?: boolean
+  italics?: boolean
 };
 
 export default (props: PrimaryButtonPropsT) => {
-  const { active, title, icon, callback, i } = props;
+  const { active, title, icon, callback, italics } = props;
 
   const Icon = icon;
 
@@ -24,7 +24,7 @@ export default (props: PrimaryButtonPropsT) => {
         alignItems: 'center',
         justifyContent: 'center',
         fontSize: '14px',
-        fontStyle: i ? 'italic' : 'normal',
+        fontStyle: italics ? 'italic' : 'normal',
         cursor: callback && 'pointer',
         padding: '20px 0'
       }}

--- a/frog/imports/client/Wiki/components/TopNavbar/index.js
+++ b/frog/imports/client/Wiki/components/TopNavbar/index.js
@@ -7,7 +7,7 @@ import OverflowPanel from './OverflowPanel';
 
 type TopNavBarPropsT = {
   /** The current Meteor username */
-  user: string,
+  username: string,
   /* Status of the user, username will be displayed in italics if true */
   isAnonymous: boolean,
   /** List of buttons to display in the primary view */
@@ -31,8 +31,7 @@ type TopNavBarPropsT = {
  * Controls can be primary (displayed horizontally), or secondary (displayed in a dropdown).
  */
 export default (props: TopNavBarPropsT) => {
-  const { user, isAnonymous, primaryNavItems, secondaryNavItems } = props;
-
+  const { username, isAnonymous, primaryNavItems, secondaryNavItems } = props;
   return (
     <div
       style={{
@@ -45,7 +44,7 @@ export default (props: TopNavBarPropsT) => {
       {primaryNavItems.map((item, index) => (
         <PrimaryButton key={index} {...item} />
       ))}
-      <PrimaryButton key="username" title={user} i={isAnonymous}/>
+      <PrimaryButton key="username" title={username} i={isAnonymous}/>
       <OverflowPanel overflowElements={secondaryNavItems} />
     </div>
   );

--- a/frog/imports/client/Wiki/components/TopNavbar/index.js
+++ b/frog/imports/client/Wiki/components/TopNavbar/index.js
@@ -6,11 +6,10 @@ import PrimaryButton from './PrimaryButton';
 import OverflowPanel from './OverflowPanel';
 
 type TopNavBarPropsT = {
-  /** The current Meteor username */
   username: string,
-  /* Status of the user, username will be displayed in italics if true */
+  // Status of the user, username will be displayed in italics if true
   isAnonymous: boolean,
-  /** List of buttons to display in the primary view */
+  // List of buttons to display in the primary view
   primaryNavItems: Array<{
     active?: boolean,
     title: string,
@@ -18,7 +17,7 @@ type TopNavBarPropsT = {
     callback?: () => void
   }>,
 
-  /** List of buttons to display in the secondary view (dropdown) */
+  // List of buttons to display in the secondary view (dropdown)
   secondaryNavItems: Array<{
     title: string,
     icon: React.ComponentType<*>,
@@ -44,7 +43,7 @@ export default (props: TopNavBarPropsT) => {
       {primaryNavItems.map((item, index) => (
         <PrimaryButton key={index} {...item} />
       ))}
-      <PrimaryButton key="username" title={username} i={isAnonymous} />
+      <PrimaryButton key="username" title={username} italics={isAnonymous} />
       <OverflowPanel overflowElements={secondaryNavItems} />
     </div>
   );

--- a/frog/imports/client/Wiki/components/TopNavbar/index.js
+++ b/frog/imports/client/Wiki/components/TopNavbar/index.js
@@ -1,4 +1,4 @@
-//@flow
+// @flow
 
 import * as React from 'react';
 
@@ -18,7 +18,7 @@ type TopNavBarPropsT = {
     callback?: () => void
   }>,
 
-  /** List of buttons to display in the secondary view (dropdown)*/
+  /** List of buttons to display in the secondary view (dropdown) */
   secondaryNavItems: Array<{
     title: string,
     icon: React.ComponentType<*>,
@@ -26,7 +26,7 @@ type TopNavBarPropsT = {
   }>
 };
 
-/***
+/** *
  * The navbar is responsible for displaying wiki page controls.
  * Controls can be primary (displayed horizontally), or secondary (displayed in a dropdown).
  */
@@ -44,7 +44,7 @@ export default (props: TopNavBarPropsT) => {
       {primaryNavItems.map((item, index) => (
         <PrimaryButton key={index} {...item} />
       ))}
-      <PrimaryButton key="username" title={username} i={isAnonymous}/>
+      <PrimaryButton key="username" title={username} i={isAnonymous} />
       <OverflowPanel overflowElements={secondaryNavItems} />
     </div>
   );

--- a/frog/imports/client/Wiki/components/TopNavbar/index.js
+++ b/frog/imports/client/Wiki/components/TopNavbar/index.js
@@ -45,7 +45,7 @@ export default (props: TopNavBarPropsT) => {
       {primaryNavItems.map((item, index) => (
         <PrimaryButton key={index} {...item} />
       ))}
-      <PrimaryButton key="username" title={user} />
+      <PrimaryButton key="username" title={user} i={isAnonymous}/>
       <OverflowPanel overflowElements={secondaryNavItems} />
     </div>
   );

--- a/frog/imports/client/Wiki/components/TopNavbar/index.js
+++ b/frog/imports/client/Wiki/components/TopNavbar/index.js
@@ -8,7 +8,8 @@ import OverflowPanel from './OverflowPanel';
 type TopNavBarPropsT = {
   /** The current Meteor username */
   user: string,
-
+  /* Status of the user, username will be displayed in italics if true */
+  isAnonymous: boolean,
   /** List of buttons to display in the primary view */
   primaryNavItems: Array<{
     active?: boolean,
@@ -30,7 +31,7 @@ type TopNavBarPropsT = {
  * Controls can be primary (displayed horizontally), or secondary (displayed in a dropdown).
  */
 export default (props: TopNavBarPropsT) => {
-  const { user, primaryNavItems, secondaryNavItems } = props;
+  const { user, isAnonymous, primaryNavItems, secondaryNavItems } = props;
 
   return (
     <div

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -67,8 +67,7 @@ type WikiCompStateT = {
   restoreModalOpen: boolean,
   search: '',
   urlInstance: ?string,
-  noInstance: ?boolean,
-  user: Object
+  noInstance: ?boolean
 };
 
 class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
@@ -111,8 +110,7 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
       deletedPageModalOpen: false,
       currentDeletedPageId: null,
       currentDeletedPageTitle: null,
-      rightSideCurrentPageObj: null,
-      user: Meteor.user()
+      rightSideCurrentPageObj: null
     };
   }
 
@@ -225,7 +223,7 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
     if (!currentPageObj) {
       if (!fullPageObj.noNewInstances) {
         this.initialLoad = true;
-        const instanceName = this.state.user.username;
+        const instanceName = Meteor.user().username;
         this.createNewInstancePage(fullPageObj, instanceId, instanceName);
       }
       return;
@@ -658,8 +656,8 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
           {sideNavBar}
           <div style={contentDivStyle}>
             <WikiTopNavbar
-              username={this.state.user.username}
-              isAnonymous={this.state.user.isAnonymous}
+              username={Meteor.user().username}
+              isAnonymous={Meteor.user().isAnonymous}
               primaryNavItems={primaryNavItems}
               secondaryNavItems={secondaryNavItems}
             />

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -67,7 +67,8 @@ type WikiCompStateT = {
   restoreModalOpen: boolean,
   search: '',
   urlInstance: ?string,
-  noInstance: ?boolean
+  noInstance: ?boolean,
+  user: Object
 };
 
 class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
@@ -110,7 +111,8 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
       deletedPageModalOpen: false,
       currentDeletedPageId: null,
       currentDeletedPageTitle: null,
-      rightSideCurrentPageObj: null
+      rightSideCurrentPageObj: null,
+      user: Meteor.user()
     };
   }
 
@@ -223,7 +225,7 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
     if (!currentPageObj) {
       if (!fullPageObj.noNewInstances) {
         this.initialLoad = true;
-        const instanceName = Meteor.user().username;
+        const instanceName = this.state.user.username;
         this.createNewInstancePage(fullPageObj, instanceId, instanceName);
       }
       return;
@@ -509,7 +511,6 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
 
   render() {
     if (!this.state.currentPageObj) return null;
-
     const validPages = wikiStore.pagesArrayOnlyValid;
     const invalidPages = wikiStore.pagesArrayOnlyInvalid;
 
@@ -651,15 +652,14 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
         )}
       </div>
     );
-
     return (
       <div>
         <div style={containerDivStyle}>
           {sideNavBar}
           <div style={contentDivStyle}>
             <WikiTopNavbar
-              username={Meteor.user().username}
-              isAnonymous={Meteor.user().isAnonymous}
+              username={this.state.user.username}
+              isAnonymous={this.state.user.isAnonymous}
               primaryNavItems={primaryNavItems}
               secondaryNavItems={secondaryNavItems}
             />

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -658,11 +658,8 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
           {sideNavBar}
           <div style={contentDivStyle}>
             <WikiTopNavbar
-              user={
-                Meteor.user().isAnonymous
-                  ? 'Anonymous Visitor'
-                  : Meteor.user().username
-              }
+              username={Meteor.user().username}
+              isAnonymous={Meteor.user().isAnonymous}
               primaryNavItems={primaryNavItems}
               secondaryNavItems={secondaryNavItems}
             />

--- a/frog/package.json
+++ b/frog/package.json
@@ -82,6 +82,7 @@
     "sharedb-redis-pubsub": "^1.0.0-beta.1",
     "styled-components": "^4.1.3",
     "twit": "^2.2.10",
+    "unique-names-generator": "^3.0.0",
     "unzipper": "^0.9.10",
     "utf-8-validate": "^5.0.2",
     "ws": "^6.1.3",

--- a/frog/server/user_accounts.js
+++ b/frog/server/user_accounts.js
@@ -3,6 +3,10 @@
 import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
 import { uuid } from 'frog-utils';
+import {
+  uniqueNamesGenerator,
+  UniqueNamesGeneratorConfig
+} from 'unique-names-generator';
 
 import { Sessions } from '../imports/api/sessions';
 
@@ -13,7 +17,7 @@ const doLogin = (user, self) => {
       return Accounts._loginUser(self, alreadyUser._id);
     }
   }
-  const userServiceData = { id: user || uuid() };
+  const userServiceData = { id: user || uniqueNamesGenerator(usernameConfig) };
   const { userId } = Accounts.updateOrCreateUserFromExternalService(
     'frog',
     userServiceData
@@ -108,3 +112,8 @@ Meteor.methods({
     }
   }
 });
+
+const usernameConfig: UniqueNamesGeneratorConfig = {
+  separator: ' ',
+  length: 2
+};

--- a/frog/server/user_accounts.js
+++ b/frog/server/user_accounts.js
@@ -18,7 +18,9 @@ const doLogin = (user, self) => {
       return Accounts._loginUser(self, alreadyUser._id);
     }
   }
-  const userServiceData = { id: user || startCase(uniqueNamesGenerator(usernameConfig)) };
+  const userServiceData = {
+    id: user || startCase(uniqueNamesGenerator(usernameConfig))
+  };
   const { userId } = Accounts.updateOrCreateUserFromExternalService(
     'frog',
     userServiceData

--- a/frog/server/user_accounts.js
+++ b/frog/server/user_accounts.js
@@ -3,6 +3,7 @@
 import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
 import { uuid } from 'frog-utils';
+import { startCase } from 'lodash';
 import {
   uniqueNamesGenerator,
   UniqueNamesGeneratorConfig
@@ -17,7 +18,7 @@ const doLogin = (user, self) => {
       return Accounts._loginUser(self, alreadyUser._id);
     }
   }
-  const userServiceData = { id: user || uniqueNamesGenerator(usernameConfig) };
+  const userServiceData = { id: user || startCase(uniqueNamesGenerator(usernameConfig)) };
   const { userId } = Accounts.updateOrCreateUserFromExternalService(
     'frog',
     userServiceData

--- a/yarn.lock
+++ b/yarn.lock
@@ -16855,6 +16855,11 @@ unique-filename@^1.1.1:
   dependencies:
     unique-slug "^2.0.0"
 
+unique-names-generator@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unique-names-generator/-/unique-names-generator-3.0.0.tgz#2282d88cdef175093ac04c8edf3f89ab19469756"
+  integrity sha512-5BQhANYUKPqFnFYL1OduL7FDPiV7u5K1Lm4Z89YL4uOLH/uCNTnHkW3roFUEiEptOKt8f3uhmWnZj9w0zBXppw==
+
 unique-slug@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.1.tgz#5e9edc6d1ce8fb264db18a507ef9bd8544451ca6"


### PR DESCRIPTION
This replaces the 'Anonymous Visitor' greeting in the Wiki's Top Navbar to the user's randomly computer generated human friendly english username composed of 2 words.

**How to test?**
`git pull`
`git checkout random-username`
Since it introduces a new package, please do
`npm start yarn`
`npm start server`
View the wiki as an Anonymous user (i.e. without login)