### PR TITLE
Trimming of leading, trailing and extra spaces on the Wiki page titles

### DIFF
--- a/frog-utils/src/ReactiveRichText/main.js
+++ b/frog-utils/src/ReactiveRichText/main.js
@@ -4,11 +4,6 @@ import '@houshuang/react-quill/dist/quill.snow.css';
 import React, { Component } from 'react';
 import uuid from 'cuid';
 import ReactQuill, { Quill } from '@houshuang/react-quill';
-import { HighlightSearchText } from '../HighlightSearchText';
-import { highlightTargetRichText } from '../highlightTargetRichText';
-import { cloneDeep } from '../cloneDeep';
-import { WikiContext } from '../WikiContext';
-
 import {
   isEmpty,
   get,
@@ -21,6 +16,10 @@ import {
   debounce
 } from 'lodash';
 import Dialog from '@material-ui/core/Dialog';
+import { HighlightSearchText } from '../HighlightSearchText';
+import { highlightTargetRichText } from '../highlightTargetRichText';
+import { cloneDeep } from '../cloneDeep';
+import { WikiContext } from '../WikiContext';
 
 import { LiViewTypes, formats } from './constants';
 import getLearningItemBlot from './LearningItemBlot';
@@ -38,7 +37,7 @@ Quill.register('formats/wiki-link', WikiLinkBlot);
 // The below placeholder object is used to pass the parameters from the 'dataFn' prop
 // from the main component to other ones. Generic definition to understand the structure
 // and satisfy Flow's requirements
-let reactiveRichTextDataFn = {
+const reactiveRichTextDataFn = {
   getLearningTypesObj: () => {
     throw new Error('Should never be uninitialized');
   },

--- a/frog-utils/src/browserOnlyComponents.js
+++ b/frog-utils/src/browserOnlyComponents.js
@@ -1,5 +1,5 @@
 // @flow
-/***
+/** *
  * This file specifies a number of components that should only be available when
  * frog-utils is accessed from a browser instance. If this is not the case, the
  * components will be replaced with dummy alternatives.

--- a/frog-utils/src/browserOnlyComponents.js
+++ b/frog-utils/src/browserOnlyComponents.js
@@ -1,5 +1,5 @@
 // @flow
-/** *
+/***
  * This file specifies a number of components that should only be available when
  * frog-utils is accessed from a browser instance. If this is not the case, the
  * components will be replaced with dummy alternatives.

--- a/frog-utils/src/dashboards/progress.js
+++ b/frog-utils/src/dashboards/progress.js
@@ -1,8 +1,6 @@
 // @flow
 
 import * as React from 'react';
-import { type LogDbT, type ActivityDbT } from '../types';
-import { values } from '../toArray';
 import {
   VictoryChart,
   VictoryLine,
@@ -10,6 +8,8 @@ import {
   VictoryLegend,
   VictoryAxis
 } from 'victory';
+import { type LogDbT, type ActivityDbT } from '../types';
+import { values } from '../toArray';
 
 const Viewer = (props: Object) => {
   const { state, activity } = props;

--- a/frog/imports/client/TeacherView/SessionUtils.jsx
+++ b/frog/imports/client/TeacherView/SessionUtils.jsx
@@ -177,7 +177,9 @@ const SessionUtils = ({
         </Typography>
       </Grid>
       <Grid item xs={4} className={classes.textCenter}>
-        {!session.singleActivity && <DashToggle visible={visible} toggleVisible={toggle} />}
+        {!session.singleActivity && (
+          <DashToggle visible={visible} toggleVisible={toggle} />
+        )}
       </Grid>
       <Grid item xs={4} style={{ textAlign: 'right' }}>
         <UtilsMenu classes={classes} buttonsModel={buttonsModel} />

--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -13,7 +13,11 @@ import LIDashboard from '../Dashboard/LIDashboard';
 import Revisions from './Revisions';
 import WikiLink from './WikiLink';
 import { LearningItem } from './wikiLearningItem';
-import { getPageDetailsForLiId, checkNewPageTitle } from './helpers.js';
+import {
+  getPageDetailsForLiId,
+  checkNewPageTitle,
+  sanitizeTitle
+} from './helpers.js';
 
 class WikiContentComp extends React.Component<> {
   constructor(props) {
@@ -83,7 +87,7 @@ class WikiContentComp extends React.Component<> {
 
     if (
       error === null ||
-      pageTitleString === this.props.currentPageObj?.title
+      sanitizeTitle(pageTitleString) === this.props.currentPageObj?.title
     ) {
       this.props.changeTitle(this.props.currentPageObj.id, pageTitleString);
       this.setState({
@@ -91,7 +95,9 @@ class WikiContentComp extends React.Component<> {
         editingTitle: false,
         showTitleEditButton: false,
         error:
-          pageTitleString === this.props.currentPageObj?.title ? null : error
+          sanitizeTitle(pageTitleString) === this.props.currentPageObj?.title
+            ? null
+            : error
       });
     }
   };

--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -91,7 +91,7 @@ class WikiContentComp extends React.Component<> {
     ) {
       this.props.changeTitle(this.props.currentPageObj.id, pageTitleString);
       this.setState({
-        pageTitleString,
+        pageTitleString: sanitizeTitle(pageTitleString),
         editingTitle: false,
         showTitleEditButton: false,
         error:

--- a/frog/imports/client/Wiki/WikiWrapper.js
+++ b/frog/imports/client/Wiki/WikiWrapper.js
@@ -14,6 +14,15 @@ type PropsT = {
   embed: boolean
 };
 
+// Redirects user to home if they don't specify a page and decodes the page title from the uri
+const decodePageTitle = (currentTitle: string): string => {
+  if (decodeURIComponent(currentTitle) === 'undefined') {
+    return 'Home';
+  }
+
+  return decodeURIComponent(currentTitle);
+};
+
 /**
  * Wraps the wiki for the router and handles URL changes
  */
@@ -22,27 +31,24 @@ function WikiWrapper(props: PropsT) {
     <Wiki
       pageObj={{
         wikiId: props.match.params.wikiId,
-        pageTitle: props.match.params.pageTitle,
+        pageTitle: decodePageTitle(props.match.params.pageTitle),
         instance: props.match.params.instance
       }}
       // Function to navigate to a page
       setPage={(pageObj: PageObjT, replace?: boolean) => {
+        const encodedTitle = encodeURIComponent(pageObj.pageTitle);
         if (pageObj.instance) {
           replace
             ? props.history.replace(
-                `/wiki/${pageObj.wikiId}/${pageObj.pageTitle}/${pageObj.instance}`
+                `/wiki/${pageObj.wikiId}/${encodedTitle}/${pageObj.instance}`
               )
             : props.history.push(
-                `/wiki/${pageObj.wikiId}/${pageObj.pageTitle}/${pageObj.instance}`
+                `/wiki/${pageObj.wikiId}/${encodedTitle}/${pageObj.instance}`
               );
         } else if (pageObj.pageTitle) {
           replace
-            ? props.history.replace(
-                `/wiki/${pageObj.wikiId}/${pageObj.pageTitle}`
-              )
-            : props.history.push(
-                `/wiki/${pageObj.wikiId}/${pageObj.pageTitle}`
-              );
+            ? props.history.replace(`/wiki/${pageObj.wikiId}/${encodedTitle}`)
+            : props.history.push(`/wiki/${pageObj.wikiId}/${encodedTitle}`);
         } else if (pageObj.wikiId) {
           replace
             ? props.history.replace(`/wiki/${pageObj.wikiId}`)

--- a/frog/imports/client/Wiki/WikiWrapper.js
+++ b/frog/imports/client/Wiki/WikiWrapper.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { withRouter } from 'react-router';
 import { toObject as queryToObject } from 'query-parse';
 import Wiki, { type PageObjT } from './index';
+import {sanitizeTitle} from './helpers'; 
 
 type PropsT = {
   location: *,
@@ -19,8 +20,8 @@ const decodePageTitle = (currentTitle: string): string => {
   if (decodeURIComponent(currentTitle) === 'undefined') {
     return 'Home';
   }
-
-  return decodeURIComponent(currentTitle);
+  const sanitizedCurrentTitle = sanitizeTitle(currentTitle)
+  return decodeURIComponent(sanitizedCurrentTitle);
 };
 
 /**

--- a/frog/imports/client/Wiki/WikiWrapper.js
+++ b/frog/imports/client/Wiki/WikiWrapper.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { withRouter } from 'react-router';
 import { toObject as queryToObject } from 'query-parse';
 import Wiki, { type PageObjT } from './index';
-import {sanitizeTitle} from './helpers'; 
+import { sanitizeTitle } from './helpers';
 
 type PropsT = {
   location: *,
@@ -20,7 +20,7 @@ const decodePageTitle = (currentTitle: string): string => {
   if (decodeURIComponent(currentTitle) === 'undefined') {
     return 'Home';
   }
-  const sanitizedCurrentTitle = sanitizeTitle(currentTitle)
+  const sanitizedCurrentTitle = sanitizeTitle(currentTitle);
   return decodeURIComponent(sanitizedCurrentTitle);
 };
 

--- a/frog/imports/client/Wiki/helpers.js
+++ b/frog/imports/client/Wiki/helpers.js
@@ -128,6 +128,15 @@ const listPages = (wikiId: string) => {
     })
   );
 };
+/**
+ * Function that removes the leading and trailing spaces from the given string.
+ * @param {string} title
+ * @return {string} the santized title
+ */
+
+const sanitizeTitle = (title: string): string => {
+  return title.trim();
+};
 
 export {
   parseDocResults,
@@ -137,5 +146,6 @@ export {
   getDifferentPageId,
   getPageDetailsForLiId,
   listWikis,
-  listPages
+  listPages,
+  sanitizeTitle
 };

--- a/frog/imports/client/Wiki/helpers.js
+++ b/frog/imports/client/Wiki/helpers.js
@@ -131,11 +131,11 @@ const listPages = (wikiId: string) => {
 /**
  * Function that removes the leading and trailing spaces from the given string.
  * @param {string} title
- * @return {string} the sanitized i.e. trimmed title
+ * @return {string} the sanitized i.e. trimmed title with extra spaces in between words also removed
  */
 
 const sanitizeTitle = (title: string): string => {
-  return title.trim();
+  return title.replace(/\s+/g," ").trim();
 };
 
 export {

--- a/frog/imports/client/Wiki/helpers.js
+++ b/frog/imports/client/Wiki/helpers.js
@@ -135,7 +135,7 @@ const listPages = (wikiId: string) => {
  */
 
 const sanitizeTitle = (title: string): string => {
-  return title.replace(/\s+/g," ").trim();
+  return title.replace(/\s+/g, ' ').trim();
 };
 
 export {

--- a/frog/imports/client/Wiki/helpers.js
+++ b/frog/imports/client/Wiki/helpers.js
@@ -131,7 +131,7 @@ const listPages = (wikiId: string) => {
 /**
  * Function that removes the leading and trailing spaces from the given string.
  * @param {string} title
- * @return {string} the santized title
+ * @return {string} the sanitized i.e. trimmed title
  */
 
 const sanitizeTitle = (title: string): string => {

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -15,7 +15,12 @@ import Delete from '@material-ui/icons/Delete';
 import RestorePage from '@material-ui/icons/RestorePage';
 
 import { connection } from '../App/connection';
-import { getPageTitle, getDifferentPageId, checkNewPageTitle } from './helpers';
+import {
+  getPageTitle,
+  getDifferentPageId,
+  checkNewPageTitle,
+  sanitizeTitle
+} from './helpers';
 import {
   invalidateWikiPage,
   changeWikiPageTitle,
@@ -102,7 +107,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
       dashboardSearch: null,
       pageId: null,
       currentPageObj: null,
-      initialPageTitle: this.decodePageTitle(this.props.pageObj.pageTitle),
+      initialPageTitle: this.props.pageObj.pageTitle,
       mode: 'document',
       docMode: query?.edit ? 'edit' : 'view',
       error: null,
@@ -143,11 +148,11 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
   }
 
   componentDidUpdate(prevProps) {
-    const pageTitle = this.decodePageTitle(this.props.pageObj.pageTitle);
+    const pageTitle = this.props.pageObj.pageTitle;
 
     if (
       (pageTitle !== this.state.currentPageObj?.title &&
-        this.decodePageTitle(prevProps.pageObj.pageTitle) !== pageTitle) ||
+        prevProps.pageObj.pageTitle !== pageTitle) ||
       prevProps.pageObj.instance !== this.props.pageObj.instance
     ) {
       this.goToPageTitle(pageTitle, this.props.pageObj.instance);
@@ -197,25 +202,10 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     }
   };
 
-  decodePageTitle = (currentTitle: string): string => {
-    if (decodeURIComponent(currentTitle) === 'undefined') {
-      this.props.setPage({
-        wikiId: this.wikiId,
-        pageTitle: 'Home'
-      });
-      return 'Home';
-    }
-
-    return decodeURIComponent(currentTitle);
-  };
-
   handleInitialLoad = () => {
     this.initialLoad = false;
     const parsedPages = wikiStore.parsedPages;
-    const pageTitle = getPageTitle(
-      parsedPages,
-      this.decodePageTitle(this.state.initialPageTitle)
-    );
+    const pageTitle = getPageTitle(parsedPages, this.state.initialPageTitle);
     const pageTitleLower = pageTitle.toLowerCase();
     const fullPageObj = parsedPages[pageTitleLower];
 
@@ -262,7 +252,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
         const instanceName = this.getInstanceNameForId(fullPageObj, instanceId);
         this.props.setPage({
           wikiId: this.wikiId,
-          pageTitle: encodeURIComponent(currentPageObj.title),
+          pageTitle: currentPageObj.title,
           instance:
             instanceId && instanceId !== this.getInstanceId(fullPageObj)
               ? instanceName
@@ -376,11 +366,11 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
   };
 
   changeTitle = (pageId, newPageTitle) => {
-    changeWikiPageTitle(this.wikiDoc, pageId, newPageTitle);
+    changeWikiPageTitle(this.wikiDoc, pageId, sanitizeTitle(newPageTitle));
     this.props.setPage(
       {
         wikiId: this.wikiId,
-        pageTitle: encodeURIComponent(newPageTitle),
+        pageTitle: newPageTitle,
         instance: this.props.pageObj.instance
       },
       true
@@ -438,7 +428,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
           this.props.setPage(
             {
               wikiId: this.wikiId,
-              pageTitle: encodeURIComponent(newCurrentPageObj.title),
+              pageTitle: newCurrentPageObj.title,
               instance:
                 instanceId && instanceId !== this.getInstanceId(fullPageObj)
                   ? instanceName
@@ -450,7 +440,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
         }
         this.props.setPage({
           wikiId: this.wikiId,
-          pageTitle: encodeURIComponent(newCurrentPageObj.title),
+          pageTitle: newCurrentPageObj.title,
           instance:
             instanceId && instanceId !== this.getInstanceId(fullPageObj)
               ? instanceName
@@ -461,7 +451,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
   };
 
   goToPageTitle = (pageTitle, instanceName, side) => {
-    const pageTitleLower = pageTitle.toLowerCase();
+    const pageTitleLower = sanitizeTitle(pageTitle.toLowerCase());
     const pageId = wikiStore.parsedPages[pageTitleLower].id;
     const instanceId = this.getInstanceIdForName(
       wikiStore.parsedPages[pageTitleLower],
@@ -485,7 +475,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     const liId = createNewLI(this.wikiId, liType, activityConfig, title);
     const pageId = addNewWikiPage(
       this.wikiDoc,
-      title,
+      sanitizeTitle(title),
       true,
       liType,
       liId,
@@ -504,7 +494,14 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     }
     const liType = 'li-richText';
     const liId = createNewLI(this.wikiId, liType, undefined, title);
-    const pageId = addNewWikiPage(this.wikiDoc, title, false, liType, liId, 3);
+    const pageId = addNewWikiPage(
+      this.wikiDoc,
+      sanitizeTitle(title),
+      false,
+      liType,
+      liId,
+      3
+    );
     return { liId, pageId };
   };
 

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -488,7 +488,8 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
   // there is a link to a page that has not yet been formally created, until
   // clicked upon, but we still keep track of it.
   addNonActivePage = title => {
-    const existingPage = wikiStore.pagesByTitle[title];
+    const sanitizedTitle = sanitizeTitle(title);
+    const existingPage = wikiStore.pagesByTitle[sanitizedTitle];
     if (existingPage) {
       return { liId: existingPage.liId, pageId: existingPage.id };
     }
@@ -496,7 +497,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     const liId = createNewLI(this.wikiId, liType, undefined, title);
     const pageId = addNewWikiPage(
       this.wikiDoc,
-      sanitizeTitle(title),
+      sanitizedTitle,
       false,
       liType,
       liId,

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -370,7 +370,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     this.props.setPage(
       {
         wikiId: this.wikiId,
-        pageTitle: newPageTitle,
+        pageTitle: sanitizeTitle(newPageTitle),
         instance: this.props.pageObj.instance
       },
       true

--- a/frog/imports/client/Wiki/store.js
+++ b/frog/imports/client/Wiki/store.js
@@ -1,6 +1,6 @@
 import { extendObservable, action, toJS } from 'mobx';
 import { values } from 'frog-utils';
-import {sanitizeTitle} from './helpers'; 
+import { sanitizeTitle } from './helpers';
 
 class WikiStore {
   constructor() {

--- a/frog/imports/client/Wiki/store.js
+++ b/frog/imports/client/Wiki/store.js
@@ -1,5 +1,6 @@
 import { extendObservable, action, toJS } from 'mobx';
 import { values } from 'frog-utils';
+import {sanitizeTitle} from './helpers'; 
 
 class WikiStore {
   constructor() {
@@ -20,7 +21,7 @@ class WikiStore {
         // eslint-disable-next-line guard-for-in
         for (const pageId in this.pages) {
           const pageObj = this.pages[pageId];
-          pages[pageObj.title.toLowerCase()] = pageObj;
+          pages[sanitizeTitle(pageObj.title.toLowerCase())] = pageObj;
         }
         return pages;
       },

--- a/frog/imports/operatorTypes.js
+++ b/frog/imports/operatorTypes.js
@@ -4,9 +4,7 @@ import importAll from 'import-all.macro';
 import { type operatorPackageT, entries, values } from 'frog-utils';
 
 const packagesRaw = importAll.sync('../node_modules/op-*/src/index.js');
-const packagesRawInternal = importAll.sync(
-  './internalOperators/op-*/index.js'
-);
+const packagesRawInternal = importAll.sync('./internalOperators/op-*/index.js');
 
 const operatorsExt = entries(packagesRaw).reduce(
   (acc, [k, v]) => ({ ...acc, [k.split('/')[2]]: v.default }),


### PR DESCRIPTION
This PR fixes the issue of an extra leading and trailing space sometimes inserted at the end of the wiki page title. 

**Testing instructions**

- Create a wiki page title with leading,  trailing and extra spaces between the words using either the CreateModal, RRT links or renaming an existing page. 

- Now, the spaces at the beginning, the end and extra spaces between words of the title will be removed. (see the URL bar) 

**Asana issue**
https://app.asana.com/0/1121331595459324/1129368571245493/f