### PR TITLE
Fix new wiki link

### DIFF
--- a/frog-utils/src/ReactiveRichText/WikiLink/WikiLinkModule.js
+++ b/frog-utils/src/ReactiveRichText/WikiLink/WikiLinkModule.js
@@ -222,10 +222,7 @@ class WikiLinkModule {
       );
     } else {
       if (!data.id) {
-        const { pageId, liId } = window.wiki.createNewGenericPage(
-          data.title,
-          false
-        );
+        const { pageId, liId } = window.wiki.addNonActivePage(data.title);
         data.id = pageId;
         data.liId = liId;
       }

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -92,7 +92,8 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     window.wiki = {
       createPage: this.createPage,
       goToPage: this.goToPage,
-      openDeletedPageModal: this.openDeletedPageModal
+      openDeletedPageModal: this.openDeletedPageModal,
+      addNonActivePage: this.addNonactivePage
     };
 
     const query = queryToObject(this.props.location.search.slice(1));
@@ -454,6 +455,14 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     );
     this.goToPage(pageId);
     return { pageId, liId };
+  };
+
+  addNonactivePage = title => {
+    const liType = 'li-richText';
+    const liId = createNewLI(this.wikiId, liType, undefined, title);
+
+    const pageId = addNewWikiPage(this.wikiDoc, title, false, liType, liId, 3);
+    return { liId, pageId };
   };
 
   openDeletedPageModal = (pageId, pageTitle) => {

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -93,7 +93,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
       createPage: this.createPage,
       goToPage: this.goToPage,
       openDeletedPageModal: this.openDeletedPageModal,
-      addNonActivePage: this.addNonactivePage
+      addNonActivePage: this.addNonActivePage
     };
 
     const query = queryToObject(this.props.location.search.slice(1));
@@ -457,10 +457,15 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     return { pageId, liId };
   };
 
-  addNonactivePage = title => {
+  // there is a link to a page that has not yet been formally created, until
+  // clicked upon, but we still keep track of it.
+  addNonActivePage = title => {
+    const existingPage = wikiStore.pagesByTitle[title];
+    if (existingPage) {
+      return { liId: existingPage.liId, pageId: existingPage.id };
+    }
     const liType = 'li-richText';
     const liId = createNewLI(this.wikiId, liType, undefined, title);
-
     const pageId = addNewWikiPage(this.wikiDoc, title, false, liType, liId, 3);
     return { liId, pageId };
   };

--- a/frog/imports/client/Wiki/store.js
+++ b/frog/imports/client/Wiki/store.js
@@ -30,6 +30,14 @@ class WikiStore {
 
       get pagesArrayOnlyInvalid(): Array {
         return values(toJS(wikiStore.pages)).filter(x => !x.valid && x.created);
+      },
+
+      get pagesByTitle(): Array {
+        return Object.keys(toJS(wikiStore.pages)).reduce((acc, x) => {
+          const page = wikiStore.pages[x];
+          acc[page.title] = { ...page, id: x };
+          return acc;
+        }, {});
       }
     });
   }


### PR DESCRIPTION
This PR fixes the ability to create a link to a page that does not yet exist, and create it by clicking on it.

A key idea is that if you add three links to the same non-existant page, they will all link to the same object in the background, so that once you create the page, all links will be updated and point to the newly created page - if you then rename the page, all links will point to the renamed page etc.

Note that we have decided that creating a page by link always creates a li-richText on plane 3. 

https://app.asana.com/0/1121331595459324/1127850709273037/f