### PR TITLE
Enter now works from anywhere in create modal in the wiki

### DIFF
--- a/frog/imports/client/Wiki/ModalCreate.js
+++ b/frog/imports/client/Wiki/ModalCreate.js
@@ -169,10 +169,8 @@ class NewPageModal extends React.Component<PropsT, StateT> {
         }}
         onEscapeKeyDown={() => this.props.setModalOpen(false)}
         onKeyDown={e => {
-          if (e.keyCode === 13) {
+          if (e.keyCode === 13 && this.props.errorDiv !== null)
             this.handleCreate();
-            if (this.props.errorDiv !== null) this.props.setModalOpen(false);
-          }
         }}
         scroll="paper"
       >

--- a/frog/imports/client/Wiki/ModalCreate.js
+++ b/frog/imports/client/Wiki/ModalCreate.js
@@ -168,8 +168,12 @@ class NewPageModal extends React.Component<PropsT, StateT> {
           this.props.clearError();
         }}
         onEscapeKeyDown={() => this.props.setModalOpen(false)}
-        onKeyDown = { e => { if (e.keyCode === 13) {this.handleCreate()
-          this.props.setModalOpen(false)}}}
+        onKeyDown={e => {
+          if (e.keyCode === 13) {
+            this.handleCreate();
+            if (this.props.errorDiv !== null) this.props.setModalOpen(false);
+          }
+        }}
         scroll="paper"
       >
         <FormGroup>

--- a/frog/imports/client/Wiki/ModalCreate.js
+++ b/frog/imports/client/Wiki/ModalCreate.js
@@ -168,6 +168,8 @@ class NewPageModal extends React.Component<PropsT, StateT> {
           this.props.clearError();
         }}
         onEscapeKeyDown={() => this.props.setModalOpen(false)}
+        onKeyDown = { e => { if (e.keyCode === 13) {this.handleCreate()
+          this.props.setModalOpen(false)}}}
         scroll="paper"
       >
         <FormGroup>


### PR DESCRIPTION
This PR fixes the problem of enter not always working in the create modal. 

**How to test**

- Create a new wiki page, type a title and go configure the page by expanding the modal. Hit enter and the page will be created if there are no errors. 

**Asana issue**
https://app.asana.com/0/1121331595459324/1125445940645551/f
