### PR TITLE
Fixing Minor Bugs with the Graph Editor View

### DIFF
--- a/frog/imports/client/GraphEditor/Rename.js
+++ b/frog/imports/client/GraphEditor/Rename.js
@@ -20,7 +20,7 @@ export const RenameBox = connect(
         style={{
           position: 'absolute',
           left: `${renameOpen.screenX}px`,
-          top: `${renameOpen.y + 100}px`
+          top: `calc(100vh - 300px + ${renameOpen.y}px`
         }}
       >
         <RenameField activityId={renameOpen.id} onSubmit={endRename} />

--- a/frog/imports/client/GraphEditor/SidePanel/index.js
+++ b/frog/imports/client/GraphEditor/SidePanel/index.js
@@ -12,7 +12,7 @@ import OperatorPanel from './OperatorPanel';
 
 const styles = {
   root: {
-    height: 'calc(100vh - 48px - 300px)',
+    height: 'calc(100vh - 50px - 300px)',
     backgroundColor: '#ffffff',
     borderRight: '1px solid #EAEAEA',
     width: '400px',

--- a/frog/imports/client/GraphEditor/components/fixedComponents.js
+++ b/frog/imports/client/GraphEditor/components/fixedComponents.js
@@ -41,14 +41,14 @@ export const LevelLines = connect(
     <g>
       {[1, 2, 3].map(plane => (
         <g key={plane}>
-          <text x="5" y={plane * (300 / 4) - 10} fill="#8698AB">
-            {['Class', 'Group', 'Individual'][plane - 1]}
+          <text x="5" y={300 * (1 - plane / 4) - 5} fill="#8698AB">
+            {['Individual', 'Group', 'Class'][plane - 1]}
           </text>
           <line
             x1={0}
-            y1={plane * (300 / 4)}
+            y1={300 * (1 - plane / 4)}
             x2={graphWidth * (scaled ? scale : 4)}
-            y2={plane * (300 / 4)}
+            y2={300 * (1 - plane / 4)}
             stroke="#8698AB"
             strokeWidth={5 - plane === 1 ? 2 : 1}
             strokeDasharray={5 - plane === 1 ? '10,10' : '5,5'}
@@ -56,7 +56,7 @@ export const LevelLines = connect(
           <rect
             onDoubleClick={e => onDoubleClick(plane, e)}
             x={0}
-            y={plane * (300 / 4) - 14}
+            y={300 * (1 - plane / 4) - 14}
             width={graphWidth * (scaled ? scale : 4)}
             fill="transparent"
             height={28}

--- a/frog/imports/client/GraphEditor/store/activity.js
+++ b/frog/imports/client/GraphEditor/store/activity.js
@@ -301,7 +301,7 @@ export default class Activity extends Elem {
 
       get y(): number {
         const offset = store.activityStore.activityOffsets[this.id];
-        return this.plane * (300 / 4) - 14 - offset * 30;
+        return 300 * (1 - this.plane / 4) - 14 - offset * 30;
       },
 
       get endTime(): number {


### PR DESCRIPTION
This PR fixes: 
- The fixed guide lines order in the graph
- Rename Component Positioning
- Extra spacing of the components. Now the view fits in the screen.