### PR TITLE
Simple Date Formatting for Draft/Session List Items

### DIFF
--- a/frog/imports/client/GraphEditor/Graph.js
+++ b/frog/imports/client/GraphEditor/Graph.js
@@ -22,8 +22,8 @@ const scrollMouse = e => {
 };
 
 const mousemove = e => {
-  // Subtracting Graph Editor's position from the top of the screen
-  store.ui.socialMove(e.clientX, e.clientY - (screen.height - 300 - 100));
+  // We do -100 here because there is 100px above the graph editor
+  store.ui.socialMove(e.clientX, e.clientY - 100);
 };
 
 const Graph = connect(

--- a/frog/imports/client/GraphEditor/Graph.js
+++ b/frog/imports/client/GraphEditor/Graph.js
@@ -22,8 +22,7 @@ const scrollMouse = e => {
 };
 
 const mousemove = e => {
-  // We do -100 here because there is 100px above the graph editor
-  //store.ui.socialMove(e.clientX, e.clientY - 100);
+  // Subtracting Graph Editor's position from the top of the screen
   store.ui.socialMove(e.clientX, e.clientY - (screen.height - 300 - 100));
 };
 

--- a/frog/imports/client/GraphEditor/Graph.js
+++ b/frog/imports/client/GraphEditor/Graph.js
@@ -23,7 +23,8 @@ const scrollMouse = e => {
 
 const mousemove = e => {
   // We do -100 here because there is 100px above the graph editor
-  store.ui.socialMove(e.clientX, e.clientY - 100);
+  //store.ui.socialMove(e.clientX, e.clientY - 100);
+  store.ui.socialMove(e.clientX, e.clientY - (screen.height - 300 - 100));
 };
 
 const Graph = connect(

--- a/frog/imports/client/UserDashboard/data-utils/helpers.js
+++ b/frog/imports/client/UserDashboard/data-utils/helpers.js
@@ -23,7 +23,8 @@ type meteorDraftsList = Array<meteorDraftObjectT>;
 type meteorSessionsListT = Array<meteorSessionObjectT>;
 
 export const parseDate = (date): Date => {
-  return `${date.getDate()}/${date.getMonth() + 1}/${date.getFullYear()}`;
+  return `${date.getHours()}:${date.getMinutes()}:${date.getSeconds()} ${date.getDate()}/${date.getMonth() +
+    1}/${date.getFullYear()}`;
 };
 
 const parseEpocDate = (epoc): string => {

--- a/frog/imports/ui/ListItem/index.js
+++ b/frog/imports/ui/ListItem/index.js
@@ -75,8 +75,8 @@ export const ContentListItem = ({
       parseInt(timeNowSplit[0], 10) - parseInt(timeThenSplit[0], 10);
     const diffMinutes =
       parseInt(timeNowSplit[1], 10) - parseInt(timeThenSplit[1], 10);
-    const diffSeconds =
-      parseInt(timeNowSplit[2], 10) - parseInt(timeThenSplit[2], 10);
+    // const diffSeconds =
+    //   parseInt(timeNowSplit[2], 10) - parseInt(timeThenSplit[2], 10);
     if (diffYear > 0) {
       return `${diffYear} year${diffYear > 1 ? 's' : ''} ago`;
     } else if (diffMonth > 0) {

--- a/frog/imports/ui/ListItem/index.js
+++ b/frog/imports/ui/ListItem/index.js
@@ -52,6 +52,24 @@ export const ContentListItem = ({
   const classes = useStyles();
   const secondaryText = status ? `${status} | ${itemType}` : itemType || ' ';
 
+  const DateToMoments = dateThen => {
+    dateThenParse = dateThen.split('/');
+    dateNow = new Date().toLocaleDateString();
+    dateNowParse = dateNow.split('/');
+    diffYear = parseInt(dateNowParse[2]) - parseInt(dateThenParse[2]);
+    diffMonth = parseInt(dateNowParse[1]) - parseInt(dateThenParse[1]);
+    diffDate = parseInt(dateNowParse[0]) - parseInt(dateThenParse[0]);
+    if (diffYear > 0) {
+      return `${diffYear} year${diffYear > 1 ? 's' : ''} ago`;
+    } else if (diffMonth > 0) {
+      return `${diffMonth} month${diffMonth > 1 ? 's' : ''} ago`;
+    } else if (diffDate > 0) {
+      return `${diffDate} day${diffDate > 1 ? 's' : ''} ago`;
+    } else {
+      return `Today`;
+    }
+  };
+
   return (
     <ListItem alignItems="flex-start" divider button onClick={callback}>
       <ListItemIcon>
@@ -65,7 +83,7 @@ export const ContentListItem = ({
         color="textSecondary"
         variant="body2"
       >
-        {dateCreated}
+        {DateToMoments(dateCreated)}
       </Typography>
       {secondaryActions && (
         <ListItemSecondaryAction>

--- a/frog/imports/ui/ListItem/index.js
+++ b/frog/imports/ui/ListItem/index.js
@@ -53,12 +53,15 @@ export const ContentListItem = ({
   const secondaryText = status ? `${status} | ${itemType}` : itemType || ' ';
 
   const DateToMoments = dateThen => {
-    let dateThenParse = dateThen.split('/');
-    let dateNow = new Date().toLocaleDateString();
-    let dateNowParse = dateNow.split('/');
-    let diffYear = parseInt(dateNowParse[2]) - parseInt(dateThenParse[2]);
-    let diffMonth = parseInt(dateNowParse[1]) - parseInt(dateThenParse[1]);
-    let diffDate = parseInt(dateNowParse[0]) - parseInt(dateThenParse[0]);
+    const dateThenParse = dateThen.split('/');
+    const dateNow = new Date().toLocaleDateString();
+    const dateNowParse = dateNow.split('/');
+    const diffYear =
+      parseInt(dateNowParse[2], 10) - parseInt(dateThenParse[2], 10);
+    const diffMonth =
+      parseInt(dateNowParse[1], 10) - parseInt(dateThenParse[1], 10);
+    const diffDate =
+      parseInt(dateNowParse[0], 10) - parseInt(dateThenParse[0], 10);
     if (diffYear > 0) {
       return `${diffYear} year${diffYear > 1 ? 's' : ''} ago`;
     } else if (diffMonth > 0) {

--- a/frog/imports/ui/ListItem/index.js
+++ b/frog/imports/ui/ListItem/index.js
@@ -53,12 +53,12 @@ export const ContentListItem = ({
   const secondaryText = status ? `${status} | ${itemType}` : itemType || ' ';
 
   const DateToMoments = dateThen => {
-    dateThenParse = dateThen.split('/');
-    dateNow = new Date().toLocaleDateString();
-    dateNowParse = dateNow.split('/');
-    diffYear = parseInt(dateNowParse[2]) - parseInt(dateThenParse[2]);
-    diffMonth = parseInt(dateNowParse[1]) - parseInt(dateThenParse[1]);
-    diffDate = parseInt(dateNowParse[0]) - parseInt(dateThenParse[0]);
+    let dateThenParse = dateThen.split('/');
+    let dateNow = new Date().toLocaleDateString();
+    let dateNowParse = dateNow.split('/');
+    let diffYear = parseInt(dateNowParse[2]) - parseInt(dateThenParse[2]);
+    let diffMonth = parseInt(dateNowParse[1]) - parseInt(dateThenParse[1]);
+    let diffDate = parseInt(dateNowParse[0]) - parseInt(dateThenParse[0]);
     if (diffYear > 0) {
       return `${diffYear} year${diffYear > 1 ? 's' : ''} ago`;
     } else if (diffMonth > 0) {

--- a/frog/imports/ui/ListItem/index.js
+++ b/frog/imports/ui/ListItem/index.js
@@ -52,24 +52,43 @@ export const ContentListItem = ({
   const classes = useStyles();
   const secondaryText = status ? `${status} | ${itemType}` : itemType || ' ';
 
-  const DateToMoments = dateThen => {
-    const dateThenParse = dateThen.split('/');
-    const dateNow = new Date().toLocaleDateString();
-    const dateNowParse = dateNow.split('/');
+  const DateToMoments = moment => {
+    const dateThen = moment.split(' ')[1];
+    const timeThen = moment.split(' ')[0];
+    const dateThenSplit = dateThen.split('/');
+    const timeThenSplit = timeThen.split(':');
+    const date = new Date();
+    const dateNow = date.toLocaleDateString();
+    const timeNowSplit = [
+      date.getHours(),
+      date.getMinutes(),
+      date.getSeconds()
+    ];
+    const dateNowSplit = dateNow.split('/');
     const diffYear =
-      parseInt(dateNowParse[2], 10) - parseInt(dateThenParse[2], 10);
+      parseInt(dateNowSplit[2], 10) - parseInt(dateThenSplit[2], 10);
     const diffMonth =
-      parseInt(dateNowParse[1], 10) - parseInt(dateThenParse[1], 10);
+      parseInt(dateNowSplit[1], 10) - parseInt(dateThenSplit[1], 10);
     const diffDate =
-      parseInt(dateNowParse[0], 10) - parseInt(dateThenParse[0], 10);
+      parseInt(dateNowSplit[0], 10) - parseInt(dateThenSplit[0], 10);
+    const diffHours =
+      parseInt(timeNowSplit[0], 10) - parseInt(timeThenSplit[0], 10);
+    const diffMinutes =
+      parseInt(timeNowSplit[1], 10) - parseInt(timeThenSplit[1], 10);
+    const diffSeconds =
+      parseInt(timeNowSplit[2], 10) - parseInt(timeThenSplit[2], 10);
     if (diffYear > 0) {
       return `${diffYear} year${diffYear > 1 ? 's' : ''} ago`;
     } else if (diffMonth > 0) {
       return `${diffMonth} month${diffMonth > 1 ? 's' : ''} ago`;
     } else if (diffDate > 0) {
       return `${diffDate} day${diffDate > 1 ? 's' : ''} ago`;
+    } else if (diffHours > 0) {
+      return `${diffHours} hour${diffHours > 1 ? 's' : ''} ago`;
+    } else if (diffMinutes > 0) {
+      return `${diffMinutes} minute${diffMinutes > 1 ? 's' : ''} ago`;
     } else {
-      return `Today`;
+      return `a few seconds ago`;
     }
   };
 


### PR DESCRIPTION
This PR provides a simple function to convert the date formatted as 'DD/MM/YYYY' to one these relevant strings: 'Today', 'x days ago', 'x months ago' or 'x years ago'.
Note: 'x minutes/x seconds' cannot be calculated yet as the only input received is the formatted date of creation.