### PR TITLE
Fix scrollbar always displaying

### DIFF
--- a/frog-utils/src/ReactiveRichText/WikiLink/quill.mention.css
+++ b/frog-utils/src/ReactiveRichText/WikiLink/quill.mention.css
@@ -12,7 +12,7 @@
   list-style: none;
   margin: 0;
   padding: 5px 0;
-  overflow: scroll;
+  overflow-y: auto;
 }
 
 .ql-mention-list-item {


### PR DESCRIPTION
#1717 introduced a small UI bug in the mention container. The scrollbars would always be visible even if the container was not scrollable.

**Testing done**
Manual testing