### PR TITLE
Cleaning up circular references in wiki

### DIFF
--- a/frog/imports/client/Wiki/Revisions.js
+++ b/frog/imports/client/Wiki/Revisions.js
@@ -7,7 +7,7 @@ import { A } from 'frog-utils';
 import Delta from 'quill-delta';
 
 import RenderLearningItem from '../LearningItem/RenderLearningItem';
-import { dataFn } from './index';
+import { dataFn } from './wikiLearningItem';
 
 // taken from op-richText-diff - should be moved to common location
 const transform = (item, toDiff) => {

--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -12,7 +12,7 @@ import { wikiStore } from './store';
 import LIDashboard from '../Dashboard/LIDashboard';
 import Revisions from './Revisions';
 import WikiLink from './WikiLink';
-import { LearningItem } from './index';
+import { LearningItem } from './wikiLearningItem';
 import { getPageDetailsForLiId, checkNewPageTitle } from './helpers.js';
 
 class WikiContentComp extends React.Component<> {

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -36,6 +36,7 @@ import RestoreModal from './ModalRestore';
 import WikiTopNavbar from './components/TopNavbar';
 import WikiContentComp from './WikiContentComp';
 import { addNewWikiPage } from '../../api/wikiDocHelpers';
+import { dataFn } from './wikiLearningItem';
 
 import {
   withModalController,

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -17,8 +17,6 @@ import Delete from '@material-ui/icons/Delete';
 import RestorePage from '@material-ui/icons/RestorePage';
 
 import { connection } from '../App/connection';
-import { generateReactiveFn } from '/imports/api/generateReactiveFn';
-import LI from '../LearningItem';
 import { getPageTitle, getDifferentPageId, checkNewPageTitle } from './helpers';
 import {
   invalidateWikiPage,
@@ -43,12 +41,6 @@ import {
   withModalController,
   type ModalParentPropsT
 } from './components/Modal';
-
-const genericDoc = connection.get('li');
-export const dataFn = generateReactiveFn(genericDoc, LI, {
-  createdByUser: Meteor.userId()
-});
-export const LearningItem = dataFn.LearningItem;
 
 type WikiCompPropsT = {
   location: *,

--- a/frog/imports/client/Wiki/liDocHelpers.js
+++ b/frog/imports/client/Wiki/liDocHelpers.js
@@ -1,16 +1,8 @@
 // @flow
-import { Meteor } from 'meteor/meteor';
 import { uuid } from 'frog-utils';
 import { connection } from '../App/connection';
-import { generateReactiveFn } from '/imports/api/generateReactiveFn';
-import LI from '../LearningItem';
 import { activityTypesObj } from '/imports/activityTypes';
-
-const genericDoc = connection.get('li');
-export const dataFn = generateReactiveFn(genericDoc, LI, {
-  createdByUser: Meteor.userId()
-});
-export const LearningItem = dataFn.LearningItem;
+import { dataFn } from './wikiLearningItem';
 
 // Creates an LI entry in the 'li' collection.
 export const createNewLI = (

--- a/frog/imports/client/Wiki/wikiLearningItem.js
+++ b/frog/imports/client/Wiki/wikiLearningItem.js
@@ -1,0 +1,12 @@
+// @flow
+import { Meteor } from 'meteor/meteor'
+
+import { generateReactiveFn } from '/imports/api/generateReactiveFn';
+import { connection } from '../App/connection';
+import LI from '../LearningItem';
+
+const genericDoc = connection.get('li');
+export const dataFn = generateReactiveFn(genericDoc, LI, {
+  createdByUser: Meteor.userId()
+});
+export const LearningItem = dataFn.LearningItem;


### PR DESCRIPTION
There was a bunch of circular references where things that wiki/index depended on depended on wiki/index. I moved this to a separate file, and also avoided some duplication. 

Everything should work exactly as before in terms of functionality.