### PR TITLE
Fix React `key` issue in FrogForm

### DIFF
--- a/frog/imports/frog-utils/FrogForm/components/PrimaryGrouping.jsx
+++ b/frog/imports/frog-utils/FrogForm/components/PrimaryGrouping.jsx
@@ -81,7 +81,7 @@ export const PrimaryGrouping = (props: ObjectFieldTemplatePropsT) => {
       {expand && (
         <div className={classes.fields}>
           {properties.map(p => (
-            <div>{p.content}</div>
+            <div key={p.name}>{p.content}</div>
           ))}
         </div>
       )}


### PR DESCRIPTION
This PR fixes a React warning regarding missing keys in FrogForm.

**Testing done**

Tested in Single Activity