### PR TITLE
Fix export session function

### DIFF
--- a/frog/imports/client/TeacherView/containers/TopBarContainer/index.js
+++ b/frog/imports/client/TeacherView/containers/TopBarContainer/index.js
@@ -87,7 +87,10 @@ export const TopBarContainer = withRouter(({ history }) => {
             Open 4 students
           </RowButton>
           <RowDivider />
-          <RowButton icon={<SaveAlt fontSize="small" />}>
+          <RowButton
+            icon={<SaveAlt fontSize="small" />}
+            onClick={session.exportSession}
+          >
             Export session
           </RowButton>
           <RowButton

--- a/frog/imports/client/TeacherView/context/actions/exportActions.js
+++ b/frog/imports/client/TeacherView/context/actions/exportActions.js
@@ -2,9 +2,11 @@
 
 import { Meteor } from 'meteor/meteor';
 import downloadLog from '../../utils/downloadLog';
+import { exportSession } from '../../utils/exportComponent';
 
 export const exportActions = (session: Object) => ({
   downloadLog: () => downloadLog(session._id),
+  exportSession: () => exportSession(session._id),
   exportWiki: () => () => {
     const whereTo = window.prompt('Which wiki should pages be exported to?');
     if (!whereTo) {


### PR DESCRIPTION
The button "exportSession" in the session orchestration view had no "onClick" assigned in the new UI. Adding it using the old export session seems to work.