### PR TITLE
Prevent defaults for backspace keypress event

### DIFF
--- a/frog/imports/client/GraphEditor/index.js
+++ b/frog/imports/client/GraphEditor/index.js
@@ -70,7 +70,10 @@ const bindKeys = () => {
       store.ui.unselect();
     }
   });
-  Mousetrap.bind('backspace', () => store.deleteSelected(false));
+  Mousetrap.bind('backspace', e => {
+    e.preventDefault();
+    store.deleteSelected(false);
+  });
   Mousetrap.bind('shift+backspace', () => store.deleteSelected(true));
   Mousetrap.bind('?', () => store.ui.setShowHelpModal(true));
   Mousetrap.bind('!', () => store.ui.setShowChangelogModal(true));


### PR DESCRIPTION
Pressing on backspace to delete edges or nodes of the graph editor was triggering back navigation on Firefox on macOS.