### PR TITLE
Changes to CreateModal error clearing and clicking out of the modal 

### DIFF
--- a/frog/imports/client/Wiki/ModalCreate.js
+++ b/frog/imports/client/Wiki/ModalCreate.js
@@ -159,11 +159,11 @@ class NewPageModal extends React.Component<PropsT, StateT> {
     return (
       <Dialog
         open={this.state.open}
-        onExited ={() => {
+        onExited={() => {
           this.props.setModalOpen(false);
           this.props.clearError();
         }}
-        onEnter = {() =>{
+        onEnter={() => {
           this.props.setModalOpen(true);
           this.props.clearError();
         }}

--- a/frog/imports/client/Wiki/ModalCreate.js
+++ b/frog/imports/client/Wiki/ModalCreate.js
@@ -159,8 +159,12 @@ class NewPageModal extends React.Component<PropsT, StateT> {
     return (
       <Dialog
         open={this.state.open}
-        onClose={() => {
+        onExited ={() => {
           this.props.setModalOpen(false);
+          this.props.clearError();
+        }}
+        onEnter = {() =>{
+          this.props.setModalOpen(true);
           this.props.clearError();
         }}
         scroll="paper"


### PR DESCRIPTION
This PR adds some changes to the error clearing and the create new page modal. 

**Issues resolved** 
_No. 1_ 
 - Open the CreateModal, type the name of an already existing page, press Create. 

- The modal should display an error. Change the text to a new page title (by selecting it and then typing) and press Create. The new page should be created. 

- Open the CreateModal once more, the error state should still be visible. The expected behaviour is that the error state be cleared.

_No. 2_

- Click Create New Page and enter a new page title. Select it by dragging with your mouse. If you drag outside the bounds of the modal/dialog box, the modal closes. The modal should not close in this case since the user was in the middle of editing and configuring the page. 

- Now, the only way to close the CreateModal is by clicking cancel or if the page is successfully created. This also will help if the user clicks off the modal by mistake and will prevent them to lose their changes.

**Testing done**
Manual testing 

**Asana issues**
https://app.asana.com/0/1121331595459324/1128290790044606/f
https://app.asana.com/0/1121331595459324/1128290790044606/f