### PR TITLE
Fix issue with removing template

### DIFF
--- a/frog/imports/client/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
+++ b/frog/imports/client/GraphEditor/SidePanel/ActivityPanel/EditActivity.js
@@ -143,7 +143,6 @@ const RawEditActivity = ({
     a => a.id !== activity._id
   );
   return (
-    // $FlowFixMe
     <div className="bootstrap" style={{ height: '100%', overflowY: 'scroll' }}>
       <div
         style={{
@@ -174,20 +173,7 @@ const RawEditActivity = ({
               {activity.template && !isEmpty(activity.template) && (
                 <>
                   <br />
-                  Activity has data template.{' '}
-                  <A
-                    onClick={() => {
-                      store.ui.setShowPreview({
-                        activityTypeId: activity.activityType,
-                        activityId: activity._id,
-                        config: activity.data,
-                        template: activity.template
-                      });
-                    }}
-                  >
-                    Show
-                  </A>{' '}
-                  -{' '}
+                  Activity has data template.
                   {!isEmpty(activity.template.lis) && (
                     <>
                       <A
@@ -207,7 +193,7 @@ const RawEditActivity = ({
                   )}
                   <A
                     onClick={() => {
-                      storeTemplateData(activity._id, {});
+                      storeTemplateData(activity._id, null);
                     }}
                   >
                     Remove

--- a/frog/imports/frog-utils/types.js
+++ b/frog/imports/frog-utils/types.js
@@ -148,7 +148,7 @@ export type ActivityPackageT = {
   },
   config: Object,
   configUI?: Object,
-  dataStructure?: any,
+  dataStructure?: Object | Function,
   validateConfig?: validateConfigFnT[],
   mergeFunction?: (
     dataUnitStructT,

--- a/frog/imports/internalActivities/ac-quiz/client/ActivityRunner/Quiz.js
+++ b/frog/imports/internalActivities/ac-quiz/client/ActivityRunner/Quiz.js
@@ -29,6 +29,7 @@ const Quiz = ({
   const { config } = activityData;
 
   const questionsWithIndex = config.questions.map((x, i) => [x, i]);
+
   const questions = ['questions', 'both'].includes(config.shuffle)
     ? condShuffle(questionsWithIndex, 'questions', '', groupingValue)
     : questionsWithIndex;

--- a/frog/server/mergeData.js
+++ b/frog/server/mergeData.js
@@ -1,4 +1,5 @@
 // @flow
+
 import { Meteor } from 'meteor/meteor';
 
 import { getUsername } from '/imports/api/users';
@@ -52,7 +53,7 @@ const duplicateLIs = (rz, lis) => {
 export const mergeOneInstance = async (
   grouping: string,
   activity: ActivityDbT,
-  dataStructure: any,
+  initData: Object,
   mergeFunction: ?Function,
   activityData: Object,
   structure: structureDefT,
@@ -63,17 +64,15 @@ export const mergeOneInstance = async (
   onBehalfOf?: string
 ) => {
   let data;
-  let newDataStructure = dataStructure;
+  let newInitData = initData;
   if (
     activity.template &&
     activity.template.duplicate &&
     activity.template.lis
   ) {
-    newDataStructure = duplicateLIs(
-      activity.template.rz,
-      activity.template.lis
-    );
+    newInitData = duplicateLIs(activity.template.rz, activity.template.lis);
   }
+
   if (mergeFunction) {
     const instanceActivityData =
       providedInstanceActivityData !== undefined // allows it to be null and still picked up
@@ -98,9 +97,7 @@ export const mergeOneInstance = async (
             Meteor.bindEnvironment(async () => {
               try {
                 doc.create(
-                  newDataStructure !== undefined
-                    ? cloneDeep(newDataStructure)
-                    : {}
+                  newInitData !== undefined ? cloneDeep(newInitData) : {}
                 );
               } catch (e) {
                 // eslint-disable-next-line no-console
@@ -158,7 +155,7 @@ export const mergeOneInstance = async (
       );
     }
   } else {
-    data = newDataStructure || {};
+    data = newInitData || {};
   }
 
   const serverDoc = serverConnection.get(

--- a/frog/server/mergeData.js
+++ b/frog/server/mergeData.js
@@ -96,9 +96,7 @@ export const mergeOneInstance = async (
             'load',
             Meteor.bindEnvironment(async () => {
               try {
-                doc.create(
-                  newInitData !== undefined ? cloneDeep(newInitData) : {}
-                );
+                doc.create(newInitData ? cloneDeep(newInitData) : {});
               } catch (e) {
                 // eslint-disable-next-line no-console
                 console.error(


### PR DESCRIPTION
Removing template data updates the template data to `{}` which crashes the server. This PR replaces `{}` to `null`

## How to reproduce:
- create a new graph with a single quiz activity
- configure a few questions
- save template data
- remove template data
- publish and start the session

## Other changes
- renamed a few variables to be more explicit
- Remove the "Show" option because it is outdated