### PR TITLE
Warning Light Position Fix

### DIFF
--- a/frog/imports/client/GraphEditor/Validator.js
+++ b/frog/imports/client/GraphEditor/Validator.js
@@ -145,7 +145,7 @@ export const ValidButtonRaw = ({
     <circle
       cx="17"
       cy="17"
-      r="12"
+      r="8"
       stroke="transparent"
       fill={errorColor || graphErrorColor}
       onMouseOver={() => setShowErrors(activityId || true)}

--- a/frog/imports/client/SingleActivity/components/ui/SplitLayout.js
+++ b/frog/imports/client/SingleActivity/components/ui/SplitLayout.js
@@ -13,6 +13,9 @@ const useStyle = makeStyles(() => ({
     gridTemplateRows: '1fr',
     gridTemplateColumns: '1fr 1fr',
     gridGap: '64px'
+  },
+  left: {
+    position: 'relative'
   }
 }));
 


### PR DESCRIPTION
The warning light now placed at the top-right area of the config form instead of the page by changing the position to relative for its split parent.