### PR TITLE
Don't open new pages in edit mode

### DIFF
--- a/frog/imports/client/Wiki/WikiContentComp.js
+++ b/frog/imports/client/Wiki/WikiContentComp.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { WikiContext } from '/imports/frog-utils';
+import Mousetrap from 'mousetrap';
 import 'mousetrap/plugins/global-bind/mousetrap-global-bind.min.js';
 
 import Button from '@material-ui/core/Button';
@@ -119,6 +120,17 @@ class WikiContentComp extends React.Component<> {
       });
     }
   };
+
+  componentDidMount() {
+    if (!this.props.embed && this.props.side !== 'right') {
+      Mousetrap.bindGlobal('ctrl+s', () => this.setState({ docMode: 'view' }));
+      Mousetrap.bindGlobal('ctrl+e', () => {
+        this.props.checkEdit().then(x => {
+          if (x) this.setState({ docMode: 'edit' });
+        });
+      });
+    }
+  }
 
   render() {
     const widthSize = this.props.side ? '50%' : '100%';

--- a/frog/imports/client/Wiki/index.js
+++ b/frog/imports/client/Wiki/index.js
@@ -163,11 +163,6 @@ class WikiComp extends React.Component<WikiCompPropsT, WikiCompStateT> {
     window.wikiDoc = this.wikiDoc;
     if (!this.props.embed) {
       Mousetrap.bindGlobal('ctrl+n', this.createPageModal);
-      Mousetrap.bindGlobal('ctrl+s', () => this.setState({ docMode: 'view' }));
-      Mousetrap.bindGlobal('ctrl+e', () => {
-        const { settings } = this.state;
-        if (!settings.readOnly) this.setState({ docMode: 'edit' });
-      });
       Mousetrap.bindGlobal('ctrl+f', () =>
         this.setState({ findModalOpen: true })
       );


### PR DESCRIPTION
Moving Mousetrap to the subpage to enable using keyboard shortcuts to open page for edit/save.