### PR TITLE
[Wiki Settings] Locking wikis

### DIFF
--- a/frog/imports/client/Wiki/ModalArchived.js
+++ b/frog/imports/client/Wiki/ModalArchived.js
@@ -1,0 +1,15 @@
+// @flow
+
+import React from 'react';
+import { Modal } from './components/Modal';
+
+/**
+ * This modal displays an error message when accessing an archived wiki
+ */
+export default () => {
+  return (
+    <Modal title="Wiki Archived" actions={[]}>
+      This wiki has been archived and you do not have access to its contents.
+    </Modal>
+  );
+};

--- a/frog/imports/client/Wiki/ModalLocked.js
+++ b/frog/imports/client/Wiki/ModalLocked.js
@@ -8,8 +8,8 @@ import { Modal } from './components/Modal';
  */
 export default () => {
   return (
-    <Modal title="Wiki Archived" actions={[]}>
-      This wiki has been archived and you do not have access to its contents.
+    <Modal title="Wiki Locked" actions={[]}>
+      This wiki has been locked and you do not have access to its contents.
     </Modal>
   );
 };

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -34,6 +34,7 @@ import { createNewLI } from './liDocHelpers';
 import { wikiStore } from './store';
 import CreateModal from './ModalCreate';
 import DeletedPageModal from './ModalDeletedPage';
+import ArchivedModal from './ModalArchived';
 import FindModal, { SearchAndFind } from './ModalFind';
 import RestoreModal from './ModalRestore';
 import WikiTopNavbar from './components/TopNavbar';
@@ -60,7 +61,8 @@ type WikiCompPropsT = {
 } & ModalParentPropsT;
 
 type WikiSettingsT = {
-  readOnly: boolean
+  readOnly: boolean,
+  archived: boolean
 };
 type WikiCompStateT = {
   dashboardSearch: ?string,
@@ -180,6 +182,13 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
         liId,
         Meteor.userId()
       );
+    }
+
+    if (
+      this.wikiDoc.data.settings?.archived &&
+      !this.wikiDoc.data.owners.find(x => x === Meteor.userId())
+    ) {
+      this.props.showModal(<ArchivedModal />);
     }
 
     wikiStore.setPages(this.wikiDoc.data.pages);

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -34,7 +34,7 @@ import { createNewLI } from './liDocHelpers';
 import { wikiStore } from './store';
 import CreateModal from './ModalCreate';
 import DeletedPageModal from './ModalDeletedPage';
-import ArchivedModal from './ModalArchived';
+import LockedModal from './ModalLocked';
 import FindModal, { SearchAndFind } from './ModalFind';
 import RestoreModal from './ModalRestore';
 import WikiTopNavbar from './components/TopNavbar';
@@ -62,7 +62,7 @@ type WikiCompPropsT = {
 
 type WikiSettingsT = {
   readOnly: boolean,
-  archived: boolean
+  locked: boolean
 };
 type WikiCompStateT = {
   dashboardSearch: ?string,
@@ -185,10 +185,10 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     }
 
     if (
-      this.wikiDoc.data.settings?.archived &&
+      this.wikiDoc.data.settings?.locked &&
       !this.wikiDoc.data.owners.find(x => x === Meteor.userId())
     ) {
-      this.props.showModal(<ArchivedModal />);
+      this.props.showModal(<LockedModal />);
     }
 
     wikiStore.setPages(this.wikiDoc.data.pages);


### PR DESCRIPTION
**Description**
This is a minor PR which adds a boolean ~~`archived`~~ `locked` field to the `settings` object in the `wikiDoc`.
If this is set, a modal is displayed informing user that the page is archived. (User can't hide the modal from the UI)

**Resolved Issues**
This PR builds toward the Wiki Ownership feature.
Referenced Asana Task: https://app.asana.com/0/1121331595459324/1130445664537703

**How to test?**
Cannot be tested via Browser, need to manually make changes to the database.