### PR TITLE
Add missing test of config validity for preview in Graph Editor mode

### DIFF
--- a/frog/imports/client/GraphEditor/PreviewPanel.js
+++ b/frog/imports/client/GraphEditor/PreviewPanel.js
@@ -10,10 +10,18 @@ const PreviewPanel = ({
     ui: { selected }
   }
 }) => {
-  const activityToPreview = selected && Activities.findOne(selected.id);
-  return activityToPreview &&
-    selected.activityType &&
-    activityTypesObj[selected.activityType]?.meta?.preview !== false ? (
+  if (!selected) return null;
+  const activityToPreview = Activities.findOne(selected.id);
+  if (!activityToPreview) return <p>Nothing to preview</p>;
+  if (!selected.activityType) return null;
+  const aTO = activityTypesObj[selected.activityType];
+  if (
+    aTO.validateConfig &&
+    aTO.validateConfig.find(f => f(selected.dataDelayed))
+  )
+    return <p>The config is invalid</p>;
+
+  return aTO && aTO?.meta?.preview !== false ? (
     <Preview
       activityTypeId={activityToPreview.activityType}
       graphEditor

--- a/frog/imports/client/GraphEditor/store/activity.js
+++ b/frog/imports/client/GraphEditor/store/activity.js
@@ -140,8 +140,7 @@ export default class Activity extends Elem {
         this.plane = newact.plane;
         this.activityType = newact.activityType;
         const errors = store.graphErrors.filter(x => x.id === this.id);
-        const error = errors.filter(x => x.severity === 'error');
-        if (error.length === 0) {
+        if (!errors.find(x => x.severity === 'error')) {
           if (isEmpty(toJS(this.dataDelayed))) {
             this.setDataDelayedNow(newact.data);
           } else {


### PR DESCRIPTION
Unsurprisingly students using CHILIFROG clicked on every available buttons. A lot of the errors caught on Sentry come from the preview crashing. Unlike the preview in the Preview mode, the preview in the Graph editor mode does not correctly check for config validity. This PR fixes that