### PR TITLE
Fix/field bug

### DIFF
--- a/frog-utils/src/FrogForm/components/PrimaryGrouping.jsx
+++ b/frog-utils/src/FrogForm/components/PrimaryGrouping.jsx
@@ -30,7 +30,7 @@ const useStyles = makeStyles(theme => ({
     lineHeight: 1
   },
   expandIcon: {
-    marginLeft: theme.spacing(2),
+    marginLeft: 'auto',
     transition: 'all .2s'
   },
   fields: {

--- a/frog-utils/src/FrogForm/fields/RteField.jsx
+++ b/frog-utils/src/FrogForm/fields/RteField.jsx
@@ -17,8 +17,13 @@ export const RteField = (props: CustomFieldPropsT) => {
       <Fields.rte
         {...props}
         name={undefined}
-        uiSchema={{ ...props.uiSchema, 'ui:title': undefined }}
-        schema={{ ...props.schema, title: undefined }}
+        description={undefined}
+        uiSchema={{
+          ...props.uiSchema,
+          'ui:title': undefined,
+          'ui:description': undefined
+        }}
+        schema={{ ...props.schema, title: undefined, description: undefined }}
       />
     </Label>
   );


### PR DESCRIPTION
This PR fixes some bugs related to the config UI, namely that a 1st level grouping without a description did not render correctly and that Rte field has two descriptions shown when it is defined.