### PR TITLE
Upgrading legacy accounts + Wiki compatibility with legacy accounts 

### DIFF
--- a/frog/imports/api/users.js
+++ b/frog/imports/api/users.js
@@ -36,6 +36,7 @@ export const getUsername = (user: User, wiki: boolean = false): ?string => {
  */
 export const userType = (user: User): string => {
   const selectedUser = getUser(user);
+  // if there is no user logged in then we treat it the same as anonymous
   if (!selectedUser) return 'Anonymous';
   else if (selectedUser.isAnonymous) return 'Anonymous';
   else if (isVerifiedUser({ selectedUser })) return 'Verified';

--- a/frog/imports/api/users.js
+++ b/frog/imports/api/users.js
@@ -49,7 +49,6 @@ export const getUserType = (user?: UserObj): UserType => {
   const selectedUser = getUser(user);
   // if there is no user logged in then we treat it the same as anonymous
   if (!selectedUser || selectedUser.isAnonymous) return 'Anonymous';
-  // eslint-disable-next-line no-extra-boolean-cast
   else if (isVerifiedUser({ meteorUser: selectedUser })) return 'Verified';
   else if (selectedUser.username) return 'Legacy';
   else return 'No user logged in';

--- a/frog/imports/api/users.js
+++ b/frog/imports/api/users.js
@@ -30,7 +30,17 @@ export const getUsername = (user: User, wiki: boolean = false): ?string => {
   }
   return undefined;
 };
-
+/**
+ * Returns the type of the given user if the user is passed or the current user
+ * @param: {User=} user
+ */
+export const userType = (user: User): string => {
+  const selectedUser = getUser(user);
+  if (!selectedUser) return 'Anonymous';
+  else if (selectedUser.isAnonymous) return 'Anonymous';
+  else if (isVerifiedUser({ selectedUser })) return 'Verified';
+  else if (selectedUser.username) return 'Legacy';
+};
 /**
  * Returns the appropriate user object based on the type of user. If no user is passed as args then will return the current user object.
  *

--- a/frog/imports/api/users.js
+++ b/frog/imports/api/users.js
@@ -49,7 +49,8 @@ export const getUserType = (user?: UserObj): UserType => {
   const selectedUser = getUser(user);
   // if there is no user logged in then we treat it the same as anonymous
   if (!selectedUser || selectedUser.isAnonymous) return 'Anonymous';
-  else if (isVerifiedUser({ meteorUser: selectedUser })) return 'Verified';
+  // eslint-disable-next-line no-extra-boolean-cast
+  else if (!!selectedUser.emails) return 'Verified';
   else if (selectedUser.username) return 'Legacy';
   else return 'No user logged in';
 };

--- a/frog/imports/api/users.js
+++ b/frog/imports/api/users.js
@@ -28,7 +28,10 @@ const getAnimalAnonymous = (userId: string): string => {
  * @param: {User=} user
  */
 
-export const getUsername = (user?: UserObj, wiki?: boolean = false): string => {
+export const getUsername = (
+  user?: UserObj,
+  wiki?: boolean = false
+): ?string => {
   const selectedUser = getUser(user);
   if (selectedUser) {
     if (selectedUser.isAnonymous)
@@ -36,7 +39,7 @@ export const getUsername = (user?: UserObj, wiki?: boolean = false): string => {
     else if (selectedUser.emails) return selectedUser.profile.displayName;
     else if (selectedUser.username) return selectedUser.username;
   }
-  return 'No user logged in';
+  return undefined;
 };
 /**
  * Returns the type of the given user if the user is passed or the current user

--- a/frog/imports/api/users.js
+++ b/frog/imports/api/users.js
@@ -50,7 +50,7 @@ export const getUserType = (user?: UserObj): UserType => {
   // if there is no user logged in then we treat it the same as anonymous
   if (!selectedUser || selectedUser.isAnonymous) return 'Anonymous';
   // eslint-disable-next-line no-extra-boolean-cast
-  else if (!!selectedUser.emails) return 'Verified';
+  else if (isVerifiedUser({ meteorUser: selectedUser })) return 'Verified';
   else if (selectedUser.username) return 'Legacy';
   else return 'No user logged in';
 };
@@ -73,7 +73,7 @@ const getUser = (user?: UserObj): ?MeteorUser => {
  * @param: {User=} user
  */
 
-export const isVerifiedUser = (user?: UserObj): boolean => {
+const isVerifiedUser = (user?: UserObj): boolean => {
   const selectedUser = getUser(user);
   if (selectedUser) return !!selectedUser.emails;
   else return false;

--- a/frog/imports/api/users.js
+++ b/frog/imports/api/users.js
@@ -4,9 +4,22 @@ import { Meteor } from 'meteor/meteor';
 import { hashCode } from '/imports/frog-utils';
 import animals from './animals';
 
-type User = {
+type MeteorUser = {
+  _id: string,
+  emails?: string[],
+  username: string,
+  isAnonymous: boolean,
+  profile?: { displayName: string }
+};
+type UserObj = {
   id?: string,
-  userObj?: { _id: string, emails: ?(string[]) }
+  meteorUser?: MeteorUser
+};
+type UserType = 'Anonymous' | 'Verified' | 'Legacy' | 'No user logged in';
+
+const getAnimalAnonymous = (userId: string): string => {
+  const animal = animals[Math.abs(hashCode(userId)) % 286];
+  return 'Anonymous ' + animal;
 };
 
 /**
@@ -15,12 +28,7 @@ type User = {
  * @param: {User=} user
  */
 
-const getAnimalAnonymous = (userId: string): string => {
-  const animal = animals[Math.abs(hashCode(userId)) % 286];
-  return 'Anonymous ' + animal;
-};
-
-export const getUsername = (user: User, wiki: boolean = false): ?string => {
+export const getUsername = (user?: UserObj, wiki?: boolean = false): string => {
   const selectedUser = getUser(user);
   if (selectedUser) {
     if (selectedUser.isAnonymous)
@@ -28,30 +36,30 @@ export const getUsername = (user: User, wiki: boolean = false): ?string => {
     else if (selectedUser.emails) return selectedUser.profile.displayName;
     else if (selectedUser.username) return selectedUser.username;
   }
-  return undefined;
+  return 'No user logged in';
 };
 /**
  * Returns the type of the given user if the user is passed or the current user
  * @param: {User=} user
  */
-export const userType = (user: User): string => {
+export const getUserType = (user?: UserObj): UserType => {
   const selectedUser = getUser(user);
   // if there is no user logged in then we treat it the same as anonymous
-  if (!selectedUser) return 'Anonymous';
-  else if (selectedUser.isAnonymous) return 'Anonymous';
-  else if (isVerifiedUser({ selectedUser })) return 'Verified';
+  if (!selectedUser || selectedUser.isAnonymous) return 'Anonymous';
+  else if (isVerifiedUser({ meteorUser: selectedUser })) return 'Verified';
   else if (selectedUser.username) return 'Legacy';
+  else return 'No user logged in';
 };
 /**
  * Returns the appropriate user object based on the type of user. If no user is passed as args then will return the current user object.
- *
+ * If there is no user logged in, returns undefined.
  * @param: {User=} user
  */
-const getUser = (user: User): ?userObj => {
+const getUser = (user?: UserObj): ?MeteorUser => {
   // object spread to allow destructure a null object
-  const { id, userObj } = { ...user };
+  const { id, meteorUser } = { ...user };
   if (id) return Meteor.users.findOne(id);
-  else if (userObj) return userObj;
+  else if (meteorUser) return meteorUser;
   else return Meteor.user();
 };
 
@@ -61,10 +69,8 @@ const getUser = (user: User): ?userObj => {
  * @param: {User=} user
  */
 
-export const isVerifiedUser = (user: User) => {
+export const isVerifiedUser = (user?: UserObj): boolean => {
   const selectedUser = getUser(user);
-  const { id, userObj } = selectedUser;
-  if (id) return !!Meteor.users.findOne(id).emails;
-  else if (userObj) return !!userObj.emails;
-  else return !!selectedUser.emails;
+  if (selectedUser) return !!selectedUser.emails;
+  else return false;
 };

--- a/frog/imports/client/AccountModal/SignUp.js
+++ b/frog/imports/client/AccountModal/SignUp.js
@@ -11,6 +11,7 @@ import {
 } from '@material-ui/core';
 import LockOutlinedIcon from '@material-ui/icons/LockOutlined';
 import { withStyles } from '@material-ui/styles';
+import { getUsername, getUserType } from '/imports/api/users';
 import {
   errorBasedOnChars,
   emailErrors,
@@ -67,7 +68,7 @@ class SignUp extends React.Component<SignUpPropsT, SignUpStateT> {
   constructor() {
     super();
     this.state = {
-      displayName: '',
+      displayName: getUserType() === 'Legacy' ? getUsername() : '',
       email: '',
       password: '',
       formErrors: {
@@ -124,9 +125,17 @@ class SignUp extends React.Component<SignUpPropsT, SignUpStateT> {
           <Avatar className={classes.avatar}>
             <LockOutlinedIcon />
           </Avatar>
-          <Typography component="h1" variant="h5">
-            Create an account with FROG
-          </Typography>
+
+          {getUserType() === 'Legacy' ? (
+            <Typography component="h1" variant="h6">
+              Upgrade your account to verified
+            </Typography>
+          ) : (
+            <Typography component="h1" variant="h5">
+              Create an account
+            </Typography>
+          )}
+
           <form
             className={classes.form}
             onSubmit={e => this.handleSubmit(e)}
@@ -137,6 +146,7 @@ class SignUp extends React.Component<SignUpPropsT, SignUpStateT> {
                 <TextField
                   autoComplete="fname"
                   fullWidth
+                  defaultValue={this.state.displayName}
                   name="displayName"
                   error={this.state.formErrors.displayName !== ''}
                   variant="outlined"
@@ -178,15 +188,27 @@ class SignUp extends React.Component<SignUpPropsT, SignUpStateT> {
                 />
               </Grid>
               <Grid item xs={12}>
-                <Button
-                  type="submit"
-                  fullWidth
-                  variant="contained"
-                  color="primary"
-                  className={classes.submit}
-                >
-                  Sign Up
-                </Button>
+                {getUserType() === 'Legacy' ? (
+                  <Button
+                    type="submit"
+                    fullWidth
+                    variant="contained"
+                    color="primary"
+                    className={classes.submit}
+                  >
+                    Upgrade now!
+                  </Button>
+                ) : (
+                  <Button
+                    type="submit"
+                    fullWidth
+                    variant="contained"
+                    color="primary"
+                    className={classes.submit}
+                  >
+                    Sign Up
+                  </Button>
+                )}
               </Grid>
             </Grid>
 

--- a/frog/imports/client/App/TopBar.js
+++ b/frog/imports/client/App/TopBar.js
@@ -6,7 +6,7 @@ import { withRouter } from 'react-router';
 import { withStyles } from '@material-ui/styles';
 import { compose } from 'recompose';
 import { getUsername } from '/imports/api/users';
-
+import { Meteor } from 'meteor/meteor';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';

--- a/frog/imports/client/SingleActivity/TopBar.js
+++ b/frog/imports/client/SingleActivity/TopBar.js
@@ -14,7 +14,7 @@ import { useModal } from '/imports/ui/Modal';
 import { type PropsT } from './types';
 import { style } from './style';
 import AccountModal from '/imports/client/AccountModal/AccountModal';
-import { getUsername, userType } from '/imports/api/users';
+import { getUsername, getUserType } from '/imports/api/users';
 /**
  * Navigation bar displayed at the top
  */
@@ -37,7 +37,7 @@ function TopBar(props: PropsT) {
         <Typography variant="h6" color="inherit" className={classes.logo}>
           FROG
         </Typography>
-        {userType() === 'Anonymous' && (
+        {getUserType() === 'Anonymous' && (
           <>
             <Button size="medium" onClick={openSignUpModal}>
               Create an account
@@ -47,7 +47,7 @@ function TopBar(props: PropsT) {
             </Button>
           </>
         )}
-        {userType() === 'Verified' && (
+        {getUserType() === 'Verified' && (
           <>
             <Button
               size="medium"
@@ -64,7 +64,7 @@ function TopBar(props: PropsT) {
             />
           </>
         )}
-        {userType() === 'Legacy' && (
+        {getUserType() === 'Legacy' && (
           <>
             <Button
               size="medium"

--- a/frog/imports/client/SingleActivity/TopBar.js
+++ b/frog/imports/client/SingleActivity/TopBar.js
@@ -14,7 +14,7 @@ import { useModal } from '/imports/ui/Modal';
 import { type PropsT } from './types';
 import { style } from './style';
 import AccountModal from '/imports/client/AccountModal/AccountModal';
-import { getUsername } from '/imports/api/users';
+import { getUsername, userType } from '/imports/api/users';
 /**
  * Navigation bar displayed at the top
  */
@@ -22,7 +22,6 @@ import { getUsername } from '/imports/api/users';
 function TopBar(props: PropsT) {
   const [showModal] = useModal();
   const { classes } = props;
-  const user = Meteor.user();
 
   const openSignUpModal = () => {
     showModal(<AccountModal formToDisplay="signup" />);
@@ -38,16 +37,17 @@ function TopBar(props: PropsT) {
         <Typography variant="h6" color="inherit" className={classes.logo}>
           FROG
         </Typography>
-        {user.isAnonymous || !user ? (
+        {userType() === 'Anonymous' && (
           <>
             <Button size="medium" onClick={openSignUpModal}>
-              Create a verified account
+              Create an account
             </Button>
             <Button size="medium" onClick={openLoginModal}>
               Login
             </Button>
           </>
-        ) : (
+        )}
+        {userType() === 'Verified' && (
           <>
             <Button
               size="medium"
@@ -58,6 +58,28 @@ function TopBar(props: PropsT) {
               }}
             >
               Logout
+            </Button>
+            <Chip
+              avatar={<Avatar>{getUsername().charAt(0)}</Avatar>}
+              label={getUsername()}
+            />
+          </>
+        )}
+        {userType() === 'Legacy' && (
+          <>
+            <Button
+              size="medium"
+              onClick={() => {
+                sessionStorage.removeItem('frog.sessionToken');
+                Meteor.logout();
+                window.location.replace('/');
+              }}
+            >
+              Logout
+            </Button>
+
+            <Button size="medium" onClick={openSignUpModal}>
+              Upgrade your account
             </Button>
             <Chip
               avatar={<Avatar>{getUsername().charAt(0)}</Avatar>}

--- a/frog/imports/client/TeacherView/utils/downloadLog.js
+++ b/frog/imports/client/TeacherView/utils/downloadLog.js
@@ -34,7 +34,7 @@ const userLookup = userId => {
     ret = ['teacher', 'teacher'];
   } else {
     ret = userobj
-      ? [userobj.userid || '', getUsername({ userObj: userobj })]
+      ? [userobj.userid || '', getUsername({ meteorUser: userobj })]
       : [userId, ''];
   }
   userIds[userId] = ret;

--- a/frog/imports/client/TeacherView/utils/exportComponent.js
+++ b/frog/imports/client/TeacherView/utils/exportComponent.js
@@ -34,7 +34,7 @@ const userLookup = (userId: string): [string, string] => {
   }
   const userobj = Meteor.users.findOne(userId);
   const ret = userobj
-    ? [userobj.userid || '', getUsername({ userObj: userobj })]
+    ? [userobj.userid || '', getUsername({ meteorUser: userobj })]
     : [userId, ''];
   userIds[userId] = ret;
   return ret;

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -6,7 +6,7 @@ import Mousetrap from 'mousetrap';
 import 'mousetrap/plugins/global-bind/mousetrap-global-bind.min.js';
 import { values } from '/imports/frog-utils';
 import { withModal, type ModalParentPropsT } from '/imports/ui/Modal';
-import { getUsername, isVerifiedUser } from '/imports/api/users';
+import { getUsername, userType } from '/imports/api/users';
 import Button from '@material-ui/core/Button';
 import History from '@material-ui/icons/History';
 import ChromeReaderMode from '@material-ui/icons/ChromeReaderMode';
@@ -994,8 +994,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
         }
       });
     }
-
-    if (Meteor.user().isAnonymous || !isVerifiedUser() || !Meteor.user()) {
+    if (userType() === 'Anonymous') {
       secondaryNavItems.push({
         title: 'Create an account',
         icon: LockOutlinedIcon,
@@ -1008,7 +1007,24 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
         callback: () =>
           this.props.showModal(<AccountModal formToDisplay="login" />)
       });
-    } else {
+    } else if (userType() === 'Verified') {
+      secondaryNavItems.push({
+        title: 'Logout',
+        icon: LockOutlinedIcon,
+        callback: () => {
+          sessionStorage.removeItem('frog.sessionToken');
+          Meteor.logout(() => window.location.reload());
+        }
+      });
+    } else if (userType() === 'Legacy') {
+      secondaryNavItems.push({
+        title: 'Upgrade your account',
+        icon: LockOutlinedIcon,
+        callback: () => {
+          this.props.showModal(<AccountModal formToDisplay="login" />);
+        }
+      });
+
       secondaryNavItems.push({
         title: 'Logout',
         icon: LockOutlinedIcon,

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -1062,7 +1062,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
         title: 'Upgrade your account',
         icon: LockOutlinedIcon,
         callback: () => {
-          this.props.showModal(<AccountModal formToDisplay="login" />);
+          this.props.showModal(<AccountModal formToDisplay="signup" />);
         }
       });
 

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -7,7 +7,7 @@ import { Meteor } from 'meteor/meteor';
 import 'mousetrap/plugins/global-bind/mousetrap-global-bind.min.js';
 import { values, entries } from '/imports/frog-utils';
 import { withModal, type ModalParentPropsT } from '/imports/ui/Modal';
-import { getUsername, userType } from '/imports/api/users';
+import { getUsername, getUserType } from '/imports/api/users';
 import Button from '@material-ui/core/Button';
 import History from '@material-ui/icons/History';
 import ChromeReaderMode from '@material-ui/icons/ChromeReaderMode';
@@ -1035,7 +1035,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
         }
       });
     }
-    if (userType() === 'Anonymous') {
+    if (getUserType() === 'Anonymous') {
       secondaryNavItems.push({
         title: 'Create an account',
         icon: LockOutlinedIcon,
@@ -1048,7 +1048,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
         callback: () =>
           this.props.showModal(<AccountModal formToDisplay="login" />)
       });
-    } else if (userType() === 'Verified') {
+    } else if (getUserType() === 'Verified') {
       secondaryNavItems.push({
         title: 'Logout',
         icon: LockOutlinedIcon,
@@ -1057,7 +1057,7 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
           Meteor.logout(() => window.location.reload());
         }
       });
-    } else if (userType() === 'Legacy') {
+    } else if (getUserType() === 'Legacy') {
       secondaryNavItems.push({
         title: 'Upgrade your account',
         icon: LockOutlinedIcon,

--- a/frog/server/accountManagement.js
+++ b/frog/server/accountManagement.js
@@ -30,7 +30,6 @@ export const createAccount = (
     (email !== '' && email) &&
     (profile?.displayName && profile?.displayName !== '')
   ) {
-    
     if (
       passwordErrors(password) !== '' ||
       emailErrors(email) !== '' ||
@@ -45,11 +44,10 @@ export const createAccount = (
       );
     } else if (!Accounts.findUserByEmail(email)) {
       const user = Meteor.user();
-      // if the user is anonymous or a legacy user we want to simply add the email and password to their 
-      // account. This allows them to keep the graphs and activities they created when they didn't have an 
-      // account. Else we just create a new account 
+      // if the user is anonymous or a legacy user we want to simply add the email and password to their
+      // account. This allows them to keep the graphs and activities they created when they didn't have an
+      // account. Else we just create a new account
       if (user?.isAnonymous || (user.username && !isVerifiedUser())) {
-  
         Meteor.users.update(user._id, {
           $set: {
             emails: [{ address: email, verified: false }],

--- a/frog/server/accountManagement.js
+++ b/frog/server/accountManagement.js
@@ -23,13 +23,14 @@ export const createAccount = (
   password: string,
   profile: Profile
 ) => {
+  // Validate input params to prevent incorrect data from the console/client.
   if (
     password !== '' &&
     password &&
     (email !== '' && email) &&
     (profile?.displayName && profile?.displayName !== '')
   ) {
-    // Validate input params
+    
     if (
       passwordErrors(password) !== '' ||
       emailErrors(email) !== '' ||
@@ -44,10 +45,11 @@ export const createAccount = (
       );
     } else if (!Accounts.findUserByEmail(email)) {
       const user = Meteor.user();
-
+      // if the user is anonymous or a legacy user we want to simply add the email and password to their 
+      // account. This allows them to keep the graphs and activities they created when they didn't have an 
+      // account. Else we just create a new account 
       if (user?.isAnonymous || (user.username && !isVerifiedUser())) {
-        // checks for duplicate email and displays error on the console.
-
+  
         Meteor.users.update(user._id, {
           $set: {
             emails: [{ address: email, verified: false }],
@@ -69,6 +71,7 @@ export const createAccount = (
           }
         });
       }
+      // error handling
     } else {
       throw new Meteor.Error('dup-email', 'Email already exists');
     }

--- a/frog/server/accountManagement.js
+++ b/frog/server/accountManagement.js
@@ -6,6 +6,7 @@ import {
   emailErrors,
   passwordErrors
 } from '/imports/frog-utils/validationHelpers';
+import { isVerifiedUser } from '/imports/api/users';
 
 type Profile = { displayName: string };
 
@@ -44,7 +45,7 @@ export const createAccount = (
     } else if (!Accounts.findUserByEmail(email)) {
       const user = Meteor.user();
 
-      if (user?.isAnonymous) {
+      if (user?.isAnonymous || (user.username && !isVerifiedUser())) {
         // checks for duplicate email and displays error on the console.
 
         Meteor.users.update(user._id, {

--- a/frog/server/accountManagement.js
+++ b/frog/server/accountManagement.js
@@ -6,7 +6,7 @@ import {
   emailErrors,
   passwordErrors
 } from '/imports/frog-utils/validationHelpers';
-import { isVerifiedUser } from '/imports/api/users';
+import { getUserType } from '/imports/api/users';
 
 type Profile = { displayName: string };
 
@@ -47,7 +47,10 @@ export const createAccount = (
       // if the user is anonymous or a legacy user we want to simply add the email and password to their
       // account. This allows them to keep the graphs and activities they created when they didn't have an
       // account. Else we just create a new account
-      if (user?.isAnonymous || (user.username && !isVerifiedUser())) {
+      if (
+        getUserType({ meteorUser: user }) === 'Anonymous' ||
+        getUserType({ meteorUser: user }) === 'Legacy'
+      ) {
         Meteor.users.update(user._id, {
           $set: {
             emails: [{ address: email, verified: false }],

--- a/frog/server/user_accounts.js
+++ b/frog/server/user_accounts.js
@@ -3,7 +3,7 @@
 import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
 import { uuid } from '/imports/frog-utils';
-import { isVerifiedUser } from '/imports/api/users';
+import { getUserType } from '/imports/api/users';
 import { Sessions } from '../imports/api/sessions';
 
 const doLogin = (user, self) => {
@@ -50,7 +50,11 @@ Meteor.methods({
     const userObj = Meteor.users.findOne({ username });
     // for anonymous login
     if (username === null) return doLogin(username, self);
-    if (!isStudentList && userObj && isVerifiedUser({ userObj })) {
+    if (
+      !isStudentList &&
+      userObj &&
+      getUserType({ meteorUser: userObj }) === 'Verified'
+    ) {
       return 'NOTVALID';
     } else {
       if (isStudentList) {


### PR DESCRIPTION
This PR adds functionality to upgrade legacy accounts to have a password and display name. Also fixes the logout not being displayed when a legacy account logs into the wiki. 

**Testing instructions**

- Login to a legacy account by using ?login=someusername. Note the user id

- Click upgrade your account on the single activity TopBar or the wiki topbar. Enter some display name, email, password. Check the database and the same user id should have the email associated with it. 
- Try to login using the email you entered 

**Asana task**
https://app.asana.com/0/1121331595459324/1133484398049560/f
https://app.asana.com/0/1129712605359574/1133484398049561/f