### PR TITLE
Wiki page title can now contain special characters except % and /

### DIFF
--- a/frog/imports/client/Wiki/helpers.js
+++ b/frog/imports/client/Wiki/helpers.js
@@ -52,6 +52,7 @@ const checkNewPageTitle = (parsedPages, newPageTitle) => {
   const parsedTitle = newPageTitle.toLowerCase().trim();
   if (parsedTitle === '') return 'Title cannot be empty';
   if (parsedTitle.includes('/')) return 'Title cannot contain /';
+  if (parsedTitle.includes('%')) return 'Title cannot contain %';
   if (parsedPages[parsedTitle]?.valid) return 'Title already used';
 
   return null;

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -102,7 +102,12 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
       dashboardSearch: null,
       pageId: null,
       currentPageObj: null,
-      initialPageTitle: this.props.match.params.pageTitle || null,
+      initialPageTitle:{if (decodeURIComponent(this.props.params.pageTitle) === "undefined") 
+                            null
+                        else if (decodeURIComponent(this.props.params.pageTitle !== "undefined"))
+                              decodeURIComponent(this.props.params.pageTitle)
+                        else
+                           null},
       mode: 'document',
       docMode: query.edit ? 'edit' : 'view',
       error: null,
@@ -142,12 +147,13 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
   }
 
   componentDidUpdate(prevProps) {
-    const pageTitle = this.props.match.params.pageTitle;
+    const pageTitle = decodeURIComponent(this.props.match.params.pageTitle);
+
     if (
       (pageTitle !== this.state.currentPageObj?.title &&
-        prevProps.match.params.pageTitle !==
-          this.props.match.params.pageTitle) ||
-      prevProps.match.params.instance !== this.props.match.params.instance
+        decodeURIComponent(prevProps.match.params.pageTitle) !==
+          decodeURIComponent(this.props.match.params.pageTitle) ||
+      (prevProps.match.params.instance !== this.props.match.params.instance)
     ) {
       this.goToPageTitle(pageTitle, this.props.match.params.instance);
     }
@@ -250,7 +256,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
           '/wiki/' +
           this.wikiId +
           '/' +
-          currentPageObj.title +
+          encodeURIComponent(currentPageObj.title) +
           (instanceId && instanceId !== this.getInstanceId(fullPageObj)
             ? '/' + instanceName
             : '');
@@ -351,7 +357,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
       '/wiki/' +
       this.wikiId +
       '/' +
-      newPageTitle +
+      encodeURIComponent(newPageTitle) +
       (instanceId ? '/' + instanceId : '');
     this.props.history.replace(link);
   };
@@ -407,7 +413,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
           '/wiki/' +
           this.wikiId +
           '/' +
-          newCurrentPageObj.title +
+          encodeURIComponent(newCurrentPageObj.title) +
           (instanceId && instanceId !== this.getInstanceId(fullPageObj)
             ? '/' + instanceName
             : '');

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -102,7 +102,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
       dashboardSearch: null,
       pageId: null,
       currentPageObj: null,
-      initialPageTitle:  (this.props.match.pageTitle) || null, 
+      initialPageTitle: this.props.match.pageTitle || null,
       mode: 'document',
       docMode: query.edit ? 'edit' : 'view',
       error: null,
@@ -147,9 +147,9 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     if (
       (pageTitle !== this.state.currentPageObj?.title &&
         decodeURIComponent(prevProps.match.params.pageTitle) !==
-          decodeURIComponent(this.props.match.params.pageTitle) ||
-      (prevProps.match.params.instance !== this.props.match.params.instance)
-    )) {
+          decodeURIComponent(this.props.match.params.pageTitle)) ||
+      prevProps.match.params.instance !== this.props.match.params.instance
+    ) {
       this.goToPageTitle(pageTitle, this.props.match.params.instance);
     }
   }

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -102,7 +102,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
       dashboardSearch: null,
       pageId: null,
       currentPageObj: null,
-      initialPageTitle:decodeURIComponent(this.props.match.pageTitle) || null, 
+      initialPageTitle:  (this.props.match.pageTitle) || null, 
       mode: 'document',
       docMode: query.edit ? 'edit' : 'view',
       error: null,

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -149,8 +149,8 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
         decodeURIComponent(prevProps.match.params.pageTitle) !==
           decodeURIComponent(this.props.match.params.pageTitle) ||
       (prevProps.match.params.instance !== this.props.match.params.instance)
-    ) {
-      this.goToPageTitle(pageTitle, this.match.params.instance);
+    )) {
+      this.goToPageTitle(pageTitle, this.props.match.params.instance);
     }
   }
 

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -102,12 +102,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
       dashboardSearch: null,
       pageId: null,
       currentPageObj: null,
-      initialPageTitle:{if (decodeURIComponent(this.props.params.pageTitle) === "undefined") 
-                            null
-                        else if (decodeURIComponent(this.props.params.pageTitle !== "undefined"))
-                              decodeURIComponent(this.props.params.pageTitle)
-                        else
-                           null},
+      initialPageTitle:decodeURIComponent(this.props.match.pageTitle) || null, 
       mode: 'document',
       docMode: query.edit ? 'edit' : 'view',
       error: null,
@@ -155,7 +150,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
           decodeURIComponent(this.props.match.params.pageTitle) ||
       (prevProps.match.params.instance !== this.props.match.params.instance)
     ) {
-      this.goToPageTitle(pageTitle, this.props.match.params.instance);
+      this.goToPageTitle(pageTitle, this.match.params.instance);
     }
   }
 

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -102,7 +102,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
       dashboardSearch: null,
       pageId: null,
       currentPageObj: null,
-      initialPageTitle: this.props.match.pageTitle || null,
+      initialPageTitle: this.props.match.params.pageTitle || null,
       mode: 'document',
       docMode: query.edit ? 'edit' : 'view',
       error: null,


### PR DESCRIPTION
This PR allows wiki titles to contain special characters except % and / by encoding the title. Earlier FROG would crash if you make a page with title containing a ? for example. Also, this PR adds error handling if the title contains %.

**Testing instructions**
Create a wiki page title with a special character and it should not crash.

**Testing done**
Manual testing - entered a lot of random combinations of text with random special characters.
