### PR TITLE
Removing unused Meteor packages

### DIFF
--- a/frog/.meteor/packages
+++ b/frog/.meteor/packages
@@ -10,7 +10,7 @@ mongo@1.5.0                   # The database Meteor supports right now
 reactive-var@1.0.11            # Reactive variable for tracker
 jquery@1.11.10                  # Helpful client-side library
 tracker@1.2.0                 # Meteor's client-side reactive programming library
-
+insecure@1.0.7                # Allow all DB writes from clients (for prototyping)
 standard-minifier-css@1.4.1   # CSS minifier run for production mode
 es5-shim@4.8.0                # ECMAScript 5 compatibility for older browsers.
 ecmascript@0.11.0              # Enable ECMAScript2015+ syntax in app code

--- a/frog/.meteor/packages
+++ b/frog/.meteor/packages
@@ -6,9 +6,7 @@
 
 qualia:one
 meteor-base@1.4.0             # Packages every Meteor app needs to have
-mobile-experience@1.0.5       # Packages for a great mobile UX
 mongo@1.5.0                   # The database Meteor supports right now
-blaze-html-templates@1.0.4    # Compile .html files into Meteor Blaze views
 reactive-var@1.0.11            # Reactive variable for tracker
 jquery@1.11.10                  # Helpful client-side library
 tracker@1.2.0                 # Meteor's client-side reactive programming library
@@ -18,13 +16,10 @@ es5-shim@4.8.0                # ECMAScript 5 compatibility for older browsers.
 ecmascript@0.11.0              # Enable ECMAScript2015+ syntax in app code
 shell-server@0.3.1            # Server-side component of the `meteor shell` command
 
-insecure@1.0.7                # Allow all DB writes from clients (for prototyping)
 accounts-ui@1.3.0
 accounts-password
 react-meteor-data
-practicalmeteor:mocha
 check@1.3.1
-dispatch:mocha-phantomjs@0.1.9
 dynamic-import@0.4.0
 reywood:publish-composite
 standard-minifier-js@2.3.4
@@ -34,3 +29,4 @@ kadira:dochead
 mizzao:timesync
 mizzao:user-status
 underscore
+static-html

--- a/frog/.meteor/versions
+++ b/frog/.meteor/versions
@@ -9,7 +9,6 @@ babel-runtime@1.3.0
 base64@1.0.11
 binary-heap@1.0.11
 blaze@2.3.3
-blaze-html-templates@1.1.2
 blaze-tools@1.0.10
 boilerplate-generator@1.6.0
 caching-compiler@1.2.1
@@ -24,8 +23,6 @@ ddp-rate-limiter@1.0.7
 ddp-server@2.3.0
 deps@1.0.12
 diff-sequence@1.1.1
-dispatch:mocha-phantomjs@0.1.9
-dispatch:phantomjs-tests@0.0.7
 dynamic-import@0.5.1
 ecmascript@0.12.7
 ecmascript-runtime@0.7.0
@@ -41,11 +38,9 @@ html-tools@1.0.11
 htmljs@1.0.11
 http@1.4.2
 id-map@1.1.0
-insecure@1.0.7
 inter-process-messaging@0.1.0
 jquery@1.12.1-beta162.5
 kadira:dochead@1.5.0
-launch-screen@1.1.1
 less@2.8.0
 livedata@1.0.18
 localstorage@1.2.0
@@ -57,8 +52,6 @@ minifier-js@2.4.1
 minimongo@1.4.5
 mizzao:timesync@0.5.0
 mizzao:user-status@0.6.7
-mobile-experience@1.0.5
-mobile-status-bar@1.0.14
 modern-browsers@0.1.4
 modules@0.13.0
 modules-runtime@0.10.3
@@ -70,11 +63,6 @@ npm-bcrypt@0.9.3
 npm-mongo@3.1.2
 observe-sequence@1.0.16
 ordered-dict@1.1.0
-practicalmeteor:chai@2.1.0_1
-practicalmeteor:loglevel@1.2.0_2
-practicalmeteor:mocha@2.4.5_6
-practicalmeteor:mocha-core@1.0.1
-practicalmeteor:sinon@1.14.1_2
 promise@0.11.2
 qualia:one@0.1.0
 random@1.1.0
@@ -97,14 +85,13 @@ srp@1.0.12
 standard-minifier-css@1.5.3
 standard-minifier-js@2.4.1
 staringatlights:inject-data@2.3.0
+static-html@1.2.2
 templating@1.3.2
 templating-compiler@1.3.3
 templating-runtime@1.3.2
 templating-tools@1.1.2
 tmeasday:check-npm-versions@0.3.2
-tmeasday:test-reporter-helpers@0.2.1
 tracker@1.2.0
-ui@1.0.13
 underscore@1.0.10
 url@1.2.0
 webapp@1.7.4

--- a/frog/.meteor/versions
+++ b/frog/.meteor/versions
@@ -38,6 +38,7 @@ html-tools@1.0.11
 htmljs@1.0.11
 http@1.4.2
 id-map@1.1.0
+insecure@1.0.7
 inter-process-messaging@0.1.0
 jquery@1.12.1-beta162.5
 kadira:dochead@1.5.0


### PR DESCRIPTION
Seems like there are a number of Meteor packages that aren't being used, but still get compiled at startup, removing them seems like a good idea. Could you make sure things still seem to work well?