### PR TITLE
Make sure allowed characters for link creation in RRT is in sync with wiki policy

### DIFF
--- a/frog-utils/src/ReactiveRichText/WikiLink/WikiLinkModule.js
+++ b/frog-utils/src/ReactiveRichText/WikiLink/WikiLinkModule.js
@@ -23,7 +23,7 @@ class WikiLinkModule {
       },
       mentionDenotationChars: ['@'],
       showDenotationChar: true,
-      allowedChars: /^[a-zA-Z0-9_$&+,:;=?@#|'<>.^*()!-]*$/,
+      allowedChars: /^[a-zA-Z0-9_]*$/,
       minChars: 0,
       maxChars: 31,
       offsetTop: 2,

--- a/frog-utils/src/ReactiveRichText/WikiLink/WikiLinkModule.js
+++ b/frog-utils/src/ReactiveRichText/WikiLink/WikiLinkModule.js
@@ -23,7 +23,7 @@ class WikiLinkModule {
       },
       mentionDenotationChars: ['@'],
       showDenotationChar: true,
-      allowedChars: /^[a-zA-Z0-9_]*$/,
+      allowedChars: /^[a-zA-Z0-9_$&+,:;=?@#|'<>.^*()!-]*$/,
       minChars: 0,
       maxChars: 31,
       offsetTop: 2,

--- a/frog-utils/src/ReactiveRichText/main.js
+++ b/frog-utils/src/ReactiveRichText/main.js
@@ -690,7 +690,7 @@ class ReactiveRichText extends Component<
                 wikiLink: isEmpty(wikiContext)
                   ? null
                   : {
-                      allowedChars: /^[A-Za-z\sÅÄÖåäö/0-9]*$/,
+                      allowedChars: /^[A-Za-z\sÅÄÖåäö/0-9_ !""$&'()*+,-.:;<=>?@#[\]^_`{|}~]*$/,
                       mentionDenotationChars: ['@'],
                       source: (searchTerm, renderList) => {
                         const values = wikiContext.getOnlyValidWikiPages();
@@ -755,7 +755,7 @@ class ReactiveRichText extends Component<
                 wikiEmbed: isEmpty(wikiContext)
                   ? null
                   : {
-                      allowedChars: /^[A-Za-z\sÅÄÖåäö/0-9]*$/,
+                      allowedChars: /^[A-Za-z\sÅÄÖåäö/0-9_ !""$&'()*+,-.:;<=>?@#[\]^_`{|}~]*$/,
                       mentionDenotationChars: ['#'],
                       type: 'embed',
                       source: (searchTerm, renderList) => {


### PR DESCRIPTION
This PR makes sure allowed characters for link creation is consistent when you create a page in RRT and through the create modal. 

**Steps to test**
Type @ in the rich text editor and try to create a wiki page with a special character, for example: 
"Hello! are you there?". If the page doesn't exist a green link should pop up and clicking it should create a page with the same name. If the page exists then it should link to the page. 

**Asana Issue**
https://app.asana.com/0/1121331595459324/1128677555115569/f
