### PR TITLE
Compute score for quiz leaderboard based on configured correct answers

### DIFF
--- a/frog/imports/internalActivities/ac-quiz/__tests__/index.js
+++ b/frog/imports/internalActivities/ac-quiz/__tests__/index.js
@@ -1,5 +1,6 @@
 import { chainUpgrades } from '/imports/frog-utils';
 import pkg from '../index';
+import { computeScore } from '../utils';
 
 test('all correct formatProduct', () => {
   expect(
@@ -94,6 +95,13 @@ test('chainUpgrades02to1', () => {
 
 test('chainUpgrades01to1', () => {
   expect(chainUpgrades(pkg.upgradeFunctions, -1, 1)(dataV1)).toEqual(dataV3);
+});
+
+test('Testing function computeScore', () => {
+  const scores = Object.values(reactiveData).map(({ data }) =>
+    computeScore(config.questions, data.form)
+  );
+  expect(scores).toEqual([0, 0, 2, 0, 0, 0, 1, 1, 0, 0, 2, 1, 0, 0, 0, 0]);
 });
 
 const config = {

--- a/frog/imports/internalActivities/ac-quiz/client/ActivityRunner/Question.js
+++ b/frog/imports/internalActivities/ac-quiz/client/ActivityRunner/Question.js
@@ -13,7 +13,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import CircularProgress from '@material-ui/core/CircularProgress';
 
 import { condShuffle } from './Quiz';
-import { computeProgress, computeCoordinates } from '../../utils';
+import { computeProgress, computeCoordinates, computeScore } from '../../utils';
 
 const styles = theme => ({
   root: {
@@ -164,10 +164,11 @@ export default withStyles(styles)(
 
       const newProgress = computeProgress(configQuestions, newForm);
       const newCoordinates = computeCoordinates(configQuestions, newForm);
+      const newScore = computeScore(configQuestions, newForm);
 
       logger([
         { type: 'progress', value: newProgress },
-        { type: 'score', value: newProgress },
+        { type: 'score', value: newScore },
         { type: 'choice', itemId: questionIndex, value: idx },
         { type: 'coordinates', payload: newCoordinates }
       ]);

--- a/frog/imports/internalActivities/ac-quiz/utils.js
+++ b/frog/imports/internalActivities/ac-quiz/utils.js
@@ -78,6 +78,23 @@ export const computeProgress = (
   return nAnsweredQuestions / questions.length;
 };
 
+export const isCorrect = (
+  qData: { [idx: string]: boolean, text: string },
+  qConfig: { answers: Object[], text: boolean }
+) => {
+  return !qConfig.answers.some((x, i) => !!x.isCorrect !== !!qData[`${i}`]);
+};
+
+export const computeScore = (
+  questions: { answers: Object[], text: boolean }[],
+  form: { [qIdx: number]: { [idx: string]: boolean, text: string } }
+) => {
+  return questions.reduce(
+    (acc, q, qIdx) => (isCorrect(form[qIdx], q) ? acc + 1 : acc),
+    0
+  );
+};
+
 export const formatProduct = (
   config: Object,
   item: Object,

--- a/frog/imports/internalActivities/ac-quiz/utils.js
+++ b/frog/imports/internalActivities/ac-quiz/utils.js
@@ -90,7 +90,7 @@ export const computeScore = (
   form: { [qIdx: number]: { [idx: string]: boolean, text: string } }
 ) => {
   return questions.reduce(
-    (acc, q, qIdx) => (isCorrect(form[qIdx], q) ? acc + 1 : acc),
+    (acc, q, qIdx) => (form[qIdx] && isCorrect(form[qIdx], q) ? acc + 1 : acc),
     0
   );
 };


### PR DESCRIPTION
Before this PR the quiz leaderboard would only count the student progress (useless). Now it works by counting the number of correct answers as specified by the teacher in the quiz config.