### PR TITLE
Make highlight extend to 100% of width of parent container in sidebar of Wiki

### DIFF
--- a/frog/imports/client/Wiki/ModalFind.js
+++ b/frog/imports/client/Wiki/ModalFind.js
@@ -45,6 +45,7 @@ export const PagesLinks = ({
             fontSize: '14px',
             marginTop: '12px',
             backgroundColor: i === index ? 'cornflowerblue' : (currentPageBool ? '#e6e6e6': undefined), 
+            width: '100%'
       }
       return (
         <li

--- a/frog/imports/client/Wiki/ModalFind.js
+++ b/frog/imports/client/Wiki/ModalFind.js
@@ -33,36 +33,30 @@ export const PagesLinks = ({
 
       const currentPageBool = pageId === currentPage;
 
-      const style = currentPageBool
-        ? {
-            color: 'blue',
-            cursor: 'pointer'
-          }
-        : {
-            cursor: 'pointer'
-          };
       const pageLinkStyle = {
-            fontSize: '14px',
-            marginTop: '12px',
-            backgroundColor: i === index ? 'cornflowerblue' : (currentPageBool ? '#e6e6e6': undefined), 
-            width: '100%'
-      }
+        fontSize: '14px',
+        marginTop: '12px',
+        backgroundColor:
+          i === index
+            ? 'cornflowerblue'
+            : currentPageBool
+            ? '#e6e6e6'
+            : undefined,
+        color: currentPageBool ? 'blue' : 'auto',
+        cursor: currentPageBool ? 'auto' : 'pointer'
+      };
       return (
-        <li
-          key={pageId}
-          style={pageLinkStyle}
-
-        >
-          <span
+        <li key={pageId}>
+          <div
+            style={pageLinkStyle}
             onClick={e => {
               const sideToSend = e.shiftKey ? 'right' : 'left';
               onSelect(pageTitle, null, sideToSend);
               e.preventDefault();
             }}
-            style={style}
           >
             <Highlight searchStr={search} text={pageTitle} />
-          </span>
+          </div>
           {currentPageBool &&
             (search.trim().length === 0 &&
               pages.filter(x => x.title.startsWith(pageTitle + '/')).length >

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -532,7 +532,7 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
       backgroundColor: 'white',
       overflowX: 'hidden',
       overflowY: 'auto',
-      padding: '10px 0 10px 10px',
+      padding: '10px',
       borderRight: '1px lightgrey solid'
     };
 

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -532,7 +532,7 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
       backgroundColor: 'white',
       overflowX: 'hidden',
       overflowY: 'auto',
-      padding: '10px',
+      padding: '10px 0 10px 10px',
       borderRight: '1px lightgrey solid'
     };
 


### PR DESCRIPTION
Reference [https://github.com/chili-epfl/FROG/pull/1718](url).
This PR makes the changes discussed in the link above. 