### PR TITLE
[Wiki Settings] Store list of owners

### DIFF
--- a/frog/imports/api/wikiDocHelpers.js
+++ b/frog/imports/api/wikiDocHelpers.js
@@ -113,9 +113,10 @@ export const changeWikiPageLI = (wikiDoc, pageId, newLiId) => {
   wikiDoc.submitOp(op);
 };
 
-export const createNewEmptyWikiDoc = (wikiDoc, wikiId, liId) => {
+export const createNewEmptyWikiDoc = (wikiDoc, wikiId, liId, owner) => {
   const emptyDocValues = {
     wikiId,
+    owners: Array.of(owner),
     pages: {
       home: {
         id: 'home',

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -168,7 +168,12 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
 
     if (!this.wikiDoc.data) {
       const liId = createNewLI(this.wikiId, 'li-richText');
-      return createNewEmptyWikiDoc(this.wikiDoc, this.wikiId, liId);
+      return createNewEmptyWikiDoc(
+        this.wikiDoc,
+        this.wikiId,
+        liId,
+        Meteor.userId()
+      );
     }
 
     wikiStore.setPages(this.wikiDoc.data.pages);


### PR DESCRIPTION
**Description**
This is a minor PR which adds a owners field to the `wikiDoc` containing an array of user ids of the owners which would initially contain the creator of the wiki.

**Resolved Issues**
This PR builds toward the Wiki Ownership feature.
Referenced Asana Task: https://app.asana.com/0/1115664036175110/1129993564633221

**How to test?**
Create a new wiki, if you have a database viewer (e.g. MongoDB Compass) you can see the new field along with your user Id