### PR TITLE
Fix anonymous users in wiki, and updating user account with ShareDB

### DIFF
--- a/frog-utils/src/TextInput.js
+++ b/frog-utils/src/TextInput.js
@@ -12,7 +12,8 @@ type TextInputPropsT = {
   clearOnEnter?: boolean,
   style?: Object,
   noBlur?: boolean,
-  placeholder?: string
+  placeholder?: string,
+  penOnLeft?: boolean
 };
 
 export class TextInput extends React.Component<
@@ -46,10 +47,13 @@ export class TextInput extends React.Component<
     }
   };
 
-  onSubmit = (e: any) => {
+  onSubmit = async (e: any) => {
     e.preventDefault();
     if (this.props.onSubmit) {
-      this.props.onSubmit(this.state.value);
+      const result = await this.props.onSubmit(this.state.value);
+      if (result === false) {
+        this.setState({ value: this.props.value || '' });
+      }
     }
   };
 
@@ -125,17 +129,30 @@ export class ChangeableText extends React.Component<
         <EditComponent
           value={this.state.value}
           {...rest}
-          onSubmit={e => {
+          onSubmit={async e => {
             this.setState({ edit: false, value: e });
             if (this.props.onSubmit) {
-              this.props.onSubmit(e);
+              const result = await this.props.onSubmit(e);
+              if (result === false) {
+                this.setState({ value: this.props.value });
+                return false;
+              }
             }
           }}
         />
       );
     } else {
       return (
-        <span>
+        <span className="hoverable">
+          {this.props.penOnLeft && (
+            <i
+              role="button"
+              tabIndex={0}
+              style={{ color: 'blue' }}
+              onClick={() => this.setState({ edit: true })}
+              className={`fa fa-pencil ${onlyHover ? 'show-on-hover' : ''}`}
+            />
+          )}
           <span
             role="button"
             tabIndex={0}
@@ -144,13 +161,15 @@ export class ChangeableText extends React.Component<
             &nbsp;
             {this.state.value}
           </span>
-          <i
-            role="button"
-            tabIndex={0}
-            style={{ color: 'blue' }}
-            onClick={() => this.setState({ edit: true })}
-            className={`fa fa-pencil ${onlyHover ? 'edithover' : ''}`}
-          />
+          {!this.props.penOnLeft && (
+            <i
+              role="button"
+              tabIndex={0}
+              style={{ color: 'blue' }}
+              onClick={() => this.setState({ edit: true })}
+              className={`fa fa-pencil ${onlyHover ? 'show-on-hover' : ''}`}
+            />
+          )}
         </span>
       );
     }

--- a/frog/imports/client/App/index.js
+++ b/frog/imports/client/App/index.js
@@ -27,6 +27,7 @@ import StudentLogin from '../StudentView/StudentLogin';
 import { LocalSettings } from '/imports/api/settings';
 import Wiki from '../Wiki';
 import SingleActivity from '../SingleActivity';
+import { connection } from './connection';
 
 const TeacherContainer = Loadable({
   loader: () => import('./TeacherContainer'),
@@ -60,9 +61,15 @@ const subscriptionCallback = (error, response, setState, storeInSession) => {
       );
     } else {
       Meteor.connection.setUserId(response.id);
+      connection.createFetchQuery('rz', { resetUserId: Meteor.userId() });
     }
 
-    Meteor.subscribe('userData', { onReady: () => setState('ready') });
+    Meteor.subscribe('userData', {
+      onReady: () => {
+        setState('ready');
+        connection.createFetchQuery('rz', { resetUserId: Meteor.userId() });
+      }
+    });
   }
 };
 
@@ -89,7 +96,10 @@ const FROGRouter = withRouter(
       this.state = { mode: 'waiting' };
       if (Meteor.user()) {
         Meteor.subscribe('userData', {
-          onReady: () => this.setState({ mode: 'ready' })
+          onReady: () => {
+            this.setState({ mode: 'ready' });
+            connection.createFetchQuery('rz', { resetUserId: Meteor.userId() });
+          }
         });
       }
     }
@@ -128,6 +138,9 @@ const FROGRouter = withRouter(
         isStudentList,
         this.props.match.params.slug,
         (err, id) => {
+          if (id) {
+            connection.createFetchQuery('rz', { resetUserId: Meteor.userId() });
+          }
           subscriptionCallback(
             err,
             id,
@@ -148,6 +161,9 @@ const FROGRouter = withRouter(
         } else {
           Meteor.subscribe('userData', {
             onReady: () => {
+              connection.createFetchQuery('rz', {
+                resetUserId: Meteor.userId()
+              });
               this.setState({ mode: 'ready' });
             }
           });

--- a/frog/imports/client/Wiki/components/TopNavbar/PrimaryButton.js
+++ b/frog/imports/client/Wiki/components/TopNavbar/PrimaryButton.js
@@ -11,7 +11,7 @@ type PrimaryButtonPropsT = {
 };
 
 export default (props: PrimaryButtonPropsT) => {
-  const { active, title, icon, callback, italics } = props;
+  const { children, active, title, icon, callback, italics } = props;
 
   const Icon = icon;
 
@@ -36,7 +36,10 @@ export default (props: PrimaryButtonPropsT) => {
           color={active ? 'secondary' : 'primary'}
         />
       ) : null}
-      <span>{title}</span>
+      <>
+        <span>{title}</span>
+        {children}
+      </>
     </div>
   );
 };

--- a/frog/imports/client/Wiki/components/TopNavbar/index.js
+++ b/frog/imports/client/Wiki/components/TopNavbar/index.js
@@ -52,14 +52,14 @@ const TopNavbar = (props: TopNavBarPropsT) => {
       {primaryNavItems.map((item, index) => (
         <PrimaryButton key={index} {...item} />
       ))}
-      <div style={isAnonymous ? { fontStyle: 'italic' } : {}}>
+      <PrimaryButton style={isAnonymous ? { fontStyle: 'italic' } : {}}>
         <ChangeableText
           penOnLeft
           onlyHover
-          value={isAnonymous ? 'Anonymous User' : username}
+          value={username}
           onSubmit={changeUsername}
         />
-      </div>
+      </PrimaryButton>
       <OverflowPanel overflowElements={secondaryNavItems} />
     </div>
   );

--- a/frog/imports/client/Wiki/components/TopNavbar/index.js
+++ b/frog/imports/client/Wiki/components/TopNavbar/index.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 
+import { ChangeableText } from 'frog-utils';
 import PrimaryButton from './PrimaryButton';
 import OverflowPanel from './OverflowPanel';
 
@@ -9,6 +10,7 @@ type TopNavBarPropsT = {
   username: string,
   // Status of the user, username will be displayed in italics if true
   isAnonymous: boolean,
+  changeUsername: Function,
   // List of buttons to display in the primary view
   primaryNavItems: Array<{
     active?: boolean,
@@ -30,7 +32,13 @@ type TopNavBarPropsT = {
  * Controls can be primary (displayed horizontally), or secondary (displayed in a dropdown).
  */
 const TopNavbar = (props: TopNavBarPropsT) => {
-  const { username, isAnonymous, primaryNavItems, secondaryNavItems } = props;
+  const {
+    username,
+    isAnonymous,
+    primaryNavItems,
+    secondaryNavItems,
+    changeUsername
+  } = props;
 
   return (
     <div
@@ -44,7 +52,14 @@ const TopNavbar = (props: TopNavBarPropsT) => {
       {primaryNavItems.map((item, index) => (
         <PrimaryButton key={index} {...item} />
       ))}
-      <PrimaryButton key="username" title={username} italics={isAnonymous} />
+      <div style={isAnonymous ? { fontStyle: 'italic' } : {}}>
+        <ChangeableText
+          penOnLeft
+          onlyHover
+          value={isAnonymous ? 'Anonymous User' : username}
+          onSubmit={changeUsername}
+        />
+      </div>
       <OverflowPanel overflowElements={secondaryNavItems} />
     </div>
   );

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -70,7 +70,9 @@ type WikiCompStateT = {
   findModalOpen: boolean,
   search: '',
   urlInstance: ?string,
-  noInstance: ?boolean
+  noInstance: ?boolean,
+  username: string,
+  isAnonymous: boolean
 };
 
 class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
@@ -99,6 +101,8 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     const query = queryToObject(this.props.location.search.slice(1));
 
     this.state = {
+      username: Meteor.user().username,
+      isAnonymous: Meteor.user().isAnonymous,
       pagesData: null,
       dashboardSearch: null,
       pageId: null,
@@ -653,8 +657,20 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
           {sideNavBar}
           <div style={contentDivStyle}>
             <WikiTopNavbar
-              username={Meteor.user().username}
-              isAnonymous={Meteor.user().isAnonymous}
+              username={this.state.username}
+              isAnonymous={this.state.isAnonymous}
+              changeUsername={async e => {
+                const err = await new Promise(resolve =>
+                  Meteor.call('change.username', e, error => resolve(error))
+                );
+                if (err?.error === 'User already exists') {
+                  window.alert('Username already exists');
+                  return false;
+                } else {
+                  this.setState({ username: e, isAnonymous: false });
+                  return true;
+                }
+              }}
               primaryNavItems={primaryNavItems}
               secondaryNavItems={secondaryNavItems}
             />

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -101,7 +101,9 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     const query = queryToObject(this.props.location.search.slice(1));
 
     this.state = {
-      username: Meteor.user().username,
+      username: Meteor.user().isAnonymous
+        ? 'Anonymous User'
+        : Meteor.user().username,
       isAnonymous: Meteor.user().isAnonymous,
       pagesData: null,
       dashboardSearch: null,

--- a/frog/server/share-db-manager.js
+++ b/frog/server/share-db-manager.js
@@ -152,8 +152,8 @@ const sharedbGetRevisionList = (coll, id) =>
                   data: cloneDeep(last),
                   contributors: Object.keys(contributors).map(x => {
                     const userObj = Meteor.users.findOne(x);
-                    return userObj && !user.isAnonymous
-                      ? user.username
+                    return userObj && !userObj?.isAnonymous
+                      ? userObj.username
                       : 'Anonymous User';
                   }),
                   time: op.m.ts

--- a/frog/server/share-db-manager.js
+++ b/frog/server/share-db-manager.js
@@ -150,9 +150,12 @@ const sharedbGetRevisionList = (coll, id) =>
               if (tsDiff > 30000 || i === res.length - 1) {
                 milestoneOpsIndices.push({
                   data: cloneDeep(last),
-                  contributors: Object.keys(contributors).map(
-                    x => Meteor.users.findOne(x)?.username
-                  ),
+                  contributors: Object.keys(contributors).map(x => {
+                    const userObj = Meteor.users.findOne(x);
+                    return userObj && !user.isAnonymous
+                      ? user.username
+                      : 'Anonymous User';
+                  }),
                   time: op.m.ts
                 });
                 contributors = {};

--- a/frog/server/share-db-manager.js
+++ b/frog/server/share-db-manager.js
@@ -60,6 +60,15 @@ export const startShareDB = () => {
         next();
       });
 
+      backend.use('query', (request, next) => {
+        if (request.query?.resetUserId) {
+          Object.assign(request.agent.custom, {
+            userId: request.query?.resetUserId
+          });
+          next('400: Userid reset successfully');
+        }
+        next();
+      });
       backend.use('submit', (request, next) => {
         request.op.m.userId = request.agent.custom.userId;
         next();

--- a/frog/server/user_accounts.js
+++ b/frog/server/user_accounts.js
@@ -22,7 +22,7 @@ const doLogin = (user, self) => {
   );
   Meteor.users.update(userId, {
     $set: {
-      username: user || 'Anonymous User',
+      username: user || uuid(),
       isAnonymous: !user
     }
   });


### PR DESCRIPTION
This PR adds a way of updating the current user in the ShareDB module after the websocket has connected. This is a bit of a hack - we make a specific fetchQuery (we could have made an op, but then we would need a document, fetchQuery can be done directly on the connection), but then intercept it using middleware and instead update the userid. 

I also made it possible to rename the wiki user. This is in anticipation of all the RFC work around accounts, just a quick fix. And I made sure that each user in the wiki is actually different (previously all anonymous users were the same user). 

If you wish to log out the user when you are testing, you can open dev tools, go to Application/Local Storage, and delete the data. (Or add ?reset=true to the URL)

Desired functionality:
- the user in ShareDB is always up to date, even when logging in and logging out without reloading the page, when being automatically logged in as an anonymous user, etc. (You can see this on the op.m.userid field in o_li, or in the Revisions of the wiki).
- when a user is anonymous, we always show "Anonymous User" and never the uuid
- a user can try to change their username. if the username exists, they get a warning, and the displayed username stays Anonymous...
- when a user changes their username, you can see the new username in Revisions etc.
- when two users logs in anonymously in two different browsers, they are logged in as two different anonymous users

Known bugs:
The intercepted fetchQuery results in a console.error because we are not properly catching the error. This doesn't seem to harm anything else, I will add an Asana task to look into this in the future. 

Other concerns:
- I modified the ChangeableText component to be able to place the pen on the left, to correctly hide until hover, and to cancel updating if the onChange returns false