### PR TITLE
Cannot rename page to an invalid page in wiki 

### DIFF
--- a/frog/imports/client/Wiki/ModalCreate.js
+++ b/frog/imports/client/Wiki/ModalCreate.js
@@ -132,7 +132,7 @@ class NewPageModal extends React.Component<PropsT, StateT> {
     } = this.state;
     this.props.onCreate(pageTitle, socialPlane, activityConfig, operatorConfig);
   };
-  // Clears error messages if the user tries to create a page with an empty title and then types in a new title
+  
   handleErrorClearing(currentTitle:string) {
     if (currentTitle === "" || (currentTitle.length > 0 && this.props.errorDiv === "Title cannot be empty"))
       this.props.clearError();

--- a/frog/imports/client/Wiki/ModalCreate.js
+++ b/frog/imports/client/Wiki/ModalCreate.js
@@ -27,7 +27,6 @@ import ApiForm from '../GraphEditor/SidePanel/ApiForm';
 import OperatorForm from '../GraphEditor/SidePanel/OperatorForm';
 import { activityTypesObj } from '/imports/activityTypes';
 
-
 type StateT = {
   currentTab: number,
   pageTitle: string,
@@ -45,7 +44,7 @@ type PropsT = {
   classes: Object,
   onCreate: Function,
   setModalOpen: Function,
-  clearError: Function, 
+  clearError: Function,
   errorDiv: any,
   wikiId: string
 };
@@ -90,9 +89,8 @@ class NewPageModal extends React.Component<PropsT, StateT> {
   }
 
   handleTitleChange = (e: any) => {
-    this.handleErrorClearing(e.target.value); 
+    this.handleErrorClearing(e.target.value);
     this.setState({ pageTitle: e.target.value });
-    
   };
 
   handleTabs = (e: any, value: number) => {
@@ -132,9 +130,14 @@ class NewPageModal extends React.Component<PropsT, StateT> {
     } = this.state;
     this.props.onCreate(pageTitle, socialPlane, activityConfig, operatorConfig);
   };
-  
-  handleErrorClearing(currentTitle:string) {
-    if (currentTitle === "" || (currentTitle.length > 0 && this.props.errorDiv === "Title cannot be empty"))
+
+  // Clears error messages if the user tries to create a page with an empty title and then types in a new title
+  handleErrorClearing(currentTitle: string) {
+    if (
+      currentTitle === '' ||
+      (currentTitle.length > 0 &&
+        this.props.errorDiv === 'Title cannot be empty')
+    )
       this.props.clearError();
   }
 
@@ -157,8 +160,9 @@ class NewPageModal extends React.Component<PropsT, StateT> {
       <Dialog
         open={this.state.open}
         onClose={() => {
-          this.props.setModalOpen(false)
-          this.props.clearError()}}
+          this.props.setModalOpen(false);
+          this.props.clearError();
+        }}
         scroll="paper"
       >
         <FormGroup>
@@ -244,13 +248,21 @@ class NewPageModal extends React.Component<PropsT, StateT> {
             {currentTab === 1 && (
               <ApiForm
                 categories={['Core', 'Other']}
-                whiteList={['li-richText', 'ac-gallery', 'ac-brainstorm']}
+                whiteList={[
+                  'li-richText',
+                  'ac-gallery',
+                  'ac-brainstorm',
+                  'ac-quiz',
+                  'ac-ck-board'
+                ]}
                 config={this.state.activityConfig?.config}
                 activityType={this.state.activityConfig?.activityType}
                 activityMapping={{
                   'li-richText': 'Core',
                   'ac-gallery': 'Core',
-                  'ac-brainstorm': 'Other'
+                  'ac-brainstorm': 'Other',
+                  'ac-quiz': 'Core',
+                  'ac-ck-board': 'Core'
                 }}
                 noOffset
                 showDelete
@@ -262,7 +274,6 @@ class NewPageModal extends React.Component<PropsT, StateT> {
               <OperatorForm
                 operatorType="product"
                 config={this.state.operatorConfig?.config}
-                operatorType={this.state.operatorConfig?.operatorType}
                 categories={['From the web', 'From the current page']}
                 operatorTypesList={operatorTypesList}
                 operatorMappings={{
@@ -286,10 +297,10 @@ class NewPageModal extends React.Component<PropsT, StateT> {
             {expanded ? <ExpandLess /> : <ExpandMore />}
           </IconButton>
           <Button
-            onClick={() => { 
+            onClick={() => {
               this.props.setModalOpen(false);
-              this.props.clearError(); 
-              }}
+              this.props.clearError();
+            }}
             color="primary"
           >
             Cancel

--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -77,15 +77,15 @@ class WikiContentComp extends React.Component<> {
   handleErrorClearing(currentTitle) {
     if (
       currentTitle === '' ||
-      (currentTitle.length > 0 && this.state.error === 'Title cannot be empty')
-    )
+      (currentTitle.length > 0 && this.state.error === 'Title cannot be empty')  )
       this.clearErrors();
   }
 
   saveNewPageTitle = () => {
     const { pageTitleString } = this.state;
     const error = this.handleErrors(pageTitleString);
-    if (error === null) {
+  
+    if (error === null || pageTitleString === this.props.currentPageObj?.title) {
       this.props.changeTitle(this.props.currentPageObj.id, pageTitleString);
       this.setState({
         pageTitleString,

--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -6,13 +6,18 @@ import Button from '@material-ui/core/Button';
 import Paper from '@material-ui/core/Paper';
 import Edit from '@material-ui/icons/Edit';
 import Check from '@material-ui/icons/Check';
+import {
+  TextField,
+  FormHelperText
+} from '@material-ui/core'; 
 
 import { wikiStore } from './store';
 import LIDashboard from '../Dashboard/LIDashboard';
 import Revisions from './Revisions';
 import WikiLink from './WikiLink';
 import { LearningItem } from './index';
-import { getPageDetailsForLiId } from './helpers.js';
+import { getPageDetailsForLiId, checkNewPageTitle } from './helpers.js';
+import Form from 'react-jsonschema-form';
 
 class WikiContentComp extends React.Component<> {
   constructor(props) {
@@ -33,8 +38,9 @@ class WikiContentComp extends React.Component<> {
     this.state = {
       docMode: 'view',
       pageTitleString: this.props.currentPageObj?.title,
-      editingTitle: false,
-      showTitleEditButton: false
+      e: false,
+      showTitleEditButton: false,
+      error:null
     };
   }
 
@@ -45,7 +51,8 @@ class WikiContentComp extends React.Component<> {
         docMode: 'view',
         pageTitleString: this.props.currentPageObj.title,
         editingTitle: false,
-        showTitleEditButton: false
+        showTitleEditButton: false,
+        error:null
       });
     }
   }
@@ -56,17 +63,31 @@ class WikiContentComp extends React.Component<> {
     }));
   };
 
+  handleErrors = (newPageTitle) =>{
+    const error =
+    checkNewPageTitle(wikiStore.parsedPages, newPageTitle);
+    console.log(error); 
+    if(error){
+      this.setState({error}); 
+    }
+    else 
+       this.setState({error:null}); 
+  }
+
   saveNewPageTitle = () => {
-    const newPageTitle = this.state.pageTitleString;
-    if (!newPageTitle) throw new Error('Cannot save empty new page title');
-
-    this.props.changeTitle(this.props.currentPageObj.id, newPageTitle);
-
+    const {pageTitleString ,error} = this.state; 
+    this.handleErrors(pageTitleString);
+    if (error === null){
+    this.props.changeTitle(this.props.currentPageObj.id, pageTitleString);
     this.setState({
-      pageTitleString: newPageTitle,
+      pageTitleString,
       editingTitle: false,
       showTitleEditButton: false
     });
+
+    }
+   
+  
   };
 
   render() {
@@ -135,14 +156,21 @@ class WikiContentComp extends React.Component<> {
     const titleDiv = this.state.editingTitle ? (
       <div style={titleDivStyle}>
         <div>
-          <input
-            placeholder="New Title"
+       
+          <TextField
+            label="New Title"
+            error = {this.state.error !== null}
             value={this.state.pageTitleString}
             onChange={e => {
               this.setState({ pageTitleString: e.target.value });
             }}
           />
+          { (this.state.error!==null) &&
+          <FormHelperText error> {this.state.error} </FormHelperText>}
+         
           <Check onClick={() => this.saveNewPageTitle()} />
+
+       
         </div>
         <div style={{ flex: '1', textAlign: 'right' }}>{docModeButton}</div>
       </div>

--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -6,12 +6,7 @@ import Button from '@material-ui/core/Button';
 import Paper from '@material-ui/core/Paper';
 import Edit from '@material-ui/icons/Edit';
 import Check from '@material-ui/icons/Check';
-import {
-  TextField,
-  FormHelperText,
-  Input,
-  FormControl
-} from '@material-ui/core'; 
+import { TextField, FormHelperText, FormControl } from '@material-ui/core';
 
 import { wikiStore } from './store';
 import LIDashboard from '../Dashboard/LIDashboard';
@@ -19,7 +14,6 @@ import Revisions from './Revisions';
 import WikiLink from './WikiLink';
 import { LearningItem } from './index';
 import { getPageDetailsForLiId, checkNewPageTitle } from './helpers.js';
-import Form from 'react-jsonschema-form';
 
 class WikiContentComp extends React.Component<> {
   constructor(props) {
@@ -42,7 +36,7 @@ class WikiContentComp extends React.Component<> {
       pageTitleString: this.props.currentPageObj?.title,
       e: false,
       showTitleEditButton: false,
-      error:null
+      error: null
     };
   }
 
@@ -54,13 +48,14 @@ class WikiContentComp extends React.Component<> {
         pageTitleString: this.props.currentPageObj.title,
         editingTitle: false,
         showTitleEditButton: false,
-        error:null
+        error: null
       });
     }
   }
+
   clearErrors = () => {
-    this.setState({error:null}); 
-  }
+    this.setState({ error: null });
+  };
 
   handleEditingTitle = () => {
     this.setState(prevState => ({
@@ -68,38 +63,35 @@ class WikiContentComp extends React.Component<> {
     }));
   };
 
-  handleErrors = (newPageTitle) =>{
-    const error =
-    checkNewPageTitle(wikiStore.parsedPages, newPageTitle);
-    console.log(error); 
-    if(error){
-      this.setState({error}); 
+  handleErrors = newPageTitle => {
+    const error = checkNewPageTitle(wikiStore.parsedPages, newPageTitle);
+    if (error) {
+      this.setState({ error });
+    } else {
+      this.setState({ error });
     }
-    else{
-         this.setState({error});
-    }
-    return error; 
-  }
+    return error;
+  };
 
-   handleErrorClearing(currentTitle) {
-    if (currentTitle === "" || (currentTitle.length > 0 && this.state.error === "Title cannot be empty"))
+  handleErrorClearing(currentTitle) {
+    if (
+      currentTitle === '' ||
+      (currentTitle.length > 0 && this.state.error === 'Title cannot be empty')
+    )
       this.clearErrors();
   }
 
   saveNewPageTitle = () => {
-    const {pageTitleString} = this.state; 
+    const { pageTitleString } = this.state;
     const error = this.handleErrors(pageTitleString);
-    if (error === null){
-    this.props.changeTitle(this.props.currentPageObj.id, pageTitleString);
-    this.setState({
-      pageTitleString,
-      editingTitle: false,
-      showTitleEditButton: false
-    });
-
+    if (error === null) {
+      this.props.changeTitle(this.props.currentPageObj.id, pageTitleString);
+      this.setState({
+        pageTitleString,
+        editingTitle: false,
+        showTitleEditButton: false
+      });
     }
-   
-  
   };
 
   render() {
@@ -130,11 +122,10 @@ class WikiContentComp extends React.Component<> {
     };
 
     const titleStyle = {
-      lineHeight:'1.2'
+      lineHeight: '1.2'
+    };
 
-    }; 
-
-    const docModeButton = (() => {
+    const docModeButton = () => {
       if (
         this.state.docMode === 'history' ||
         this.props.liType === 'li-activity'
@@ -163,28 +154,31 @@ class WikiContentComp extends React.Component<> {
           Finish
         </Button>
       );
-    })
+    };
 
     const titleDiv = this.state.editingTitle ? (
       <div style={titleDivStyle}>
-      
-         
-         <FormControl margin = 'normal'>
+        <FormControl margin="normal">
           <TextField
-            id ="title-input"
+            id="title-input"
             placeholder="New Title"
-            error = {this.state.error !== null}
+            error={this.state.error !== null}
             value={this.state.pageTitleString}
-            onChange = {e  => {this.setState({pageTitleString: e.target.value })
-                               this.handleErrorClearing(e.target.value); }}
-            aria-describedby = "title-input-helper-text"
-            
+            onChange={e => {
+              this.setState({ pageTitleString: e.target.value });
+              this.handleErrorClearing(e.target.value);
+            }}
+            aria-describedby="title-input-helper-text"
           />
-             { (this.state.error!==null) &&
-          <FormHelperText id = "title-input-helper-text" error> {this.state.error} </FormHelperText>}
-          </FormControl>
+          {this.state.error !== null && (
+            <FormHelperText id="title-input-helper-text" error>
+              {' '}
+              {this.state.error}{' '}
+            </FormHelperText>
+          )}
+        </FormControl>
 
-          <Check onClick={() => this.saveNewPageTitle()} />
+        <Check onClick={() => this.saveNewPageTitle()} />
         <div style={{ flex: '1', textAlign: 'right' }}>{docModeButton}</div>
       </div>
     ) : (
@@ -197,7 +191,7 @@ class WikiContentComp extends React.Component<> {
             this.setState({ showTitleEditButton: false });
           }}
         >
-          <span style = {titleStyle}>{this.state.pageTitleString}</span>
+          <span style={titleStyle}>{this.state.pageTitleString}</span>
           {this.state.showTitleEditButton && (
             <Edit
               onClick={this.handleEditingTitle}

--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -34,7 +34,7 @@ class WikiContentComp extends React.Component<> {
     this.state = {
       docMode: 'view',
       pageTitleString: this.props.currentPageObj?.title,
-      e: false,
+      editingTitle: false,
       showTitleEditButton: false,
       error: null
     };
@@ -72,12 +72,9 @@ class WikiContentComp extends React.Component<> {
     }
     return error;
   };
-
+  // Clears error messages if the user tries to edit a page with an empty title and then types in a new title
   handleErrorClearing(currentTitle) {
-    if (
-      currentTitle === '' ||
-      (currentTitle.length > 0 && this.state.error === 'Title cannot be empty')
-    )
+    if (currentTitle === '' || (currentTitle.length > 0 && this.state.error === 'Title cannot be empty'))
       this.clearErrors();
   }
 
@@ -172,8 +169,7 @@ class WikiContentComp extends React.Component<> {
           />
           {this.state.error !== null && (
             <FormHelperText id="title-input-helper-text" error>
-              {' '}
-              {this.state.error}{' '}
+              {this.state.error}
             </FormHelperText>
           )}
         </FormControl>

--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -8,7 +8,9 @@ import Edit from '@material-ui/icons/Edit';
 import Check from '@material-ui/icons/Check';
 import {
   TextField,
-  FormHelperText
+  FormHelperText,
+  Input,
+  FormControl
 } from '@material-ui/core'; 
 
 import { wikiStore } from './store';
@@ -56,6 +58,9 @@ class WikiContentComp extends React.Component<> {
       });
     }
   }
+  clearErrors = () => {
+    this.setState({error:null}); 
+  }
 
   handleEditingTitle = () => {
     this.setState(prevState => ({
@@ -70,13 +75,20 @@ class WikiContentComp extends React.Component<> {
     if(error){
       this.setState({error}); 
     }
-    else 
-       this.setState({error:null}); 
+    else{
+         this.setState({error});
+    }
+    return error; 
+  }
+
+   handleErrorClearing(currentTitle) {
+    if (currentTitle === "" || (currentTitle.length > 0 && this.state.error === "Title cannot be empty"))
+      this.clearErrors();
   }
 
   saveNewPageTitle = () => {
-    const {pageTitleString ,error} = this.state; 
-    this.handleErrors(pageTitleString);
+    const {pageTitleString} = this.state; 
+    const error = this.handleErrors(pageTitleString);
     if (error === null){
     this.props.changeTitle(this.props.currentPageObj.id, pageTitleString);
     this.setState({
@@ -151,27 +163,28 @@ class WikiContentComp extends React.Component<> {
           Finish
         </Button>
       );
-    })();
+    })
 
     const titleDiv = this.state.editingTitle ? (
       <div style={titleDivStyle}>
-        <div>
-       
+      
+         
+         <FormControl margin = 'normal'>
           <TextField
-            label="New Title"
+            id ="title-input"
+            placeholder="New Title"
             error = {this.state.error !== null}
             value={this.state.pageTitleString}
-            onChange={e => {
-              this.setState({ pageTitleString: e.target.value });
-            }}
+            onChange = {e  => {this.setState({pageTitleString: e.target.value })
+                               this.handleErrorClearing(e.target.value); }}
+            aria-describedby = "title-input-helper-text"
+            
           />
-          { (this.state.error!==null) &&
-          <FormHelperText error> {this.state.error} </FormHelperText>}
-         
-          <Check onClick={() => this.saveNewPageTitle()} />
+             { (this.state.error!==null) &&
+          <FormHelperText id = "title-input-helper-text" error> {this.state.error} </FormHelperText>}
+          </FormControl>
 
-       
-        </div>
+          <Check onClick={() => this.saveNewPageTitle()} />
         <div style={{ flex: '1', textAlign: 'right' }}>{docModeButton}</div>
       </div>
     ) : (

--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -72,9 +72,13 @@ class WikiContentComp extends React.Component<> {
     }
     return error;
   };
+
   // Clears error messages if the user tries to edit a page with an empty title and then types in a new title
   handleErrorClearing(currentTitle) {
-    if (currentTitle === '' || (currentTitle.length > 0 && this.state.error === 'Title cannot be empty'))
+    if (
+      currentTitle === '' ||
+      (currentTitle.length > 0 && this.state.error === 'Title cannot be empty')
+    )
       this.clearErrors();
   }
 

--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -77,15 +77,19 @@ class WikiContentComp extends React.Component<> {
   handleErrorClearing(currentTitle) {
     if (
       currentTitle === '' ||
-      (currentTitle.length > 0 && this.state.error === 'Title cannot be empty')  )
+      (currentTitle.length > 0 && this.state.error === 'Title cannot be empty')
+    )
       this.clearErrors();
   }
 
   saveNewPageTitle = () => {
     const { pageTitleString } = this.state;
     const error = this.handleErrors(pageTitleString);
-  
-    if (error === null || pageTitleString === this.props.currentPageObj?.title) {
+
+    if (
+      error === null ||
+      pageTitleString === this.props.currentPageObj?.title
+    ) {
       this.props.changeTitle(this.props.currentPageObj.id, pageTitleString);
       this.setState({
         pageTitleString,

--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -65,11 +65,7 @@ class WikiContentComp extends React.Component<> {
 
   handleErrors = newPageTitle => {
     const error = checkNewPageTitle(wikiStore.parsedPages, newPageTitle);
-    if (error) {
-      this.setState({ error });
-    } else {
-      this.setState({ error });
-    }
+    this.setState({error});
     return error;
   };
 

--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -94,7 +94,9 @@ class WikiContentComp extends React.Component<> {
       this.setState({
         pageTitleString,
         editingTitle: false,
-        showTitleEditButton: false
+        showTitleEditButton: false,
+        error:
+          pageTitleString === this.props.currentPageObj?.title ? null : error
       });
     }
   };

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -66,7 +66,7 @@ type WikiCompStateT = {
   mode: string,
   error: ?string,
   openCreator: ?Object,
-  createModalOpen:boolean,
+  createModalOpen: boolean,
   findModalOpen: boolean,
   search: '',
   urlInstance: ?string,
@@ -345,7 +345,6 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
   };
 
   changeTitle = (pageId, newPageTitle) => {
-
     changeWikiPageTitle(this.wikiDoc, pageId, newPageTitle);
     const instanceId = this.props.match.params.instance;
     const link =
@@ -355,7 +354,6 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
       newPageTitle +
       (instanceId ? '/' + instanceId : '');
     this.props.history.replace(link);
-  
   };
 
   goToPage = (pageId, cb, side, foreignInstanceId) => {
@@ -682,7 +680,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
           <CreateModal
             onCreate={this.createPage}
             setModalOpen={e => this.setState({ createModalOpen: e })}
-            clearError = {() => this.setState({error: null})}
+            clearError={() => this.setState({ error: null })}
             errorDiv={this.state.error}
             wikiId={this.wikiId}
           />

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -357,6 +357,7 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
   };
 
   changeTitle = (pageId, newPageTitle) => {
+
     changeWikiPageTitle(this.wikiDoc, pageId, newPageTitle);
     const instanceId = this.props.match.params.instance;
     const link =
@@ -366,6 +367,7 @@ class WikiComp extends Component<WikiCompPropsT, WikiCompStateT> {
       newPageTitle +
       (instanceId ? '/' + instanceId : '');
     this.props.history.replace(link);
+  
   };
 
   goToPage = (pageId, cb, side, foreignInstanceId) => {


### PR DESCRIPTION
The following PR fixes the bug of pages getting lost if you rename it to an existing page title. Also it fixes the bug of letting the user rename the page title to empty. 

**Steps to reproduce**

- Create a page on the wiki with title X 

- Create another page on the wiki with title Y 

- Rename page Y to X. There will be 2 pages with title X on the sidebar. Furthermore, Y can be renamed to anything including an empty title. 

**Testing done**
Manual testing 

**Future thoughts**
There is a lot of similarities with the error handling logic when Creating a page and renaming it.
So I would possibly like to make another PR that abstracts this out in some form. 
