### PR TITLE
Enabling operators in the wiki

### DIFF
--- a/frog/imports/api/generateReactiveFn.js
+++ b/frog/imports/api/generateReactiveFn.js
@@ -157,11 +157,15 @@ export class Doc {
     }
   };
 
-  duplicateLI = async (li: string | Object, meta?: Object) => {
+  duplicateLI = async (
+    li: string | Object,
+    meta?: Object,
+    instanceId?: string
+  ) => {
     if (typeof li !== 'string') {
       const liT = learningItemTypesObj[li.liDocument.liType];
       if (liT.duplicate) {
-        return liT.duplicate(li, this, this.meta);
+        return liT.duplicate(li, this, this.meta, instanceId);
       } else {
         return li;
       }
@@ -186,23 +190,6 @@ export class Doc {
       'li',
       id
     );
-    if (LIData.liType === 'li-activity') {
-      // In this case the activity also needs to be duplicated
-      const acData = await new Promise(resolve => {
-        const ac = connection.get('rz', LIData.payload.rz);
-        ac.fetch();
-        if (ac.type) {
-          resolve(ac.data);
-        }
-        ac.once('load', () => {
-          resolve(ac.data);
-        });
-      });
-      const acId = uuid();
-      const activityPointer = connection.get('rz', acId);
-      activityPointer.create(acData || {});
-      LIData.payload.rz = acId;
-    }
     const newLI = {
       ...LIData,
       createdAt: new Date(),

--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -265,6 +265,7 @@ class WikiContentComp extends React.Component<> {
                 >
                   {this.props.currentPageObj?.liId && (
                     <LearningItem
+                      disableDragging
                       type={this.state.docMode}
                       id={this.props.currentPageObj.liId}
                     />

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -331,7 +331,11 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
   };
 
   createNewInstancePage = async (pageObj, instanceId, instanceName) => {
-    const liId = await dataFn.duplicateLI(pageObj.liId);
+    const liId = await dataFn.duplicateLI(
+      pageObj.liId,
+      undefined,
+      instanceName
+    );
     addNewInstancePage(
       this.wikiDoc,
       pageObj.id,
@@ -461,7 +465,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
   };
 
   // Creates a new page entry in ShareDB and navigates to it.
-  createPage = (title, socialPlane, activityConfig, operatorConfig) => {
+  createPage = async (title, socialPlane, activityConfig, operatorConfig) => {
     const error =
       checkNewPageTitle(wikiStore.parsedPages, title) ||
       (activityConfig?.invalid && 'Activity config is not valid') ||
@@ -472,7 +476,20 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     }
     this.preventRenderUntilNextShareDBUpdate = true;
     const liType = activityConfig ? 'li-activity' : 'li-richText';
-    const liId = createNewLI(this.wikiId, liType, activityConfig, title);
+    let data = undefined;
+    if (operatorConfig) {
+      const { operatorType, config } = operatorConfig;
+      data = await new Promise((resolve, reject) =>
+        Meteor.call('run.operator', operatorType, config, (err, res) => {
+          if (err) {
+            reject(console.error(err));
+          } else {
+            resolve(res);
+          }
+        })
+      );
+    }
+    const liId = createNewLI(this.wikiId, liType, activityConfig, title, data);
     const pageId = addNewWikiPage(
       this.wikiDoc,
       sanitizeTitle(title),

--- a/frog/imports/client/Wiki/liDocHelpers.js
+++ b/frog/imports/client/Wiki/liDocHelpers.js
@@ -18,18 +18,18 @@ export const createNewLI = (
     // Need to create an entry for the activity in the 'rz' collection before creating the LI
     const { activityType, config } = activityConfig;
     const id = uuid();
-    const doc = connection.get('rz', id + '/all');
+    const doc = connection.get('rz', id);
     const dS = activityTypesObj[activityType].dataStructure;
     const initData = typeof dS === 'function' ? dS(config) : dS;
     doc.create(initData || {});
     const payload = {
       acType: activityType,
       activityData: { config },
-      rz: id + '/all',
+      rz: id,
       title: pageTitle,
       activityTypeTitle: activityTypesObj[activityType].meta.name
     };
-    return dataFn.createLearningItem(liType, payload, meta);
+    return dataFn.createLearningItem(liType, payload, meta, true);
   }
   return dataFn.createLearningItem(liType, undefined, meta);
 };


### PR DESCRIPTION
Need to rethink approach - there is a lot of logic in runDataFlow, mergeData etc but it depends on having Session, graphs with connections etc... Could we actually model a wiki as a hidden Session with connections etc, would save a lot of time/bugs to reuse existing machinery... Or do we need to make existing functions more flexible?