### PR TITLE
Remove .js from import statements

### DIFF
--- a/frog/imports/api/mergeLogData.js
+++ b/frog/imports/api/mergeLogData.js
@@ -6,7 +6,7 @@ import { cloneDeep } from 'lodash';
 import { activityTypesObj } from '../activityTypes';
 import { Logs } from './logs';
 import { DashboardStates } from './cache';
-import { Activities } from './activities.js';
+import { Activities } from './activities';
 
 const activityCache = {};
 

--- a/frog/imports/client/GraphEditor/components/Lines.js
+++ b/frog/imports/client/GraphEditor/components/Lines.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 
 import { connect, type StoreProp } from '../store';
-import Connection from '../store/connection.js';
+import Connection from '../store/connection';
 
 export const Line = observer(
   ({ connection, scaled }: { connection: Connection, scaled: boolean }) => (

--- a/frog/imports/internalOperators/op-aggregate/__tests__/index.js
+++ b/frog/imports/internalOperators/op-aggregate/__tests__/index.js
@@ -1,5 +1,5 @@
-import object from '../__fixtures__/object.js';
-import sumObject from '../__fixtures__/objectScore.js';
+import object from '../__fixtures__/object';
+import sumObject from '../__fixtures__/objectScore';
 import operator from '../operatorRunner';
 
 const op = operator;

--- a/frog/imports/internalOperators/op-dataset/__tests__/index.js
+++ b/frog/imports/internalOperators/op-dataset/__tests__/index.js
@@ -1,5 +1,5 @@
 import pkg from '../operatorRunner';
-import { object, coffeeConfig, heightConfig } from '../__fixtures__/coffee.js';
+import { object, coffeeConfig, heightConfig } from '../__fixtures__/coffee';
 
 test('coffee', () => {
   expect(pkg(coffeeConfig, object)).toEqual({

--- a/frog/imports/internalOperators/op-returnReviews/__tests__/index.js
+++ b/frog/imports/internalOperators/op-returnReviews/__tests__/index.js
@@ -1,5 +1,5 @@
 import pkg from '../operatorRunner';
-import { objectp2, result2 } from '../__fixtures__/index.js';
+import { objectp2, result2 } from '../__fixtures__';
 
 test('P2, 2 objects', () => {
   expect(pkg({}, objectp2)).toEqual(result2);

--- a/frog/imports/internalOperators/op-richtext-diff/__tests__/index.js
+++ b/frog/imports/internalOperators/op-richtext-diff/__tests__/index.js
@@ -1,5 +1,5 @@
 import ShareDB from 'sharedb';
-import { generateReactiveFn } from '../../../../frog/imports/api/generateReactiveFn.js';
+import { generateReactiveFn } from '../../../../frog/imports/api/generateReactiveFn';
 import op from '../operatorRunner';
 
 jest.spyOn(Date, 'now').mockImplementation(() => 1479427200000);

--- a/frog/imports/internalOperators/op-wrap-peer-review/__tests__/index.js
+++ b/frog/imports/internalOperators/op-wrap-peer-review/__tests__/index.js
@@ -2,7 +2,7 @@ import lodash from 'lodash';
 
 import ShareDB from 'sharedb';
 import operator from '../operatorRunner';
-import { generateReactiveFn } from '../../../../frog/imports/api/generateReactiveFn.js';
+import { generateReactiveFn } from '../../../../frog/imports/api/generateReactiveFn';
 
 lodash.shuffle = jest.fn(x => [...x].sort());
 jest.spyOn(Date, 'now').mockImplementation(() => 1479427200000);

--- a/frog/server/main.js
+++ b/frog/server/main.js
@@ -8,7 +8,7 @@ import { publishComposite } from 'meteor/reywood:publish-composite';
 import { uuid } from 'frog-utils';
 
 import { startShareDB } from './share-db-manager';
-import '../imports/startup/shutdown-if-env.js';
+import '../imports/startup/shutdown-if-env';
 
 import { Logs } from '../imports/api/logs';
 import teacherImports from './teacherImports';
@@ -17,13 +17,13 @@ import {
   findActivitiesMongo,
   Connections,
   DashboardData
-} from '../imports/api/activities.js';
-import { upgradeGraphMongo } from '../imports/api/graphs.js';
-import { Operators, findOperatorsMongo } from '../imports/api/operators.js';
-import { Sessions } from '../imports/api/sessions.js';
-import { Products } from '../imports/api/products.js';
-import { Objects } from '../imports/api/objects.js';
-import { GlobalSettings } from '../imports/api/settings.js';
+} from '../imports/api/activities';
+import { upgradeGraphMongo } from '../imports/api/graphs';
+import { Operators, findOperatorsMongo } from '../imports/api/operators';
+import { Sessions } from '../imports/api/sessions';
+import { Products } from '../imports/api/products';
+import { Objects } from '../imports/api/objects';
+import { GlobalSettings } from '../imports/api/settings';
 import dashboardSubscription from './dashboardSubscription';
 import './getLogMethods';
 import { activityTypesObj } from '../imports/activityTypes';

--- a/frog/server/teacherImports.js
+++ b/frog/server/teacherImports.js
@@ -5,13 +5,13 @@ import {
   Activities,
   Connections,
   DashboardData
-} from '../imports/api/activities.js';
-import { UploadList } from '../imports/api/openUploads.js';
-import { Operators, ExternalOperators } from '../imports/api/operators.js';
-import { Graphs } from '../imports/api/graphs.js';
-import { Sessions } from '../imports/api/sessions.js';
-import { Products } from '../imports/api/products.js';
-import { Objects } from '../imports/api/objects.js';
+} from '../imports/api/activities';
+import { UploadList } from '../imports/api/openUploads';
+import { Operators, ExternalOperators } from '../imports/api/operators';
+import { Graphs } from '../imports/api/graphs';
+import { Sessions } from '../imports/api/sessions';
+import { Products } from '../imports/api/products';
+import { Objects } from '../imports/api/objects';
 
 const teacherPublish = (publish, collection, limitation) => {
   Meteor.publish(publish, function() {


### PR DESCRIPTION
This PR removes the `.js` extension from a number of import statements to align them with the way imports are handled in the rest of the codebase. Behaviour should not change with this PR.