### PR TITLE
Fixed bugs when handling errors of names of titles in the wiki  

### DIFF
--- a/frog/imports/client/Wiki/ModalCreate.js
+++ b/frog/imports/client/Wiki/ModalCreate.js
@@ -92,7 +92,7 @@ class NewPageModal extends React.Component<PropsT, StateT> {
   }
 
   handleTitleChange = (e: any) => {
-    if (e.target.value === "") this.props.clearError(); 
+    this.handleErrorClearing(e.target.value); 
     this.setState({ pageTitle: e.target.value });
     
   };
@@ -129,6 +129,11 @@ class NewPageModal extends React.Component<PropsT, StateT> {
     const { pageTitle, socialPlane, config, operatorConfig } = this.state;
     this.props.onCreate(pageTitle, socialPlane, config, operatorConfig);
   };
+  // Clears error messages if the user tries to create a page with an empty title and then types in a new title
+  handleErrorClearing(currentTitle:string) {
+    if (currentTitle === "" || (currentTitle.length > 0 && this.props.errorDiv === "Title cannot be empty"))
+      this.props.clearError();
+  }
 
   render() {
     const { currentTab, socialPlane, expanded, pageTitle } = this.state;
@@ -148,7 +153,9 @@ class NewPageModal extends React.Component<PropsT, StateT> {
     return (
       <Dialog
         open={this.state.open}
-        onClose={() => this.props.setModalOpen(false)}
+        onClose={() => {
+          this.props.setModalOpen(false)
+          this.props.clearError()}}
         scroll="paper"
       >
         <FormGroup>

--- a/frog/imports/client/Wiki/ModalCreate.js
+++ b/frog/imports/client/Wiki/ModalCreate.js
@@ -26,7 +26,7 @@ import IconButton from '@material-ui/core/IconButton';
 import ApiForm from '../GraphEditor/SidePanel/ApiForm';
 import OperatorForm from '../GraphEditor/SidePanel/OperatorForm';
 import { activityTypesObj } from '/imports/activityTypes';
-import { wikiStore } from './store';
+
 
 type StateT = {
   currentTab: number,

--- a/frog/imports/client/Wiki/ModalCreate.js
+++ b/frog/imports/client/Wiki/ModalCreate.js
@@ -26,6 +26,7 @@ import IconButton from '@material-ui/core/IconButton';
 import ApiForm from '../GraphEditor/SidePanel/ApiForm';
 import OperatorForm from '../GraphEditor/SidePanel/OperatorForm';
 import { activityTypesObj } from '/imports/activityTypes';
+import { wikiStore } from './store';
 
 type StateT = {
   currentTab: number,
@@ -44,6 +45,7 @@ type PropsT = {
   classes: Object,
   onCreate: Function,
   setModalOpen: Function,
+  clearError: Function, 
   errorDiv: any,
   wikiId: string
 };
@@ -90,7 +92,9 @@ class NewPageModal extends React.Component<PropsT, StateT> {
   }
 
   handleTitleChange = (e: any) => {
+    if (e.target.value === "") this.props.clearError(); 
     this.setState({ pageTitle: e.target.value });
+    
   };
 
   handleTabs = (e: any, value: number) => {
@@ -152,7 +156,7 @@ class NewPageModal extends React.Component<PropsT, StateT> {
             <Typography variant="h6">Create New Page</Typography>
             <TextField
               autoFocus
-              error={errorDiv != null}
+              error={errorDiv !== null}
               id="page-title"
               value={pageTitle}
               onChange={this.handleTitleChange}
@@ -168,7 +172,7 @@ class NewPageModal extends React.Component<PropsT, StateT> {
                 }
               }}
             />
-            {errorDiv != null && (
+            {errorDiv !== null && (
               <FormHelperText error>{errorDiv}</FormHelperText>
             )}
           </FormControl>
@@ -272,7 +276,10 @@ class NewPageModal extends React.Component<PropsT, StateT> {
             {expanded ? <ExpandLess /> : <ExpandMore />}
           </IconButton>
           <Button
-            onClick={() => this.props.setModalOpen(false)}
+            onClick={() => { 
+              this.props.setModalOpen(false);
+              this.props.clearError(); 
+              }}
             color="primary"
           >
             Cancel

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -473,16 +473,10 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
       (config.invalid && 'Activity config is not valid') ||
       (operatorConfig.invalid && 'Operator config is not valid');
     
-    
-
-    if (error) {
+     if (error) {
       this.setState({ error }); 
       return;
     }
-  
-
-    
-
     this.preventRenderUntilNextShareDBUpdate = true;
     // TODO: Rewrite this function to propely handle creating different types of activities/LIs
 
@@ -507,10 +501,7 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
         liId
       );
     }
-
-
-    this.goToPage(pageId);
-    this.setState({error:null}); 
+     this.goToPage(pageId);
     // setTimeout(() => {
     //   this.goToPage(pageId);
     // }, 100);

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -62,7 +62,7 @@ type WikiCompStateT = {
   mode: string,
   error: ?string,
   openCreator: ?Object,
-  createModalOpen: boolean,
+  createModalOpen:boolean,
   findModalOpen: boolean,
   restoreModalOpen: boolean,
   search: '',
@@ -467,14 +467,21 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
   };
 
   createLI = (newTitle, plane, config, operatorConfig) => {
+    
     const error =
       checkNewPageTitle(wikiStore.parsedPages, newTitle) ||
       (config.invalid && 'Activity config is not valid') ||
       (operatorConfig.invalid && 'Operator config is not valid');
+    
+    
+
     if (error) {
-      this.setState({ error });
+      this.setState({ error }); 
       return;
     }
+  
+
+    
 
     this.preventRenderUntilNextShareDBUpdate = true;
     // TODO: Rewrite this function to propely handle creating different types of activities/LIs
@@ -501,7 +508,9 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
       );
     }
 
+
     this.goToPage(pageId);
+    this.setState({error:null}); 
     // setTimeout(() => {
     //   this.goToPage(pageId);
     // }, 100);
@@ -726,6 +735,7 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
           <CreateModal
             onCreate={this.createLI}
             setModalOpen={e => this.setState({ createModalOpen: e })}
+            clearError = {() => this.setState({error: null})}
             errorDiv={this.state.error}
             wikiId={this.wikiId}
           />


### PR DESCRIPTION
This PR fixes the following existing bugs related to error handling of wiki titles described below:

 **Bug 1**
1.  Create a new wiki page 
2.  Name it something say "Hello"
3.  Create another wiki page and name it the same as step 2 
4.  Click create and you should get the error: "Title already used"
5.  Click off by either clicking cancel or clicking outside the dialog. 
6.  Create a new page again and the error: "Title already used" pops up even though you have not entered anything 

**Bug 2**

1. Create a new wiki page. 
2.  Don't give it a title and the error "Title cannot be empty" pops up. 
3. Click off or click cancel but the error on creating a new page with a non empty title still persists. 

In short this PR fixes the bugs of the error messages not being cleared properly. 

**Testing done**
Manual testing






