### PR TITLE
Function to list pages from a Wiki

### DIFF
--- a/frog/imports/client/Wiki/helpers.js
+++ b/frog/imports/client/Wiki/helpers.js
@@ -106,7 +106,7 @@ const listWikis = async () => {
 };
 
 /**
- * Function to get the pages of all pages in a wiki
+ * Function to get the pages of all (valid) pages in a wiki
  * @param {wikiDoc} ShareDB document corresponding to the Wiki
  * @return{Array} Array of pages in the form of [Title, ID] 
  */

--- a/frog/imports/client/Wiki/helpers.js
+++ b/frog/imports/client/Wiki/helpers.js
@@ -108,13 +108,12 @@ const listWikis = async () => {
 /**
  * Function to get the pages of all (valid) pages in a wiki
  * @param {wikiDoc} ShareDB document corresponding to the Wiki
- * @return{Array} Array of pages in the form of [Title, ID] 
+ * @return{Promise} A Promise that resolves into an array of pages in the form of [Title, ID] 
  */
 const listPages = wikiDoc => {
   return new Promise((resolve, reject) =>
     wikiDoc.fetch(err => {
       if (err) {
-        // eslint-disable-next-line no-console
         reject(Error('Unable to fetch the Wiki Document'));
       }
       resolve(

--- a/frog/imports/client/Wiki/helpers.js
+++ b/frog/imports/client/Wiki/helpers.js
@@ -107,10 +107,11 @@ const listWikis = async () => {
 
 /**
  * Function to get the pages of all (valid) pages in a wiki
- * @param {wikiDoc} ShareDB document corresponding to the Wiki
+ * @param {string} wikiId: id of the wiki to list
  * @return{Promise} A Promise that resolves into an array of pages in the form of [Title, ID] 
  */
-const listPages = wikiDoc => {
+const listPages = (wikiId: string) => {
+  const wikiDoc = connection.get('wiki', wikiId);
   return new Promise((resolve, reject) =>
     wikiDoc.fetch(err => {
       if (err) {

--- a/frog/imports/client/Wiki/helpers.js
+++ b/frog/imports/client/Wiki/helpers.js
@@ -106,18 +106,26 @@ const listWikis = async () => {
 };
 
 // Function to get the pages of all pages in a wiki, returns [Title, ID]
-const listPages = async (wikiDoc) => {
+const listPages = async wikiDoc => {
   const list = await new Promise(resolve =>
     wikiDoc.fetch(err => {
-      if(err) {
-        console.log("Unable to fetch");
+      if (err) {
+        // eslint-disable-next-line no-console
+        console.log('Unable to fetch');
         return;
       }
-      resolve(Object.keys(wikiDoc.data.pages).filter(key => wikiDoc.data.pages[key].created && wikiDoc.data.pages[key].valid).map(key => [wikiDoc.data.pages[key].title, key])); 
+      resolve(
+        Object.keys(wikiDoc.data.pages)
+          .filter(
+            key =>
+              wikiDoc.data.pages[key].created && wikiDoc.data.pages[key].valid
+          )
+          .map(key => [wikiDoc.data.pages[key].title, key])
+      );
     })
   );
   return list;
-}
+};
 
 export {
   parseDocResults,

--- a/frog/imports/client/Wiki/helpers.js
+++ b/frog/imports/client/Wiki/helpers.js
@@ -105,14 +105,17 @@ const listWikis = async () => {
   });
 };
 
-// Function to get the pages of all pages in a wiki, returns [Title, ID]
-const listPages = async wikiDoc => {
-  const list = await new Promise(resolve =>
+/**
+ * Function to get the pages of all pages in a wiki
+ * @param {wikiDoc} ShareDB document corresponding to the Wiki
+ * @return{Array} Array of pages in the form of [Title, ID] 
+ */
+const listPages = wikiDoc => {
+  return new Promise((resolve, reject) =>
     wikiDoc.fetch(err => {
       if (err) {
         // eslint-disable-next-line no-console
-        console.log('Unable to fetch');
-        return;
+        reject(Error('Unable to fetch the Wiki Document'));
       }
       resolve(
         Object.keys(wikiDoc.data.pages)
@@ -124,7 +127,6 @@ const listPages = async wikiDoc => {
       );
     })
   );
-  return list;
 };
 
 export {

--- a/frog/imports/client/Wiki/helpers.js
+++ b/frog/imports/client/Wiki/helpers.js
@@ -105,6 +105,20 @@ const listWikis = async () => {
   });
 };
 
+// Function to get the pages of all pages in a wiki, returns [Title, ID]
+const listPages = async (wikiDoc) => {
+  const list = await new Promise(resolve =>
+    wikiDoc.fetch(err => {
+      if(err) {
+        console.log("Unable to fetch");
+        return;
+      }
+      resolve(Object.keys(wikiDoc.data.pages).filter(key => wikiDoc.data.pages[key].created && wikiDoc.data.pages[key].valid).map(key => [wikiDoc.data.pages[key].title, key])); 
+    })
+  );
+  return list;
+}
+
 export {
   parseDocResults,
   parseSearch,
@@ -112,5 +126,6 @@ export {
   checkNewPageTitle,
   getDifferentPageId,
   getPageDetailsForLiId,
-  listWikis
+  listWikis,
+  listPages
 };


### PR DESCRIPTION
**Description**
This is a minor PR which introduces a function to list all the pages of a wiki.

**How to test?**
This would be used in future PRs, but could be tested by calling `listPages()` from `frog/imports/client/Wiki/helpers.js`
