### PR TITLE
Shifting location of create using wizard button on logged in view 

### DIFF
--- a/frog/imports/client/UserDashboard/components/DashboardSideBar/index.js
+++ b/frog/imports/client/UserDashboard/components/DashboardSideBar/index.js
@@ -1,6 +1,12 @@
 // @flow
 import * as React from 'react';
-import { AccessTimeOutlined, Bookmark, ShowChart } from '@material-ui/icons';
+import {
+  AccessTimeOutlined,
+  Bookmark,
+  ShowChart,
+  Add,
+  KeyboardArrowRight
+} from '@material-ui/icons';
 import { Sidebar, Panel } from '/imports/ui/Sidebar';
 import { Logo } from '/imports/ui/Logo';
 import { SidebarLayout } from '/imports/ui/Layout/SidebarLayout';
@@ -39,12 +45,15 @@ export const DashboardSideBar = ({
               <>
                 <Logo />
                 <RowTitle> Dashboard </RowTitle>
+
+                <RowButton
+                  size="large"
+                  icon={<Add fontSize="small" />}
+                  onClick={() => history.push('/wizard')}
+                >
+                  Create using Wizard
+                </RowButton>
               </>
-            }
-            footer={
-              <RowButton active onClick={() => history.push('/wizard')}>
-                Create using Wizard
-              </RowButton>
             }
           >
             <Panel>
@@ -52,6 +61,7 @@ export const DashboardSideBar = ({
                 onClick={callbackRecentsView}
                 active={recentsActive}
                 icon={<AccessTimeOutlined />}
+                rightIcon={<KeyboardArrowRight fontSize="small" />}
               >
                 Recents
               </RowButton>
@@ -59,6 +69,7 @@ export const DashboardSideBar = ({
                 icon={<Bookmark />}
                 active={sessionsActive}
                 onClick={callbackSessionsView}
+                rightIcon={<KeyboardArrowRight fontSize="small" />}
               >
                 Sessions
               </RowButton>
@@ -66,6 +77,7 @@ export const DashboardSideBar = ({
                 icon={<ShowChart />}
                 active={draftsActive}
                 onClick={callbackDraftsView}
+                rightIcon={<KeyboardArrowRight fontSize="small" />}
               >
                 Drafts
               </RowButton>

--- a/frog/imports/client/UserDashboard/components/RecentsPage/index.js
+++ b/frog/imports/client/UserDashboard/components/RecentsPage/index.js
@@ -44,9 +44,7 @@ export const RecentsPage = ({
             <Typography variant="h5" align="left">
               <ShowChart /> Drafts
             </Typography>
-            <Button icon={<Add />} onClick={actionCallback} variant="primary">
-              Create a new graph
-            </Button>
+            <Button icon={<Add />} onClick={actionCallback} variant="primary" />
           </div>
 
           <List>


### PR DESCRIPTION
This PR introduces a small change to the logged in view of FROG to make the create using wizard button more visible. It is now shifted to the top of the sidebar. Furthermore, considering the discussion about the create using graph button not being the most important I have changed to be just a + next to the Drafts list. 

