### PR TITLE
Fix/graph editor

### DIFF
--- a/frog/imports/client/GraphEditor/EditorContainer.js
+++ b/frog/imports/client/GraphEditor/EditorContainer.js
@@ -35,7 +35,7 @@ const styles = () => ({
     height: '100vh',
     overflowX: 'auto'
   },
-  editor: { height: 350, background: '#EAF1F8' },
+  editor: { height: 300, background: '#EAF1F8' },
   editorWithPanMap: { height: 150 }
 });
 
@@ -159,9 +159,6 @@ class Editor extends React.Component<Object, StateT> {
           </Grid>
           <Grid item xs={12}>
             <Grid container id="graph-editor">
-              <Grid item xs>
-                <EditorPanel />
-              </Grid>
               <SidePanel
                 madeChanges={() => this.setState({ locallyChanged: true })}
                 locallyChanged={this.state.locallyChanged}
@@ -171,6 +168,12 @@ class Editor extends React.Component<Object, StateT> {
                   setIdRemove
                 }}
               />
+              <Grid></Grid>
+            </Grid>
+          </Grid>
+          <Grid item xs={12}>
+            <Grid item xs>
+              <EditorPanel />
             </Grid>
           </Grid>
         </Grid>

--- a/frog/imports/client/GraphEditor/EditorContainer.js
+++ b/frog/imports/client/GraphEditor/EditorContainer.js
@@ -168,7 +168,6 @@ class Editor extends React.Component<Object, StateT> {
                   setIdRemove
                 }}
               />
-              <Grid></Grid>
             </Grid>
           </Grid>
           <Grid item xs={12}>

--- a/frog/imports/client/GraphEditor/Graph.js
+++ b/frog/imports/client/GraphEditor/Graph.js
@@ -62,8 +62,8 @@ const Graph = connect(
       <svg
         viewBox={
           scaled
-            ? [panOffset, 0, graphWidth, 350].join(' ')
-            : [0, 0, 4 * graphWidth, 350].join(' ')
+            ? [panOffset, 0, graphWidth, 300].join(' ')
+            : [0, 0, 4 * graphWidth, 300].join(' ')
         }
         preserveAspectRatio="none"
         ref={ref => {
@@ -78,7 +78,7 @@ const Graph = connect(
           fill="#EAF1F8"
           stroke="transparent"
           width={scaled ? graphWidth * scale : graphWidth * 4}
-          height="350px"
+          height="300px"
           onClick={canvasClick}
         />
         <LevelLines scaled={scaled} />

--- a/frog/imports/client/GraphEditor/SidePanel/index.js
+++ b/frog/imports/client/GraphEditor/SidePanel/index.js
@@ -12,10 +12,10 @@ import OperatorPanel from './OperatorPanel';
 
 const styles = {
   root: {
-    height: 'calc(100vh - 112px)',
+    height: 'calc(100vh - 48px - 300px)',
     backgroundColor: '#ffffff',
-    boxShadow: '0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24)',
-    width: '500px',
+    borderRight: '1px solid #EAEAEA',
+    width: '400px',
     overflowX: 'auto'
   },
   helperContainer: {
@@ -34,9 +34,9 @@ const SideBarHelperText = ({ classes }) => (
       <Typography variant="h6" align="center" gutterBottom>
         Select an activity or an operator to configure it.
       </Typography>
-      <Typography variant="subtitle1" align="center">
+      {/* <Typography variant="subtitle1" align="center">
         Press the <kbd>w</kbd> key to toggle the sidebar.
-      </Typography>
+      </Typography> */}
     </div>
   </Grid>
 );

--- a/frog/imports/client/GraphEditor/components/DragGuides.js
+++ b/frog/imports/client/GraphEditor/components/DragGuides.js
@@ -18,7 +18,7 @@ const VerticalLine = ({ x }) => (
     x1={x}
     y1={0}
     x2={x}
-    y2={350}
+    y2={300}
     stroke="grey"
     strokeWidth={1}
     strokeDasharray="5,5"
@@ -33,7 +33,7 @@ const ShadedBox = ({ x, current }) => (
     x={Math.min(current, x)}
     y={0}
     width={Math.abs(x - current)}
-    height={350}
+    height={300}
   />
 );
 

--- a/frog/imports/client/GraphEditor/components/fixedComponents.js
+++ b/frog/imports/client/GraphEditor/components/fixedComponents.js
@@ -41,14 +41,14 @@ export const LevelLines = connect(
     <g>
       {[1, 2, 3].map(plane => (
         <g key={plane}>
-          <text x="5" y={plane * (350 / 4) - 10} fill="#8698AB">
+          <text x="5" y={plane * (300 / 4) - 10} fill="#8698AB">
             {['Class', 'Group', 'Individual'][plane - 1]}
           </text>
           <line
             x1={0}
-            y1={plane * (350 / 4)}
+            y1={plane * (300 / 4)}
             x2={graphWidth * (scaled ? scale : 4)}
-            y2={plane * (350 / 4)}
+            y2={plane * (300 / 4)}
             stroke="#8698AB"
             strokeWidth={5 - plane === 1 ? 2 : 1}
             strokeDasharray={5 - plane === 1 ? '10,10' : '5,5'}
@@ -56,7 +56,7 @@ export const LevelLines = connect(
           <rect
             onDoubleClick={e => onDoubleClick(plane, e)}
             x={0}
-            y={plane * (350 / 4) - 14}
+            y={plane * (300 / 4) - 14}
             width={graphWidth * (scaled ? scale : 4)}
             fill="transparent"
             height={28}
@@ -88,9 +88,9 @@ export const TimeScale = connect(
               {divider < 20 || i % 5 === 0 ? (
                 <line
                   x1={x}
-                  y1={350 - length}
+                  y1={300 - length}
                   x2={x}
-                  y2={350}
+                  y2={300}
                   stroke="#8698AB"
                 />
               ) : null}

--- a/frog/imports/client/GraphEditor/store/activity.js
+++ b/frog/imports/client/GraphEditor/store/activity.js
@@ -301,7 +301,7 @@ export default class Activity extends Elem {
 
       get y(): number {
         const offset = store.activityStore.activityOffsets[this.id];
-        return this.plane * (350 / 4) - 14 - offset * 30;
+        return this.plane * (300 / 4) - 14 - offset * 30;
       },
 
       get endTime(): number {

--- a/frog/imports/client/GraphEditor/store/store.js
+++ b/frog/imports/client/GraphEditor/store/store.js
@@ -262,7 +262,7 @@ export default class Store {
         this.history = [];
         window.setTimeout(() => mongoWatch(id));
         this.state = { mode: 'normal' };
-        this.ui.setSidepanelOpen(false);
+        this.ui.setSidepanelOpen(true);
       }),
 
       addHistory: action(() => {

--- a/frog/imports/client/GraphEditor/store/uiStore.js
+++ b/frog/imports/client/GraphEditor/store/uiStore.js
@@ -242,7 +242,7 @@ export default class uiStore {
 
       updateGraphWidth: action(() => {
         const oldPan = this.panTime;
-        //const boxWidth = this.sidepanelOpen ? 400 : 0;
+        // const boxWidth = this.sidepanelOpen ? 400 : 0;
         this.graphWidth = this.windowWidth; // - boxWidth;
         this.panx = timeToPx(oldPan, this.scale) / this.scale;
       }),

--- a/frog/imports/client/GraphEditor/store/uiStore.js
+++ b/frog/imports/client/GraphEditor/store/uiStore.js
@@ -242,8 +242,8 @@ export default class uiStore {
 
       updateGraphWidth: action(() => {
         const oldPan = this.panTime;
-        const boxWidth = this.sidepanelOpen ? 500 : 0;
-        this.graphWidth = this.windowWidth - boxWidth;
+        const boxWidth = this.sidepanelOpen ? 400 : 0;
+        this.graphWidth = this.windowWidth; // - boxWidth;
         this.panx = timeToPx(oldPan, this.scale) / this.scale;
       }),
 

--- a/frog/imports/client/GraphEditor/store/uiStore.js
+++ b/frog/imports/client/GraphEditor/store/uiStore.js
@@ -242,7 +242,7 @@ export default class uiStore {
 
       updateGraphWidth: action(() => {
         const oldPan = this.panTime;
-        const boxWidth = this.sidepanelOpen ? 400 : 0;
+        //const boxWidth = this.sidepanelOpen ? 400 : 0;
         this.graphWidth = this.windowWidth; // - boxWidth;
         this.panx = timeToPx(oldPan, this.scale) / this.scale;
       }),


### PR DESCRIPTION
This PR fixes the Graph Editor UI to match the intended design.

- [ ]  Positioning the Side Panel on the top left side
- [ ]  Placing the graph (full-width) on the bottom
- [ ]  Adding the Preview component
- [ ]  Changing the interactions to match the new design view (opening and closing of panels, action selection etc)