### PR TITLE
Fix title in array field

### DIFF
--- a/frog/imports/frog-utils/FrogForm/FieldTemplate.js
+++ b/frog/imports/frog-utils/FrogForm/FieldTemplate.js
@@ -1,14 +1,25 @@
 // @flow
 
 import * as React from 'react';
+import { makeStyles } from '@material-ui/core';
 
 import { Label } from './components/Label';
 import type { FieldTemplatePropsT } from './types';
+
+const useStyle = makeStyles(theme => ({
+  '@global': {
+    '.field-array legend': {
+      fontSize: '1.2em !important',
+      fontWeight: 700
+    }
+  }
+}));
 
 /**
  * Redefines the UI of fields, by changing the way labels are displayed
  */
 export const FieldTemplate = (props: FieldTemplatePropsT) => {
+  useStyle();
   if (props.displayLabel) {
     return (
       <Label label={props.label} description={props.rawDescription}>


### PR DESCRIPTION
This PR reduces the font size of the title in an array field. This is a hack however, look at branch `feature/ui_update_form` for a better (but broken) implementation.