### PR TITLE
Fixes exporting activities from the Wiki

### DIFF
--- a/frog/imports/client/TeacherView/utils/buttonUtils.js
+++ b/frog/imports/client/TeacherView/utils/buttonUtils.js
@@ -207,7 +207,8 @@ export const SessionUtilsButtonsModel = (
           session._id,
           whereTo,
           Meteor.userId(),
-          () => window.alert('Graph exported')
+          err =>
+            window.alert(err ? 'Oops! something went wrong.' : 'Graph exported')
         );
       },
       text: 'Export all activities to wiki'

--- a/frog/imports/client/TeacherView/utils/buttonUtils.js
+++ b/frog/imports/client/TeacherView/utils/buttonUtils.js
@@ -199,7 +199,7 @@ export const SessionUtilsButtonsModel = (
           'Which wiki should pages be exported to?'
         );
         if (!whereTo) {
-          console.log('no whereto');
+          console.warn('no whereto');
           return;
         }
         Meteor.call(

--- a/frog/server/wiki.js
+++ b/frog/server/wiki.js
@@ -25,6 +25,12 @@ const exportSessionWiki = (sessionId, wiki, userId) => {
 
   activities.forEach(act => {
     const obj = Objects.findOne(act._id);
+    if (act.plane !== 3) {
+      throw new Meteor.Error(
+        'Not implemented yet',
+        'Sorry for the incovienience'
+      );
+    }
     importWikiFromFROG(act, obj, wiki, act.title, userId);
   });
 };

--- a/frog/server/wiki.js
+++ b/frog/server/wiki.js
@@ -45,7 +45,6 @@ export const importWikiFromFROG = async (item, object, wiki, page, userId) => {
   );
   const genericDoc = connection.get('li');
   const dataFn = generateReactiveFn(genericDoc);
-
   const instanceData = instances
     .filter(x => x !== userId)
     .reduce((acc, x) => {
@@ -57,21 +56,16 @@ export const importWikiFromFROG = async (item, object, wiki, page, userId) => {
         activityTypeTitle: activityTypesObj[item.activityType].meta.name
       };
 
-      const newId = dataFn.createLearningItem(
-        'li-activity',
-        payload,
-        {
-          title: page
-        },
-        true
-      );
+      const newId = dataFn.createLearningItem('li-activity', payload, {
+        title: page
+      });
+
       acc[x] = {
         liId: newId,
         username: Meteor.users.findOne(x)?.username
       };
       return acc;
     }, {});
-
   const wikiDoc = connection.get('wiki', wiki);
   wikiDoc.subscribe(err => {
     if (err) throw err;
@@ -84,8 +78,8 @@ export const importWikiFromFROG = async (item, object, wiki, page, userId) => {
       page,
       true,
       'li-activity',
+      instanceData.all.liId,
       item.plane,
-      instanceData,
       item.groupingKey ? object.socialStructure[item.groupingKey] : undefined,
       true
     );

--- a/frog/server/wiki.js
+++ b/frog/server/wiki.js
@@ -25,13 +25,9 @@ const exportSessionWiki = (sessionId, wiki, userId) => {
 
   activities.forEach(act => {
     const obj = Objects.findOne(act._id);
-    if (act.plane !== 3) {
-      throw new Meteor.Error(
-        'Not implemented yet',
-        'Sorry for the incovienience'
-      );
+    if (act.plane === 3) {
+      importWikiFromFROG(act, obj, wiki, act.title, userId);
     }
-    importWikiFromFROG(act, obj, wiki, act.title, userId);
   });
 };
 
@@ -62,9 +58,14 @@ export const importWikiFromFROG = async (item, object, wiki, page, userId) => {
         activityTypeTitle: activityTypesObj[item.activityType].meta.name
       };
 
-      const newId = dataFn.createLearningItem('li-activity', payload, {
-        title: page
-      });
+      const newId = dataFn.createLearningItem(
+        'li-activity',
+        payload,
+        {
+          title: page
+        },
+        true
+      );
 
       acc[x] = {
         liId: newId,

--- a/op/op-twitter/src/index.js
+++ b/op/op-twitter/src/index.js
@@ -13,6 +13,7 @@ export const meta = {
 
 export const config = {
   type: 'object',
+  required: ['query'],
   properties: {
     query: {
       type: 'string',


### PR DESCRIPTION
**Description**
Due to changes in the structure of documents in Wiki, the exporting activities to wiki from the TeacherView was broken. This PR fixes that.

**Resolved Issues**
Asana task for reference: https://app.asana.com/0/1115664036175110/1127349467155372

**How to test?**
Run a graph and click on "Export activities to wiki", the activities should be imported into the chosen wiki page along with their data.

**Pending Changes**
- [ ] **Individual Plane**: Export individual activities as individual pages. (Currently, individual activities  don't export properly)