### PR TITLE
[Wiki Settings] Limiting Page Creation

### DIFF
--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -60,7 +60,8 @@ type WikiCompPropsT = {
 } & ModalParentPropsT;
 
 type WikiSettingsT = {
-  readOnly: boolean
+  readOnly: boolean,
+  limitPageCreation: boolean
 };
 type WikiCompStateT = {
   dashboardSearch: ?string,
@@ -75,7 +76,7 @@ type WikiCompStateT = {
   username: string,
   isAnonymous: boolean,
   settings?: WikiSettingsT,
-  isOwner?: boolean
+  isOwner: boolean
 };
 
 class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
@@ -119,7 +120,8 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
       openCreator: false,
       createModalOpen: false,
       search: '',
-      rightSideCurrentPageObj: null
+      rightSideCurrentPageObj: null,
+      isOwner: false
     };
   }
 
@@ -142,7 +144,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     window.wikiDoc = this.wikiDoc;
     if (!this.props.embed) {
       Mousetrap.bindGlobal('ctrl+n', () => {
-        if (!this.state.settings?.noNewPage && !this.state.isOwner)
+        if (!this.state.settings?.limitPageCreation && !this.state.isOwner)
           this.setState({ createModalOpen: true });
       });
       Mousetrap.bindGlobal('ctrl+s', () => this.setState({ docMode: 'view' }));

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -190,7 +190,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     this.setState({
       pagesData: wikiStore.pages,
       settings: this.wikiDoc.data.settings,
-      isOwner: !!this.wikiDoc.data.owners.find(x => x === Meteor.userId())
+      isOwner: this.wikiDoc.data.owners.find(x => x === Meteor.userId()) === undefined
     });
 
     if (this.initialLoad) {


### PR DESCRIPTION
**Description**
This is a minor PR which adds a boolean `limitPageCreation` field to the `settings` object in the `wikiDoc`.
If this is set, the user has no option to create a new page.

**Resolved Issues**
This PR builds toward the Wiki Ownership feature.
Referenced Asana Task: https://app.asana.com/0/1121331595459324/1130445664537704

**How to test?**
Cannot be tested via Browser, need to manually make changes to the database.