### PR TITLE
[Wiki Settings] Option for Read-only wiki

### DIFF
--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -136,7 +136,8 @@ class WikiContentComp extends React.Component<> {
     const docModeButton = () => {
       if (
         this.state.docMode === 'history' ||
-        this.props.liType === 'li-activity'
+        this.props.liType === 'li-activity' ||
+        this.props.disableEdit
       )
         return null;
       if (this.state.docMode === 'view')
@@ -258,7 +259,10 @@ class WikiContentComp extends React.Component<> {
                       this.state.docMode === 'edit' ? '#ffffff' : '#fbffe0'
                   }}
                   onDoubleClick={() => {
-                    if (this.state.docMode === 'view') {
+                    if (
+                      this.state.docMode === 'view' &&
+                      !this.props.disableEdit
+                    ) {
                       this.setState({ docMode: 'edit' });
                     }
                   }}

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -59,6 +59,9 @@ type WikiCompPropsT = {
   query?: Object
 } & ModalParentPropsT;
 
+type WikiSettingsT = {
+  readOnly: boolean
+};
 type WikiCompStateT = {
   dashboardSearch: ?string,
   mode: string,
@@ -70,7 +73,8 @@ type WikiCompStateT = {
   urlInstance: ?string,
   noInstance: ?boolean,
   username: string,
-  isAnonymous: boolean
+  isAnonymous: boolean,
+  settings?: WikiSettingsT
 };
 
 class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
@@ -141,8 +145,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
       );
       Mousetrap.bindGlobal('ctrl+s', () => this.setState({ docMode: 'view' }));
       Mousetrap.bindGlobal('ctrl+e', () => {
-        if (this.state.docMode !== 'readonly')
-          this.setState({ docMode: 'edit' });
+        if (!this.state.settings?.readOnly) this.setState({ docMode: 'edit' });
       });
       Mousetrap.bindGlobal('ctrl+f', () =>
         this.setState({ findModalOpen: true })
@@ -174,12 +177,11 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
       return createNewEmptyWikiDoc(this.wikiDoc, this.wikiId, liId);
     }
 
-    if (this.wikiDoc.data.settings?.readOnly) {
-      this.setState({ docMode: 'readonly' });
-    }
-
     wikiStore.setPages(this.wikiDoc.data.pages);
-    this.setState({ pagesData: wikiStore.pages });
+    this.setState({
+      pagesData: wikiStore.pages,
+      settings: this.wikiDoc.data.settings
+    });
 
     if (this.initialLoad) {
       return this.handleInitialLoad();
@@ -713,9 +715,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
                 goToPage={this.goToPage}
                 dashboardSearch={this.state.dashboardSearch}
                 side={this.state.mode === 'splitview' ? 'left' : null}
-                disableEdit={
-                  this.props.embed || this.state.docMode === 'readonly'
-                }
+                disableEdit={this.props.embed || this.state.settings?.readOnly}
                 embed={this.props.embed}
               />
               {this.state.mode === 'splitview' && (
@@ -731,7 +731,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
                   dashboardSearch={this.state.dashboardSearch}
                   side="right"
                   disableEdit={
-                    this.props.embed || this.state.docMode === 'readonly'
+                    this.props.embed || this.state.settings?.readOnly
                   }
                   embed={this.props.embed}
                 />

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -140,7 +140,10 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
         this.setState({ createModalOpen: true })
       );
       Mousetrap.bindGlobal('ctrl+s', () => this.setState({ docMode: 'view' }));
-      Mousetrap.bindGlobal('ctrl+e', () => this.setState({ docMode: 'edit' }));
+      Mousetrap.bindGlobal('ctrl+e', () => {
+        if (this.state.docMode !== 'readonly')
+          this.setState({ docMode: 'edit' });
+      });
       Mousetrap.bindGlobal('ctrl+f', () =>
         this.setState({ findModalOpen: true })
       );
@@ -169,6 +172,10 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     if (!this.wikiDoc.data) {
       const liId = createNewLI(this.wikiId, 'li-richText');
       return createNewEmptyWikiDoc(this.wikiDoc, this.wikiId, liId);
+    }
+
+    if (this.wikiDoc.data.settings?.readOnly) {
+      this.setState({ docMode: 'readonly' });
     }
 
     wikiStore.setPages(this.wikiDoc.data.pages);
@@ -706,6 +713,9 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
                 goToPage={this.goToPage}
                 dashboardSearch={this.state.dashboardSearch}
                 side={this.state.mode === 'splitview' ? 'left' : null}
+                disableEdit={
+                  this.props.embed || this.state.docMode === 'readonly'
+                }
                 embed={this.props.embed}
               />
               {this.state.mode === 'splitview' && (
@@ -720,6 +730,9 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
                   goToPage={this.goToPage}
                   dashboardSearch={this.state.dashboardSearch}
                   side="right"
+                  disableEdit={
+                    this.props.embed || this.state.docMode === 'readonly'
+                  }
                   embed={this.props.embed}
                 />
               )}


### PR DESCRIPTION
**Description**
This is a minor PR which adds a settings field to the `wikiDoc` containing a `bool readOnly` which if set, will cause the wiki to be read-only.

**Resolved Issues**
This PR builds toward the Wiki Ownership feature.

**How to test?**
Cannot be tested via Browser, need to manually make changes to the database.

**Caveat**
This PR disables the option of editing the wiki but does not include any access-control functionality to prevent unauthorized access.