### PR TITLE
Migrating top bar to graph editor

### DIFF
--- a/frog/imports/api/graphs.js
+++ b/frog/imports/api/graphs.js
@@ -226,6 +226,11 @@ export const setCurrentGraph = (graphId: string) => {
 };
 
 export const assignGraph = (wantedId?: string) => {
+  if (wantedId === 'new') {
+    const graphId = addGraph();
+    setCurrentGraph(graphId);
+    return graphId;
+  }
   const user = Meteor.user();
   if (wantedId && Graphs.findOne(wantedId)) {
     return wantedId;

--- a/frog/imports/api/sessions.js
+++ b/frog/imports/api/sessions.js
@@ -243,20 +243,10 @@ export const addSessionFn = (graphId: string, slug?: string): string => {
 
     const sessionId = uuid();
     const graph = Graphs.findOne(graphId);
-    const match = graph.name.match(/(.+)\((\d+)\)$/);
-    let newName;
-    if (match) {
-      newName = match[1] + ' (' + (parseInt(match[2], 10) + 1) + ')';
-    } else {
-      newName = graph.name + ' (2)';
-    }
-    if (newName[0] !== '#') {
-      newName = '#' + newName;
-    }
     const activities = Activities.find({ graphId }).fetch();
 
     const copyGraphId = addGraph({
-      graph: { ...graph, name: newName },
+      graph: { ...graph, sessionGraph: true, name: graph.name },
       activities,
       operators: Operators.find({ graphId }).fetch(),
       connections: Connections.find({ graphId }).fetch()
@@ -278,7 +268,7 @@ export const addSessionFn = (graphId: string, slug?: string): string => {
     Sessions.insert({
       _id: sessionId,
       fromGraphId: graphId,
-      name: newName,
+      name: graph.name,
       graphId: copyGraphId,
       state: 'CREATED',
       ownerId: Meteor.userId(),

--- a/frog/imports/client/GraphEditor/EditorContainer.js
+++ b/frog/imports/client/GraphEditor/EditorContainer.js
@@ -5,6 +5,7 @@ import { withStyles } from '@material-ui/styles';
 import ReactTooltip from 'react-tooltip';
 import { Graphs } from '/imports/api/graphs';
 import Grid from '@material-ui/core/Grid';
+import Clear from '@material-ui/icons/Clear';
 import { withTracker } from 'meteor/react-meteor-data';
 import { Meteor } from 'meteor/meteor';
 
@@ -21,16 +22,17 @@ import ChangelogModal from './ChangelogModal';
 import ModalExport from './RemoteControllers/ModalExport';
 import ModalImport from './RemoteControllers/ModalImport';
 import ModalDelete from './RemoteControllers/ModalDelete';
-
+import { withRouter } from 'react-router';
 import TopPanel from './TopPanel';
 import Preview from '../Preview';
 import OperatorPreview from '../Preview/OperatorPreview';
-import TopBar from '../App/TopBar';
+import { TopBarAccountsWrapper } from '/imports/containers/TopBarWrapper';
+import { Breadcrumb } from '/imports/ui/Breadcrumb';
+import { Button } from '/imports/ui/Button';
 
 const styles = () => ({
   root: {
-    marginTop: '48px',
-    height: 'calc(100vh - 48px)',
+    height: '100vh',
     overflowX: 'auto'
   },
   editor: { height: 350, background: '#EAF1F8' },
@@ -78,7 +80,7 @@ class Editor extends React.Component<Object, StateT> {
   }
 
   render() {
-    const { classes, store } = this.props;
+    const { classes, store, history } = this.props;
     const show = this.props.store.ui.showPreview;
     if (show && show.activityTypeId) {
       return (
@@ -99,9 +101,18 @@ class Editor extends React.Component<Object, StateT> {
     const setIdRemove = val => this.setState({ idRemove: val });
     return (
       <div className={classes.root}>
-        <TopBar />
-        <Grid container>
-          <Grid item xs={12}>
+        <TopBarAccountsWrapper
+          navigation={
+            <>
+              <Button
+                variant="minimal"
+                icon={<Clear />}
+                onClick={() => history.push('/')}
+              />
+              <Breadcrumb paths={['Graph Editor']} />
+            </>
+          }
+          actions={
             <TopPanel
               openExport={() => this.setState({ exportOpen: true })}
               openImport={() => this.setState({ importOpen: true })}
@@ -110,6 +121,10 @@ class Editor extends React.Component<Object, StateT> {
                 setIdRemove
               }}
             />
+          }
+        />
+        <Grid container>
+          <Grid item xs={12}>
             <ModalExport
               exportType="graph"
               modalOpen={this.state.exportOpen}
@@ -175,8 +190,8 @@ class Editor extends React.Component<Object, StateT> {
     );
   }
 }
-
-const StyledEditor = withStyles(styles)(Editor);
+const withRouterEditor = withRouter(Editor);
+const StyledEditor = withStyles(styles)(withRouterEditor);
 
 const SubscriptionWrapper = withTracker(({ graphId }) => {
   const subscription = Meteor.subscribe('teacher.graph', graphId);

--- a/frog/imports/client/GraphEditor/EditorContainer.js
+++ b/frog/imports/client/GraphEditor/EditorContainer.js
@@ -114,6 +114,9 @@ class Editor extends React.Component<Object, StateT> {
           }
           actions={
             <TopPanel
+              graphId={store.graphId}
+              history={history}
+              errors={store.graphErrors}
               openExport={() => this.setState({ exportOpen: true })}
               openImport={() => this.setState({ importOpen: true })}
               {...{

--- a/frog/imports/client/GraphEditor/TopPanel/Settings.js
+++ b/frog/imports/client/GraphEditor/TopPanel/Settings.js
@@ -68,21 +68,6 @@ const styles = theme => ({
   }
 });
 
-const HelpButtonComponent = ({ classes, store: { ui } }) => (
-  <div className={classes.root}>
-    <Tooltip id="tooltip-top" title="Show instructions">
-      <Button
-        onClick={() => ui.setShowHelpModal(true)}
-        color="primary"
-        className={classes.helpButton}
-      >
-        HELP
-        <Help className={classes.rightIcon} />
-      </Button>
-    </Tooltip>
-  </div>
-);
-
 const UndoButtonComponent = ({ classes, store: { undo } }) => (
   <div className={classes.root}>
     <Tooltip id="tooltip-top" title="undo the last graph action">
@@ -95,7 +80,6 @@ const UndoButtonComponent = ({ classes, store: { undo } }) => (
 );
 
 export const UndoButton = withStyles(styles)(connect(UndoButtonComponent));
-export const HelpButton = withStyles(styles)(connect(HelpButtonComponent));
 
 const MenuItemDeleteFromServer = ({
   setIdRemove,
@@ -140,7 +124,7 @@ class GraphActionMenu extends React.Component<*, *> {
       setIdRemove,
       store: {
         graphId,
-        ui: { setSidepanelOpen }
+        ui: { setSidepanelOpen, setShowHelpModal }
       }
     } = this.props;
     const { anchorEl } = this.state;
@@ -217,7 +201,7 @@ class GraphActionMenu extends React.Component<*, *> {
           </MenuItem>
           <MenuItem
             onClick={() => {
-              setSidepanelOpen(false);
+              setSidepanelOpen(true);
               this.props.openImport();
               this.handleClose();
             }}
@@ -255,6 +239,10 @@ class GraphActionMenu extends React.Component<*, *> {
           >
             <Timeline className={classes.leftIcon} aria-hidden="true" />
             Export Graph to the Server
+          </MenuItem>
+          <MenuItem onClick={() => setShowHelpModal(true)}>
+            <Help className={classes.leftIcon} aria-hidden="true" />
+            Help
           </MenuItem>
           <MenuItemDeleteFromServer
             {...{ setIdRemove, parentId, setDelete, classes }}

--- a/frog/imports/client/GraphEditor/TopPanel/index.js
+++ b/frog/imports/client/GraphEditor/TopPanel/index.js
@@ -5,6 +5,8 @@ import { withStyles } from '@material-ui/styles';
 import { UndoButton, ConfigMenu } from './Settings';
 import { ValidButton } from '/imports/client/GraphEditor/Validator';
 import { Button } from '/imports/ui/Button';
+import { addSession, setTeacherSession, Sessions } from '/imports/api/sessions';
+import { Graphs } from '/imports/api/graphs';
 
 const styles = theme => ({
   root: {
@@ -15,10 +17,30 @@ const styles = theme => ({
   }
 });
 
-const TopPanel = ({ classes, ...props }: Object) => (
+const publish = async (graphId, history) => {
+  const sessionId = await addSession(graphId);
+  const session = Sessions.findOne(sessionId);
+  if (session) {
+    Graphs.update(graphId, { $set: { published: true } });
+    await setTeacherSession(sessionId);
+    history.push('/t/' + session.slug);
+  }
+};
+
+const TopPanel = ({ classes, graphId, errors, history, ...props }: Object) => (
   <div className={classes.root}>
     <UndoButton />
-    <Button rightIcon={<ValidButton />}> Publish </Button>
+    <Button
+      onClick={() => {
+        // don't publish if there are errors
+        if (errors.length === 0) {
+          publish(graphId, history);
+        }
+      }}
+      rightIcon={<ValidButton />}
+    >
+      Publish
+    </Button>
     <ConfigMenu {...props} />
   </div>
 );

--- a/frog/imports/client/GraphEditor/TopPanel/index.js
+++ b/frog/imports/client/GraphEditor/TopPanel/index.js
@@ -2,10 +2,9 @@
 
 import React from 'react';
 import { withStyles } from '@material-ui/styles';
-
-import GraphMenu from './GraphMenu';
-import { UndoButton, HelpButton, ConfigMenu } from './Settings';
-import ExpandButton from '../SidePanel/ExpandButton';
+import { UndoButton, ConfigMenu } from './Settings';
+import { ValidButton } from '/imports/client/GraphEditor/Validator';
+import { Button } from '/imports/ui/Button';
 
 const styles = theme => ({
   root: {
@@ -18,11 +17,9 @@ const styles = theme => ({
 
 const TopPanel = ({ classes, ...props }: Object) => (
   <div className={classes.root}>
-    <ConfigMenu {...props} />
-    <GraphMenu />
-    <HelpButton />
     <UndoButton />
-    <ExpandButton />
+    <Button rightIcon={<ValidButton />}> Publish </Button>
+    <ConfigMenu {...props} />
   </div>
 );
 

--- a/frog/imports/client/GraphEditor/store/uiStore.js
+++ b/frog/imports/client/GraphEditor/store/uiStore.js
@@ -116,7 +116,7 @@ export default class uiStore {
     const user = Meteor.user();
 
     extendObservable(this, {
-      sidepanelOpen: false,
+      sidepanelOpen: true,
       svgRef: null,
       scale: 1,
       windowWidth: 1000,

--- a/frog/imports/client/UserDashboard/containers/DashboardContentContainer.jsx
+++ b/frog/imports/client/UserDashboard/containers/DashboardContentContainer.jsx
@@ -65,7 +65,7 @@ export const DashboardContentContainer = ({
           <RecentsPage
             sessionsList={sortedSessionsList}
             draftsList={sortedDraftsList}
-            actionCallback={() => history.push('/teacher')}
+            actionCallback={() => history.push('/teacher/graph/new')}
             moreCallbackSessions={onSelectSessionsView}
             moreCallbackDrafts={onSelectDraftsView}
           />

--- a/frog/imports/client/UserDashboard/data-utils/helpers.js
+++ b/frog/imports/client/UserDashboard/data-utils/helpers.js
@@ -58,38 +58,27 @@ const getSessionTypeInfo = (session): meteorSessionObjectT => {
   else return `Graph | Slug: ${session.slug}`;
 };
 
-export const parseDraftData = (
-  draftsList: meteorDraftsList,
-  history: Object
-) => {
-  const resArray = [];
-  draftsList.map(item => {
-    resArray.push({
+export const parseDraftData = (draftsList: meteorDraftsList, history: Object) =>
+  draftsList
+    .filter(x => !x.published && !x.sessionGraph)
+    .map(item => ({
       itemIcon: ShowChart,
       itemTitle: item.name,
       dateCreated: parseDate(item.createdAt),
       dateObj: item.createdAt,
       callback: () => history.push(`/teacher/graph/${item._id}`)
-    });
-  });
-  return resArray;
-};
+    }));
 
 export const parseSessionData = (
   sessionsList: meteorSessionsListT,
   history: Object
-) => {
-  const resArray = [];
-  sessionsList.map(item => {
-    resArray.push({
-      itemIcon: getSessionIcon(item),
-      itemTitle: getSessionTitle(item),
-      status: getSessionStatus(item),
-      itemType: getSessionTypeInfo(item),
-      dateCreated: parseEpocDate(item.startedAt),
-      dateObj: new Date(item.startedAt),
-      callback: () => history.push(`t/${item.slug}`)
-    });
-  });
-  return resArray;
-};
+) =>
+  sessionsList.map(item => ({
+    itemIcon: getSessionIcon(item),
+    itemTitle: getSessionTitle(item),
+    status: getSessionStatus(item),
+    itemType: getSessionTypeInfo(item),
+    dateCreated: parseEpocDate(item.startedAt),
+    dateObj: new Date(item.startedAt),
+    callback: () => history.push(`t/${item.slug}`)
+  }));

--- a/frog/imports/containers/TopBarWrapper/index.js
+++ b/frog/imports/containers/TopBarWrapper/index.js
@@ -50,6 +50,8 @@ export const TopBarAccountsWrapper = ({
       navigation={navigation}
       actions={
         <>
+          <>{actions}</>
+
           <OverflowMenu
             button={
               <Button variant="minimal" icon={<SupervisedUserCircle />} />
@@ -95,8 +97,6 @@ export const TopBarAccountsWrapper = ({
               </React.Fragment>
             )}
           </OverflowMenu>
-
-          <>{actions}</>
         </>
       }
     />

--- a/frog/imports/ui/Breadcrumb/index.js
+++ b/frog/imports/ui/Breadcrumb/index.js
@@ -42,7 +42,11 @@ export const Breadcrumb = (props: BreadcrumbProps) => {
       {props.paths.map((path, index) => (
         <>
           {index !== 0 && (
-            <Typography key={path+'/'} className={classes.text} variant="body1">
+            <Typography
+              key={path + '/'}
+              className={classes.text}
+              variant="body1"
+            >
               /
             </Typography>
           )}

--- a/frog/imports/ui/Breadcrumb/index.js
+++ b/frog/imports/ui/Breadcrumb/index.js
@@ -42,7 +42,7 @@ export const Breadcrumb = (props: BreadcrumbProps) => {
       {props.paths.map((path, index) => (
         <>
           {index !== 0 && (
-            <Typography key={path} className={classes.text} variant="body1">
+            <Typography key={path+'/'} className={classes.text} variant="body1">
               /
             </Typography>
           )}


### PR DESCRIPTION
Initial work. The top bar has 

1. Accounts control 
2. The title - Graph editor with a close button to go back to logged in view.
3. An overflow menu with the help button moved there 
4. A publish button with the status of the graph in it (not wired up yet) 
5. Furthermore, actions have been moved to the left of the accounts control on the TopBar. 
Todo: 
- Wire the publish button 
- Handle how to display the sidebar/preview 

This will probably be my last PR for this summer on FROG. It's been amazing working with everyone, we have accomplished a lot and I have learnt a lot. Thank you for the opportunity :) ! 
(PS: Fun fact:  This PR adds 39 lines and deletes 39 lines in case you haven't noticed, couldn't end this summer on a better note). 