### PR TITLE
TopBar element

### DIFF
--- a/frog/imports/ui/TopBar/ActionMenu.js
+++ b/frog/imports/ui/TopBar/ActionMenu.js
@@ -14,7 +14,7 @@ import { MoreVert } from '@material-ui/icons';
 
 import type { TopBarActionT } from './types';
 
-const useStyle = makeStyles(theme => ({
+const useStyle = makeStyles(() => ({
   root: {
     display: 'flex'
   }

--- a/frog/imports/ui/TopBar/ActionMenu.js
+++ b/frog/imports/ui/TopBar/ActionMenu.js
@@ -1,0 +1,76 @@
+// @flow
+
+import * as React from 'react';
+import {
+  IconButton,
+  makeStyles,
+  Button,
+  Tooltip,
+  Menu,
+  MenuItem,
+  ListItemIcon
+} from '@material-ui/core';
+import { MoreVert } from '@material-ui/icons';
+
+import type { TopBarActionT } from './types';
+
+const useStyle = makeStyles(theme => ({
+  root: {
+    display: 'flex'
+  }
+}));
+
+type ActionMenuPropsT = {
+  primaryActions?: TopBarActionT[],
+  secondaryActions?: TopBarActionT[]
+};
+
+/**
+ * Displays an action menu with an overflow panel inside a TopBar element
+ */
+export const ActionMenu = (props: ActionMenuPropsT) => {
+  const classes = useStyle();
+  const [anchorEl, setAnchorEl] = React.useState(null);
+
+  return (
+    <div className={classes.root}>
+      {props.primaryActions &&
+        props.primaryActions.map(action =>
+          action.icon ? (
+            <Tooltip key={action.id} title={action.title}>
+              <IconButton onClick={action.callback}>{action.icon}</IconButton>
+            </Tooltip>
+          ) : (
+            <Button key={action.id} onClick={action.callback}>
+              {action.title}
+            </Button>
+          )
+        )}
+      {props.secondaryActions && (
+        <>
+          <IconButton onClick={event => setAnchorEl(event.currentTarget)}>
+            <MoreVert />
+          </IconButton>
+          <Menu
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={() => setAnchorEl(null)}
+          >
+            {props.secondaryActions.map(action => (
+              <MenuItem
+                key={action.id}
+                onClick={() => {
+                  if (action.callback) action.callback();
+                  setAnchorEl(null);
+                }}
+              >
+                {action.icon && <ListItemIcon>{action.icon}</ListItemIcon>}
+                {action.title}
+              </MenuItem>
+            ))}
+          </Menu>
+        </>
+      )}
+    </div>
+  );
+};

--- a/frog/imports/ui/TopBar/Navigation.js
+++ b/frog/imports/ui/TopBar/Navigation.js
@@ -5,7 +5,7 @@ import { Tabs, Tab, Tooltip, makeStyles } from '@material-ui/core';
 
 import type { TopBarViewT } from './types';
 
-const useStyle = makeStyles(theme => ({
+const useStyle = makeStyles(() => ({
   tab: {
     // the default value is too large for our use-case
     minWidth: 0

--- a/frog/imports/ui/TopBar/Navigation.js
+++ b/frog/imports/ui/TopBar/Navigation.js
@@ -1,0 +1,47 @@
+// @flow
+
+import React from 'react';
+import { Tabs, Tab, Tooltip, makeStyles } from '@material-ui/core';
+
+import type { TopBarViewT } from './types';
+
+const useStyle = makeStyles(theme => ({
+  tab: {
+    // the default value is too large for our use-case
+    minWidth: 0
+  }
+}));
+
+type NavigationPropsT = {
+  currentView: number,
+  views: TopBarViewT[],
+  onChange?: (index: number) => void
+};
+
+/**
+ * Displays a series of tabs used for navigation inside a TopBar element
+ */
+export const Navigation = (props: NavigationPropsT) => {
+  const classes = useStyle();
+
+  return (
+    <Tabs
+      value={props.currentView}
+      indicatorColor="primary"
+      textColor="primary"
+      onChange={(_, value) => {
+        if (props.onChange) props.onChange(value);
+      }}
+    >
+      {props.views.map(item =>
+        item.icon ? (
+          <Tooltip key={item.id} title={item.title}>
+            <Tab className={classes.tab} icon={item.icon} />
+          </Tooltip>
+        ) : (
+          <Tab key={item.id} className={classes.tab} title={item.title} />
+        )
+      )}
+    </Tabs>
+  );
+};

--- a/frog/imports/ui/TopBar/index.js
+++ b/frog/imports/ui/TopBar/index.js
@@ -1,0 +1,76 @@
+// @flow
+
+import * as React from 'react';
+import { AppBar, makeStyles } from '@material-ui/core';
+
+import { Navigation } from './Navigation';
+import { ActionMenu } from './ActionMenu';
+import type { TopBarViewT, TopBarActionT } from './types';
+
+const useStyle = makeStyles(theme => ({
+  appBarRoot: {
+    display: 'flex',
+    alignItems: 'center',
+    flexFlow: 'row nowrap',
+    padding: theme.spacing(0, 1),
+    background: 'white'
+  },
+
+  actions: {
+    marginLeft: 'auto'
+  }
+}));
+
+type TopBarPropsT = {
+  /**
+   * Indicate which view is active, so we know which tab to highlight
+   */
+  currentView?: number,
+  /**
+   * The views to display as tabs
+   */
+  views?: TopBarViewT[],
+  /**
+   * Callback when the user selects another view tab
+   */
+  onViewChange?: (index: number) => void,
+  /**
+   * These actions are displayed inside the TopBar itself. We
+   * recommend not including more than 3 primary actions.
+   */
+  primaryActions?: TopBarActionT[],
+  /**
+   * These actions are displayed inside an overflow panel.
+   */
+  secondaryActions?: TopBarActionT[]
+};
+
+/**
+ * TopBar provides UI knobs to show navigation and important actions
+ */
+export const TopBar = (props: TopBarPropsT) => {
+  const classes = useStyle();
+  return (
+    <AppBar
+      classes={{ root: classes.appBarRoot }}
+      color="default"
+      elevation={0}
+    >
+      {props.views && (
+        <Navigation
+          currentView={props.currentView || 0}
+          views={props.views}
+          onChange={props.onViewChange}
+        />
+      )}
+      <div className={classes.actions}>
+        {(props.primaryActions || props.secondaryActions) && (
+          <ActionMenu
+            primaryActions={props.primaryActions}
+            secondaryActions={props.secondaryActions}
+          />
+        )}
+      </div>
+    </AppBar>
+  );
+};

--- a/frog/imports/ui/TopBar/index.stories.js
+++ b/frog/imports/ui/TopBar/index.stories.js
@@ -1,0 +1,60 @@
+// @flow
+
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { TopBar } from '.';
+import { Edit, PlayCircleFilled, PlayArrow } from '@material-ui/icons';
+
+const SimpleWrapper = () => {
+  const [currentTab, setCurrentTab] = React.useState(0);
+  return (
+    <TopBar
+      currentView={currentTab}
+      views={[
+        {
+          id: 'edit',
+          title: 'Edit graph',
+          icon: <Edit />
+        },
+        {
+          id: 'orchestrate',
+          title: 'Run session',
+          icon: <PlayCircleFilled />
+        }
+      ]}
+      primaryActions={[
+        {
+          id: 'start',
+          title: 'Start session',
+          icon: <PlayArrow />,
+          callback: action('action_callback')
+        },
+        {
+          id: 'projector',
+          title: 'Open projector view',
+          callback: action('action_callback')
+        }
+      ]}
+      secondaryActions={[
+        {
+          id: 'start',
+          title: 'Start session',
+          icon: <PlayArrow />,
+          callback: action('action_callback')
+        },
+        {
+          id: 'projector',
+          title: 'Open projector view',
+          callback: action('action_callback')
+        }
+      ]}
+      onViewChange={i => {
+        setCurrentTab(i);
+        action('tab_change')(i);
+      }}
+    />
+  );
+};
+
+storiesOf('TopBar', module).add('simple', () => <SimpleWrapper />);

--- a/frog/imports/ui/TopBar/index.stories.js
+++ b/frog/imports/ui/TopBar/index.stories.js
@@ -3,8 +3,8 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { TopBar } from '.';
 import { Edit, PlayCircleFilled, PlayArrow } from '@material-ui/icons';
+import { TopBar } from '.';
 
 const SimpleWrapper = () => {
   const [currentTab, setCurrentTab] = React.useState(0);

--- a/frog/imports/ui/TopBar/types.js
+++ b/frog/imports/ui/TopBar/types.js
@@ -1,0 +1,33 @@
+// @flow
+import * as React from 'react';
+
+export type TopBarViewT = {
+  /**
+   * Required for React and for E2E testing
+   */
+  id: string,
+  /**
+   * If specified, the title will be displayed as a tooltip
+   */
+  icon: React.Node,
+  /**
+   * Shown inside the button if no icon is specified, or as a tooltip
+   */
+  title: string
+};
+
+export type TopBarActionT = {
+  /**
+   * Required for React and for E2E testing
+   */
+  id: string,
+  /**
+   * If specified, the title will be displayed as a tooltip
+   */
+  icon?: React.Node,
+  /**
+   * Shown inside the button if no icon is specified, or as a tooltip
+   */
+  title?: string,
+  callback?: () => void
+};


### PR DESCRIPTION
This PR implements a common TopBar element with the goal to harmonise this UI widget, currently implemented three times in Wiki, Single Activity and Pro FROG. The TopBar is divided in two parts, navigation and actions.

This is how I see the various navigation views for each FROG app:

**Wiki**
- Single page
- Split view

**Single activity**
- Create/Edit activity/template
- Run session

**FROG Pro**
- Edit Graph
- Run session
- Preview activity

----

**To discuss:** 
- UI for user info, with login/sign up/logout action
- Custom views inside the top bar (for example to show the next activity when running a graph)