### PR TITLE
Refactor/wiki modal

### DIFF
--- a/frog/imports/client/Wiki/ModalDeletedPage.js
+++ b/frog/imports/client/Wiki/ModalDeletedPage.js
@@ -1,47 +1,53 @@
 // @flow
 
 import React from 'react';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import Button from '@material-ui/core/Button';
+import { Modal } from './components/Modal';
 
+type ModalDeletedPagePropsT = {
+  pageTitle: string,
+  hideModal: () => void,
+  onRestorePage: () => void,
+  onCreateNewPage: () => void
+};
+
+/**
+ * This modal allows the user to restore a page, by restoring it directly,
+ * or creating a new one.
+ */
 export default ({
-  closeModal,
-  restoreDeletedPage,
-  createNewLIForPage,
+  hideModal,
+  onRestorePage,
+  onCreateNewPage,
   pageId,
   pageTitle
-}: Object) => {
+}: ModalDeletedPagePropsT) => {
   return (
-    <Dialog open onClose={() => closeModal()}>
-      <DialogTitle>{pageTitle}</DialogTitle>
-      <DialogContent>
-        <div
-          style={{
-            width: '600',
-            height: '600'
-          }}
-        >
-          Do you want to restore the old deleted page or create a new one?
-        </div>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={closeModal}>Cancel</Button>
-        <Button
-          style={{ color: 'blue' }}
-          onClick={() => restoreDeletedPage(pageId, pageTitle)}
-        >
-          Restore Page
-        </Button>
-        <Button
-          style={{ color: 'green' }}
-          onClick={() => createNewLIForPage(pageId, pageTitle)}
-        >
-          Create New Page
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <Modal
+      title={pageTitle}
+      actions={[
+        {
+          title: 'Cancel',
+          callback: hideModal
+        },
+        {
+          title: 'Restore page',
+          primary: true,
+          callback: () => {
+            onRestorePage();
+            hideModal();
+          }
+        },
+        {
+          title: 'Create new page',
+          primary: true,
+          callback: () => {
+            onCreateNewPage();
+            hideModal();
+          }
+        }
+      ]}
+    >
+      Do you want to restore the old deleted page or create a new one?
+    </Modal>
   );
 };

--- a/frog/imports/client/Wiki/ModalRestore.js
+++ b/frog/imports/client/Wiki/ModalRestore.js
@@ -1,53 +1,44 @@
 // @flow
 
 import * as React from 'react';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import Button from '@material-ui/core/Button';
+import { Modal } from './components/Modal';
 
-export default ({ setModalOpen, pages, onSelect }: Object) => {
+type ModalRestorePropsT = {
+  pages: Object,
+  onSelect: (pageId: string) => void,
+  hideModal: () => void
+};
+
+const ModalRestore = ({ hideModal, pages, onSelect }: ModalRestorePropsT) => {
   return (
-    <Dialog open onClose={() => setModalOpen(false)}>
-      <DialogTitle>Restore page</DialogTitle>
-      <DialogContent>
-        <div
-          style={{
-            width: '600px',
-            height: '600px',
-            overflow: 'auto',
-            paddingRight: '100px'
-          }}
-        >
-          <ul>
-            {pages.map(pageObj => {
-              const pageId = pageObj.id;
-              const pageTitle = pageObj.title;
+    <Modal
+      title="Select a page to restore"
+      actions={[{ title: 'Cancel', callback: hideModal }]}
+    >
+      <ul>
+        {pages.map(pageObj => {
+          const pageId = pageObj.id;
+          const pageTitle = pageObj.title;
 
-              return (
-                <li
-                  key={pageId}
-                  style={{
-                    fontSize: '14px',
-                    cursor: 'pointer'
-                  }}
-                  onClick={e => {
-                    onSelect(pageId, pageTitle);
-                    setModalOpen(false);
-                    e.preventDefault();
-                  }}
-                >
-                  {pageTitle}
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={() => setModalOpen(false)}>Cancel</Button>
-      </DialogActions>
-    </Dialog>
+          return (
+            <li
+              key={pageId}
+              style={{
+                fontSize: '14px',
+                cursor: 'pointer'
+              }}
+              onClick={() => {
+                onSelect(pageId);
+                hideModal();
+              }}
+            >
+              {pageTitle}
+            </li>
+          );
+        })}
+      </ul>
+    </Modal>
   );
 };
+
+export default ModalRestore;

--- a/frog/imports/client/Wiki/components/Modal/Modal.js
+++ b/frog/imports/client/Wiki/components/Modal/Modal.js
@@ -1,0 +1,28 @@
+// @flow
+
+import * as React from 'react';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import Button from '@material-ui/core/Button';
+
+type ActionsT = Array<{
+  title: string,
+  primary: boolean,
+  callback: () => void
+}>;
+
+type ModalPropsT = {
+  title: string,
+  children: React.Node
+};
+
+const Modal = ({ id, title, children, actions }: ModalPropsT) => (
+  <Dialog open>
+    <DialogTitle>{title}</DialogTitle>
+    <DialogContent>{children}</DialogContent>
+  </Dialog>
+);
+
+export default Modal;

--- a/frog/imports/client/Wiki/components/Modal/Modal.js
+++ b/frog/imports/client/Wiki/components/Modal/Modal.js
@@ -1,28 +1,35 @@
 // @flow
 
-import * as React from 'react';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import Button from '@material-ui/core/Button';
+import * as React from "react";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import Button from "@material-ui/core/Button";
 
 type ActionsT = Array<{
   title: string,
-  primary: boolean,
+  primary?: boolean,
   callback: () => void
 }>;
 
 type ModalPropsT = {
   title: string,
-  children: React.Node
+  children: React.Node,
+  actions: ActionsT
 };
 
-const Modal = ({ id, title, children, actions }: ModalPropsT) => (
+/** Provides a standard modal view */
+export const Modal = ({ title, children, actions }: ModalPropsT) => (
   <Dialog open>
     <DialogTitle>{title}</DialogTitle>
     <DialogContent>{children}</DialogContent>
+    <DialogActions>
+      {actions.map(action => (
+        <Button color={action.primary && "primary"} onClick={action.callback}>
+          {action.title}
+        </Button>
+      ))}
+    </DialogActions>
   </Dialog>
 );
-
-export default Modal;

--- a/frog/imports/client/Wiki/components/Modal/index.js
+++ b/frog/imports/client/Wiki/components/Modal/index.js
@@ -1,0 +1,44 @@
+//@flow
+
+import * as React from 'react';
+
+import Modal from './Modal';
+
+type ModalContentPropsT = {
+  hideModal: () => void
+};
+
+type WithModalPropsT = {
+  showModal:
+    | ((Content: React.AbstractComponent<ModalContentPropsT>) => void)
+    | void,
+  hideModal: (() => void) | void
+};
+
+type WrapperComponentPropsT<Config: {}> = $Diff<Config, WithModalPropsT>;
+
+const withModals = <Config: {}>(
+  Component: React.AbstractComponent<Config>
+): React.AbstractComponent<WrapperComponentPropsT<Config>> => {
+  const ModalController = (props: WrapperComponentPropsT<Config>) => {
+    const [ModalContent, updateContent] = React.useState();
+
+    const showModal = (Content: React.AbstractComponent<ModalContentPropsT>) =>
+      updateContent(ModalContent);
+    const hideModal = () => updateContent(undefined);
+
+    return (
+      <>
+        {ModalContent !== undefined ? (
+          <Modal title="Test">
+            <ModalContent hideModal={hideModal} />
+          </Modal>
+        ) : null}
+        <Component {...props} showModal={showModal} hideModal={hideModal} />
+      </>
+    );
+  };
+  return ModalController;
+};
+
+export default withModals;

--- a/frog/imports/client/Wiki/components/Modal/index.js
+++ b/frog/imports/client/Wiki/components/Modal/index.js
@@ -1,44 +1,5 @@
 //@flow
 
-import * as React from 'react';
-
-import Modal from './Modal';
-
-type ModalContentPropsT = {
-  hideModal: () => void
-};
-
-type WithModalPropsT = {
-  showModal:
-    | ((Content: React.AbstractComponent<ModalContentPropsT>) => void)
-    | void,
-  hideModal: (() => void) | void
-};
-
-type WrapperComponentPropsT<Config: {}> = $Diff<Config, WithModalPropsT>;
-
-const withModals = <Config: {}>(
-  Component: React.AbstractComponent<Config>
-): React.AbstractComponent<WrapperComponentPropsT<Config>> => {
-  const ModalController = (props: WrapperComponentPropsT<Config>) => {
-    const [ModalContent, updateContent] = React.useState();
-
-    const showModal = (Content: React.AbstractComponent<ModalContentPropsT>) =>
-      updateContent(ModalContent);
-    const hideModal = () => updateContent(undefined);
-
-    return (
-      <>
-        {ModalContent !== undefined ? (
-          <Modal title="Test">
-            <ModalContent hideModal={hideModal} />
-          </Modal>
-        ) : null}
-        <Component {...props} showModal={showModal} hideModal={hideModal} />
-      </>
-    );
-  };
-  return ModalController;
-};
-
-export default withModals;
+export { withModalController } from './withModalController';
+export { Modal } from './Modal';
+export { ModalParentPropsT } from './types';

--- a/frog/imports/client/Wiki/components/Modal/types.js
+++ b/frog/imports/client/Wiki/components/Modal/types.js
@@ -7,6 +7,8 @@ export type ShowModalFunctionT = (View: React.Node) => void;
 export type HideModalFunctionT = () => void;
 
 export type ModalParentPropsT = {
+  /** Displays the provided React component as a modal */
   showModal: ShowModalFunctionT,
+  /** Hides the current modal */
   hideModal: HideModalFunctionT
 };

--- a/frog/imports/client/Wiki/components/Modal/types.js
+++ b/frog/imports/client/Wiki/components/Modal/types.js
@@ -1,0 +1,12 @@
+//@flow
+
+import * as React from 'react';
+
+export type ShowModalFunctionT = (View: React.Node) => void;
+
+export type HideModalFunctionT = () => void;
+
+export type ModalParentPropsT = {
+  showModal: ShowModalFunctionT,
+  hideModal: HideModalFunctionT
+};

--- a/frog/imports/client/Wiki/components/Modal/withModalController.js
+++ b/frog/imports/client/Wiki/components/Modal/withModalController.js
@@ -1,0 +1,52 @@
+//@flow
+
+import * as React from 'react';
+
+import {
+  type ShowModalFunctionT,
+  type HideModalFunctionT,
+  type ModalParentPropsT
+} from './types';
+
+/**
+ * HOC that adds ability to create modals via provided prop function
+ */
+export const withModalController = <T: {}>(
+  Component: React.AbstractComponent<T>
+): React.AbstractComponent<
+  $Diff<
+    T,
+    {
+      showModal: ShowModalFunctionT | void,
+      hideModal: HideModalFunctionT | void
+    }
+  >
+> => {
+  return (
+    props: $Diff<
+      T,
+      {
+        showModal: ShowModalFunctionT | void,
+        hideModal: HideModalFunctionT | void
+      }
+    >
+  ) => {
+    // Initialize the state with an undefined View, this will ensure
+    // no modal gets rendered
+    const [View, updateData] = React.useState();
+
+    // Updates the state with the provided ModalView and props
+    const showModal = (View: React.Node) => updateData(View);
+
+    const hideModal = () => updateData();
+
+    // Displays the provided Component and adds two methods to control modals to its
+    // props. Displays a modal if one is active.
+    return (
+      <>
+        {View !== undefined ? View : null}
+        <Component {...props} showModal={showModal} hideModal={hideModal} />
+      </>
+    );
+  };
+};

--- a/frog/imports/client/Wiki/components/Modal/withModalController.js
+++ b/frog/imports/client/Wiki/components/Modal/withModalController.js
@@ -35,7 +35,7 @@ export const withModalController = <T: {}>(
     // no modal gets rendered
     const [View, updateData] = React.useState();
 
-    // Updates the state with the provided ModalView and props
+    // Updates the state with the provided View
     const showModal = (View: React.Node) => updateData(View);
 
     const hideModal = () => updateData();

--- a/frog/imports/client/Wiki/components/TopNavbar/index.js
+++ b/frog/imports/client/Wiki/components/TopNavbar/index.js
@@ -25,11 +25,11 @@ type TopNavBarPropsT = {
   }>
 };
 
-/***
+/**
  * The navbar is responsible for displaying wiki page controls.
  * Controls can be primary (displayed horizontally), or secondary (displayed in a dropdown).
  */
-export default (props: TopNavBarPropsT) => {
+const TopNavbar = (props: TopNavBarPropsT) => {
   const { user, primaryNavItems, secondaryNavItems } = props;
 
   return (
@@ -49,3 +49,5 @@ export default (props: TopNavBarPropsT) => {
     </div>
   );
 };
+
+export default TopNavbar;

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Component } from 'react';
+import * as React from 'react';
 import { withRouter } from 'react-router';
 import { findKey } from 'lodash';
 import Mousetrap from 'mousetrap';
@@ -40,6 +40,8 @@ import RestoreModal from './ModalRestore';
 import WikiTopNavbar from './components/TopNavbar';
 import WikiContentComp from './WikiContentComp';
 
+import withModal from './components/Modal';
+
 const genericDoc = connection.get('li');
 export const dataFn = generateReactiveFn(genericDoc, LI, {
   createdByUser: Meteor.userId()
@@ -54,7 +56,9 @@ type WikiCompPropsT = {
       pageTitle: ?string
     }
   },
-  history: Object
+  history: Object,
+  showModal: (Content: React.AbstractComponent<*>) => void,
+  hideModal: () => void
 };
 
 type WikiCompStateT = {
@@ -70,7 +74,7 @@ type WikiCompStateT = {
   noInstance: ?boolean
 };
 
-class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
+class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
   wikiId: string = this.props.match.params.wikiId;
 
   wikiDoc: Object = {};
@@ -588,7 +592,7 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
       {
         title: 'Restore deleted page',
         icon: RestorePage,
-        callback: () => this.setState({ restoreModalOpen: true })
+        callback: () => this.props.showModal(() => <div>Hello World</div>)
       }
     ];
 
@@ -744,7 +748,7 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
   }
 }
 
-const Wiki = withRouter(WikiComp);
+const Wiki = withRouter(withModal(WikiComp));
 Wiki.displayName = 'Wiki';
 
 export default Wiki;

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -69,7 +69,6 @@ type WikiCompStateT = {
   openCreator: ?Object,
   createModalOpen: boolean,
   findModalOpen: boolean,
-  restoreModalOpen: boolean,
   search: '',
   urlInstance: ?string,
   noInstance: ?boolean
@@ -110,7 +109,6 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
       error: null,
       openCreator: false,
       createModalOpen: false,
-      restoreModalOpen: false,
       search: '',
       rightSideCurrentPageObj: null
     };
@@ -356,17 +354,6 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     this.goToPage(pageId);
   };
 
-  openDeletedPageModal = (pageId, pageTitle) => {
-    this.props.showModal(
-      <DeletedPageModal
-        hideModal={this.props.hideModal}
-        onCreateNewPage={() => this.createNewLIForPage(pageId)}
-        onRestorePage={() => this.restoreDeletedPage(pageId)}
-        pageTitle={pageTitle}
-      />
-    );
-  };
-
   changeMode = mode => {
     this.setState({
       mode,
@@ -430,8 +417,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
         mode,
         search: '',
         findModalOpen: false,
-        createModalOpen: false,
-        restoreModalOpen: false
+        createModalOpen: false
       },
       () => {
         if (!newCurrentPageObj || side === 'right') return;
@@ -503,6 +489,27 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     // setTimeout(() => {
     //   this.goToPage(pageId);
     // }, 100);
+  };
+
+  openDeletedPageModal = (pageId, pageTitle) => {
+    this.props.showModal(
+      <DeletedPageModal
+        hideModal={this.props.hideModal}
+        onCreateNewPage={() => this.createNewLIForPage(pageId)}
+        onRestorePage={() => this.restoreDeletedPage(pageId)}
+        pageTitle={pageTitle}
+      />
+    );
+  };
+
+  openRestorePageModal = pages => {
+    this.props.showModal(
+      <RestoreModal
+        pages={pages}
+        hideModal={this.props.hideModal}
+        onSelect={pageId => this.restoreDeletedPage(pageId)}
+      />
+    );
   };
 
   render() {
@@ -586,7 +593,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
       {
         title: 'Restore deleted page',
         icon: RestorePage,
-        callback: () => this.props.showModal(() => <div>Hello World</div>)
+        callback: () => this.openRestorePageModal(invalidPages)
       }
     ];
 
@@ -694,15 +701,6 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
             </div>
           </div>
         </div>
-        {this.state.restoreModalOpen && (
-          <RestoreModal
-            pages={invalidPages}
-            setModalOpen={e => this.setState({ restoreModalOpen: e })}
-            onSelect={(pageId, pageTitle) =>
-              this.openDeletedPageModal(pageId, pageTitle)
-            }
-          />
-        )}
         {this.state.findModalOpen && (
           <FindModal
             history={this.props.history}


### PR DESCRIPTION
This PR adds logic to handle modal state, allowing us to move it away from index.js. It exposes two methods, `showModal` and `hideModal` allowing us to display a particular React component as a modal, and then hide it when appropriate. Further work to move the Wiki modals to this new logic is needed.

**Testing done**
Manual testing