### PR TITLE
Creating an Admin Dashboard and Code Refactoring

### DIFF
--- a/frog/imports/api/users.js
+++ b/frog/imports/api/users.js
@@ -60,16 +60,6 @@ export const getUserType = (user?: UserObj): UserType => {
   else return 'No user logged in';
 };
 
-export const checkUserAdmin = (user?: UserObj): boolean => {
-  Meteor.call('check.admin', (err, res) => {
-    if (err) {
-      console.info(err);
-      return false;
-    }
-    console.log(res);
-    return res;
-  });
-};
 /**
  * Returns the appropriate user object based on the type of user. If no user is passed as args then will return the current user object.
  * If there is no user logged in, returns undefined.

--- a/frog/imports/api/users.js
+++ b/frog/imports/api/users.js
@@ -65,7 +65,7 @@ export const getUserType = (user?: UserObj): UserType => {
  * If there is no user logged in, returns undefined.
  * @param: {User=} user
  */
-export const getUser = (user?: UserObj): ?MeteorUser => {
+export const getUser = (user?: UserObj): MeteorUser => {
   // object spread to allow destructure a null object
   const { id, meteorUser } = { ...user };
   if (id) return Meteor.users.findOne(id);

--- a/frog/imports/api/users.js
+++ b/frog/imports/api/users.js
@@ -61,16 +61,21 @@ export const getUserType = (user?: UserObj): UserType => {
 };
 
 export const checkUserAdmin = (user?: UserObj): boolean => {
-  const selectedUser = getUser(user);
-  if (!selectedUser) return false;
-  return selectedUser.isAdmin ? selectedUser.isAdmin : false;
+  Meteor.call('check.admin', (err, res) => {
+    if (err) {
+      console.info(err);
+      return false;
+    }
+    console.log(res);
+    return res;
+  });
 };
 /**
  * Returns the appropriate user object based on the type of user. If no user is passed as args then will return the current user object.
  * If there is no user logged in, returns undefined.
  * @param: {User=} user
  */
-const getUser = (user?: UserObj): ?MeteorUser => {
+export const getUser = (user?: UserObj): ?MeteorUser => {
   // object spread to allow destructure a null object
   const { id, meteorUser } = { ...user };
   if (id) return Meteor.users.findOne(id);

--- a/frog/imports/client/AccountModal/Login.js
+++ b/frog/imports/client/AccountModal/Login.js
@@ -134,7 +134,6 @@ const Login = ({ classes, onLogin, openSignUpForm }: LoginPropsT) => {
             <Grid item xs>
               <Button
                 href="#"
-                variant="body2"
                 className={classes.link}
                 onClick={() => {
                   Meteor.call('send.password.reminder', email, err => {
@@ -156,11 +155,7 @@ const Login = ({ classes, onLogin, openSignUpForm }: LoginPropsT) => {
               </Button>
             </Grid>
             <Grid item>
-              <Button
-                onClick={openSignUpForm}
-                className={classes.link}
-                variant="body2"
-              >
+              <Button onClick={openSignUpForm} className={classes.link}>
                 {"Don't have an account? Sign Up"}
               </Button>
             </Grid>

--- a/frog/imports/client/App/index.js
+++ b/frog/imports/client/App/index.js
@@ -237,6 +237,9 @@ const FROGRouter = withRouter(
               false
             );
             this.setState({ mode: 'ready' });
+            if (query.redirect) {
+              this.props.history.push(query.redirect);
+            }
           });
           return;
         }

--- a/frog/imports/client/UserDashboard/components/AdminsPage/index.js
+++ b/frog/imports/client/UserDashboard/components/AdminsPage/index.js
@@ -1,0 +1,190 @@
+// @flow
+import * as React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { List, Grid, Typography, Paper } from '@material-ui/core';
+import { Bookmark, AccountBox, Description } from '@material-ui/icons';
+import { ContentListItem } from '/imports/ui/ListItem';
+import {
+  parseDraftData,
+  parseSessionData
+} from '/imports/client/UserDashboard/data-utils/helpers';
+
+const useStyles = makeStyles(theme => ({
+  paper: {
+    padding: theme.spacing(2),
+    textAlign: 'left',
+    color: theme.palette.text.primary
+  },
+  buttonRows: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  icon: {
+    color: theme.palette.secondary.main
+  }
+}));
+
+export const AdminsPage = ({ history }: { history: Object }) => {
+  const classes = useStyles();
+
+  const parseDate = (date): Date => {
+    return `${date.getHours()}:${date.getMinutes()}:${date.getSeconds()} ${date.getDate()}/${date.getMonth() +
+      1}/${date.getFullYear()}`;
+  };
+
+  const parseEmail = user => {
+    try {
+      return user.emails[0].address;
+    } catch {
+      return 'Email Unavailable';
+    }
+  };
+
+  const parseUsersList = (userList, history) => {
+    return userList.map(item => {
+      return {
+        itemIcon: AccountBox,
+        itemTitle: item.nameReference,
+        itemType: parseEmail(item),
+        dateCreated: parseDate(item.createdAt),
+        dateObj: item.createdAt,
+        callback: () => {}
+      };
+    });
+  };
+
+  const parseSessionsList = (sessionList, history) => {
+    return parseSessionData(sessionList, history).map((item, index) => {
+      return {
+        ...item,
+        itemType: `${item.itemType} | Owner: ${sessionList[index].ownerName}`,
+        callback: () => {},
+        secondaryActions: null
+      };
+    });
+  };
+
+  const parseGraphsList = (graphList, history) => {
+    return parseDraftData(graphList, history).map((item, index) => {
+      return {
+        ...item,
+        itemType: `Owner: ${graphList[index].ownerName}`,
+        callback: () => {},
+        secondaryActions: null
+      };
+    });
+  };
+
+  const [usersList, setUsersList] = React.useState([]);
+  const [sessionsList, setSessionsList] = React.useState([]);
+  const [graphsList, setGraphsList] = React.useState([]);
+
+  React.useEffect(() => {
+    // Newly Added Users
+    Meteor.call('admin.users.all', (err, res) => {
+      if (err) {
+        console.info(err);
+      }
+      setUsersList(parseUsersList(res, history));
+    });
+    // Newly Created Sessions
+    Meteor.call('admin.recentSessions', (err, res) => {
+      if (err) {
+        console.info(err);
+      }
+      setSessionsList(parseSessionsList(res, history));
+    });
+    // Newly Created Graphs
+    Meteor.call('admin.recentGraphs', (err, res) => {
+      if (err) {
+        console.info(err);
+      }
+      setGraphsList(parseGraphsList(res, history));
+    });
+  }, []);
+
+  return (
+    <Grid container>
+      {usersList.length > 0 && (
+        <Grid
+          item
+          xs={sessionsList.length > 0 || graphsList.length > 0 ? 6 : 12}
+        >
+          <Paper className={classes.paper} elevation={0}>
+            <div className={classes.buttonRows}>
+              <Typography variant="h5" align="left">
+                <AccountBox className={classes.icon} /> Recently Added Users
+              </Typography>
+            </div>
+
+            <List dense>
+              {usersList.slice(0, 6).map((props, index) => {
+                return <ContentListItem key={index} {...props} />;
+              })}
+            </List>
+          </Paper>
+        </Grid>
+      )}
+      {sessionsList.length > 0 && (
+        <Grid item xs={usersList.length > 0 || graphsList.length > 0 ? 6 : 12}>
+          <Paper className={classes.paper} elevation={0}>
+            <Typography variant="h5">
+              <Bookmark className={classes.icon} /> Recently Created Sessions
+            </Typography>
+
+            <List dense>
+              {sessionsList
+                .slice(0, 6)
+                .map(
+                  (
+                    {
+                      itemIcon,
+                      itemTitle,
+                      status,
+                      itemType,
+                      dateCreated,
+                      callback,
+                      secondaryActions
+                    },
+                    index
+                  ) => (
+                    <ContentListItem
+                      key={index}
+                      itemIcon={itemIcon}
+                      itemTitle={itemTitle}
+                      itemType={itemType}
+                      dateCreated={dateCreated}
+                      status={status}
+                      callback={callback}
+                      secondaryActions={secondaryActions}
+                    />
+                  )
+                )}
+            </List>
+          </Paper>
+        </Grid>
+      )}
+      {graphsList.length > 0 && (
+        <Grid
+          item
+          xs={sessionsList.length > 0 || usersList.length > 0 ? 6 : 12}
+        >
+          <Paper className={classes.paper} elevation={0}>
+            <div className={classes.buttonRows}>
+              <Typography variant="h5" align="left">
+                <Description className={classes.icon} /> Recently Created Graphs
+              </Typography>
+            </div>
+
+            <List dense>
+              {graphsList.slice(0, 6).map((props, index) => {
+                return <ContentListItem key={index} {...props} />;
+              })}
+            </List>
+          </Paper>
+        </Grid>
+      )}
+    </Grid>
+  );
+};

--- a/frog/imports/client/UserDashboard/components/AdminsPage/index.js
+++ b/frog/imports/client/UserDashboard/components/AdminsPage/index.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Meteor } from 'meteor/meteor';
-import { List, Grid, Typography, Paper } from '@material-ui/core';
+import { List, Grid, Typography, Paper, Tabs, Tab } from '@material-ui/core';
 import { Bookmark, AccountBox, Description } from '@material-ui/icons';
 import { ContentListItem } from '/imports/ui/ListItem';
 import {
@@ -11,6 +11,10 @@ import {
 } from '/imports/client/UserDashboard/data-utils/helpers';
 
 const useStyles = makeStyles(theme => ({
+  tabbar: {
+    padding: theme.spacing(0),
+    borderBottom: '1px solid #EAEAEA'
+  },
   paper: {
     padding: theme.spacing(2),
     textAlign: 'left',
@@ -103,6 +107,11 @@ export const AdminsPage = ({ history }: { history: Object }) => {
   const [usersList, setUsersList] = React.useState([]);
   const [sessionsList, setSessionsList] = React.useState([]);
   const [graphsList, setGraphsList] = React.useState([]);
+  const [tab, setTab] = React.useState(0);
+
+  const handleChange = (event, newValue) => {
+    setTab(newValue);
+  };
 
   React.useEffect(() => {
     // Newly Added Users
@@ -129,38 +138,46 @@ export const AdminsPage = ({ history }: { history: Object }) => {
   }, []);
 
   return (
-    <Grid container>
-      {usersList.length > 0 && (
-        <Grid
-          item
-          xs={sessionsList.length > 0 || graphsList.length > 0 ? 6 : 12}
+    <>
+      <Paper className={classes.tabbar} elevation={0}>
+        <Tabs
+          value={tab}
+          onChange={handleChange}
+          indicatorColor="primary"
+          textColor="primary"
         >
-          <Paper className={classes.paper} elevation={0}>
-            <div className={classes.buttonRows}>
-              <Typography variant="h5" align="left">
-                <AccountBox className={classes.icon} /> Recently Added Users
+          <Tab label={<Typography>Users</Typography>} />
+          <Tab label={<Typography>Sessions</Typography>} />
+          <Tab label={<Typography>Graphs</Typography>} />
+        </Tabs>
+      </Paper>
+      <Grid container>
+        {tab === 0 && usersList.length > 0 && (
+          <Grid item xs={12}>
+            <Paper className={classes.paper} elevation={0}>
+              <div className={classes.buttonRows}>
+                <Typography variant="h5" align="left">
+                  <AccountBox className={classes.icon} /> Recently Added Users
+                </Typography>
+              </div>
+
+              <List dense>
+                {usersList.map((props, index) => {
+                  return <ContentListItem key={index} {...props} />;
+                })}
+              </List>
+            </Paper>
+          </Grid>
+        )}
+        {tab === 1 && sessionsList.length > 0 && (
+          <Grid item xs={12}>
+            <Paper className={classes.paper} elevation={0}>
+              <Typography variant="h5">
+                <Bookmark className={classes.icon} /> Recently Created Sessions
               </Typography>
-            </div>
 
-            <List dense>
-              {usersList.slice(0, 6).map((props, index) => {
-                return <ContentListItem key={index} {...props} />;
-              })}
-            </List>
-          </Paper>
-        </Grid>
-      )}
-      {sessionsList.length > 0 && (
-        <Grid item xs={usersList.length > 0 || graphsList.length > 0 ? 6 : 12}>
-          <Paper className={classes.paper} elevation={0}>
-            <Typography variant="h5">
-              <Bookmark className={classes.icon} /> Recently Created Sessions
-            </Typography>
-
-            <List dense>
-              {sessionsList
-                .slice(0, 6)
-                .map(
+              <List dense>
+                {sessionsList.map(
                   (
                     {
                       itemIcon,
@@ -185,30 +202,29 @@ export const AdminsPage = ({ history }: { history: Object }) => {
                     />
                   )
                 )}
-            </List>
-          </Paper>
-        </Grid>
-      )}
-      {graphsList.length > 0 && (
-        <Grid
-          item
-          xs={sessionsList.length > 0 || usersList.length > 0 ? 6 : 12}
-        >
-          <Paper className={classes.paper} elevation={0}>
-            <div className={classes.buttonRows}>
-              <Typography variant="h5" align="left">
-                <Description className={classes.icon} /> Recently Created Graphs
-              </Typography>
-            </div>
+              </List>
+            </Paper>
+          </Grid>
+        )}
+        {tab === 2 && graphsList.length > 0 && (
+          <Grid item xs={12}>
+            <Paper className={classes.paper} elevation={0}>
+              <div className={classes.buttonRows}>
+                <Typography variant="h5" align="left">
+                  <Description className={classes.icon} /> Recently Created
+                  Graphs
+                </Typography>
+              </div>
 
-            <List dense>
-              {graphsList.slice(0, 6).map((props, index) => {
-                return <ContentListItem key={index} {...props} />;
-              })}
-            </List>
-          </Paper>
-        </Grid>
-      )}
-    </Grid>
+              <List dense>
+                {graphsList.map((props, index) => {
+                  return <ContentListItem key={index} {...props} />;
+                })}
+              </List>
+            </Paper>
+          </Grid>
+        )}
+      </Grid>
+    </>
   );
 };

--- a/frog/imports/client/UserDashboard/components/AdminsPage/index.js
+++ b/frog/imports/client/UserDashboard/components/AdminsPage/index.js
@@ -41,7 +41,7 @@ export const AdminsPage = ({ history }: { history: Object }) => {
     }
   };
 
-  const parseUsersList = (userList, history) => {
+  const parseUsersList = userList => {
     return userList.map(item => {
       return {
         itemIcon: AccountBox,
@@ -54,7 +54,7 @@ export const AdminsPage = ({ history }: { history: Object }) => {
     });
   };
 
-  const parseSessionsList = (sessionList, history) => {
+  const parseSessionsList = sessionList => {
     return parseSessionData(sessionList, history).map((item, index) => {
       return {
         ...item,
@@ -65,7 +65,7 @@ export const AdminsPage = ({ history }: { history: Object }) => {
     });
   };
 
-  const parseGraphsList = (graphList, history) => {
+  const parseGraphsList = graphList => {
     return parseDraftData(graphList, history).map((item, index) => {
       return {
         ...item,
@@ -86,21 +86,21 @@ export const AdminsPage = ({ history }: { history: Object }) => {
       if (err) {
         console.info(err);
       }
-      setUsersList(parseUsersList(res, history));
+      setUsersList(parseUsersList(res));
     });
     // Newly Created Sessions
     Meteor.call('admin.recentSessions', (err, res) => {
       if (err) {
         console.info(err);
       }
-      setSessionsList(parseSessionsList(res, history));
+      setSessionsList(parseSessionsList(res));
     });
     // Newly Created Graphs
     Meteor.call('admin.recentGraphs', (err, res) => {
       if (err) {
         console.info(err);
       }
-      setGraphsList(parseGraphsList(res, history));
+      setGraphsList(parseGraphsList(res));
     });
   }, []);
 

--- a/frog/imports/client/UserDashboard/components/AdminsPage/index.js
+++ b/frog/imports/client/UserDashboard/components/AdminsPage/index.js
@@ -51,7 +51,7 @@ export const AdminsPage = ({ history }: { history: Object }) => {
       if (err) {
         console.info(err);
       } else {
-        history.push(`${path}/?u=${id}&token=${res}`);
+        history.push(`/?u=${id}&token=${res}&redirect=${path}`);
         window.location.reload();
       }
     });

--- a/frog/imports/client/UserDashboard/components/DashboardSideBar/index.js
+++ b/frog/imports/client/UserDashboard/components/DashboardSideBar/index.js
@@ -7,7 +7,8 @@ import {
   Add,
   KeyboardArrowRight,
   OpenInNew,
-  MoreVert
+  MoreVert,
+  AccountBox
 } from '@material-ui/icons';
 import DescriptionIcon from '@material-ui/icons/Description';
 import ArchiveIcon from '@material-ui/icons/Archive';
@@ -44,38 +45,24 @@ const useStyles = makeStyles(theme => ({
 
 type DashBoardSideBarPropsT = {
   children: React.Node | React.Node[],
-  callbackSessionsView: () => void,
-  callbackDraftsView: () => void,
-  callbackTemplatesView: () => void,
-  callbackArchivesView: () => void,
-  callbackRecentsView: () => void,
-  sessionsActive: boolean,
-  draftsActive: boolean,
-  templatesActive: Boolean,
-  recentsActive: boolean,
-  archivesActive: boolean,
+  callbackView: () => void,
   activePage: string,
   history: any,
+  showSessions: boolean,
   showDrafts: boolean,
   showTemplates: boolean,
-  showArchives: boolean
+  showArchives: boolean,
+  showAdmin: boolean
 };
 export const DashboardSideBar = ({
-  callbackRecentsView,
-  callbackSessionsView,
-  callbackDraftsView,
-  callbackTemplatesView,
-  callbackArchivesView,
-  sessionsActive,
-  draftsActive,
-  templatesActive,
-  recentsActive,
-  archivesActive,
+  callbackView,
   history,
   activePage,
+  showSessions,
   showDrafts,
   showTemplates,
   showArchives,
+  showAdmin,
   children
 }: DashBoardSideBarPropsT) => {
   const classes = useStyles();
@@ -102,9 +89,11 @@ export const DashboardSideBar = ({
               showArchives && (
                 <Panel>
                   <RowButton
-                    active={archivesActive}
+                    active={activePage === 'Archives'}
                     icon={<ArchiveIcon />}
-                    onClick={callbackArchivesView}
+                    onClick={() => {
+                      callbackView('Archives');
+                    }}
                   >
                     Archive
                   </RowButton>
@@ -116,8 +105,10 @@ export const DashboardSideBar = ({
               {showDrafts && (
                 <>
                   <RowButton
-                    onClick={callbackRecentsView}
-                    active={recentsActive}
+                    onClick={() => {
+                      callbackView('Recents');
+                    }}
+                    active={activePage === 'Recents'}
                     icon={<AccessTimeOutlined />}
                     rightIcon={<KeyboardArrowRight fontSize="small" />}
                   >
@@ -125,8 +116,10 @@ export const DashboardSideBar = ({
                   </RowButton>
                   <RowButton
                     icon={<ShowChart />}
-                    active={draftsActive}
-                    onClick={callbackDraftsView}
+                    active={activePage === 'Drafts'}
+                    onClick={() => {
+                      callbackView('Drafts');
+                    }}
                     rightIcon={<KeyboardArrowRight fontSize="small" />}
                   >
                     Drafts
@@ -135,8 +128,10 @@ export const DashboardSideBar = ({
               )}
               <RowButton
                 icon={<Bookmark />}
-                active={sessionsActive}
-                onClick={callbackSessionsView}
+                active={showSessions}
+                onClick={() => {
+                  callbackView('Sessions');
+                }}
                 rightIcon={<KeyboardArrowRight fontSize="small" />}
               >
                 Sessions
@@ -144,11 +139,25 @@ export const DashboardSideBar = ({
               {showTemplates && (
                 <RowButton
                   icon={<DescriptionIcon />}
-                  active={templatesActive}
-                  onClick={callbackTemplatesView}
+                  active={activePage === 'Templates'}
+                  onClick={() => {
+                    callbackView('Templates');
+                  }}
                   rightIcon={<KeyboardArrowRight fontSize="small" />}
                 >
                   Templates
+                </RowButton>
+              )}
+              {showAdmin && (
+                <RowButton
+                  icon={<AccountBox />}
+                  active={activePage === 'Admin Control'}
+                  onClick={() => {
+                    callbackView('Admin Control');
+                  }}
+                  rightIcon={<KeyboardArrowRight fontSize="small" />}
+                >
+                  Admin Control
                 </RowButton>
               )}
             </Panel>

--- a/frog/imports/client/UserDashboard/components/DashboardSideBar/index.js
+++ b/frog/imports/client/UserDashboard/components/DashboardSideBar/index.js
@@ -45,7 +45,7 @@ const useStyles = makeStyles(theme => ({
 
 type DashBoardSideBarPropsT = {
   children: React.Node | React.Node[],
-  callbackView: () => void,
+  callbackView: string => void,
   activePage: string,
   history: any,
   showSessions: boolean,

--- a/frog/imports/client/UserDashboard/components/RecentsPage/index.js
+++ b/frog/imports/client/UserDashboard/components/RecentsPage/index.js
@@ -33,7 +33,7 @@ type RecentsPagePropsT = {
   draftsList: DraftsListT,
   templatesList: TemplatesListT,
   actionCallback: () => void,
-  viewCallback: () => void
+  viewCallback: string => void
 };
 
 export const RecentsPage = ({

--- a/frog/imports/client/UserDashboard/components/RecentsPage/index.js
+++ b/frog/imports/client/UserDashboard/components/RecentsPage/index.js
@@ -33,9 +33,7 @@ type RecentsPagePropsT = {
   draftsList: DraftsListT,
   templatesList: TemplatesListT,
   actionCallback: () => void,
-  moreCallbackSessions: () => void,
-  moreCallbackDrafts: () => void,
-  moreCallbackTemplates: () => void
+  viewCallback: () => void
 };
 
 export const RecentsPage = ({
@@ -43,9 +41,7 @@ export const RecentsPage = ({
   draftsList,
   templatesList,
   actionCallback,
-  moreCallbackDrafts,
-  moreCallbackSessions,
-  moreCallbackTemplates
+  viewCallback
 }: RecentsPagePropsT) => {
   const classes = useStyles();
   return (
@@ -71,7 +67,9 @@ export const RecentsPage = ({
             </List>
             {draftsList.length > 6 && (
               <Button
-                onClick={moreCallbackDrafts}
+                onClick={() => {
+                  viewCallback('Drafts');
+                }}
                 icon={<MoreHoriz />}
                 variant="minimal"
               >
@@ -119,7 +117,9 @@ export const RecentsPage = ({
           </List>
           {sessionsList.length > 6 && (
             <Button
-              onClick={moreCallbackSessions}
+              onClick={() => {
+                viewCallback('Sessions');
+              }}
               icon={<MoreHoriz />}
               variant="minimal"
             >
@@ -168,7 +168,9 @@ export const RecentsPage = ({
             </List>
             {templatesList.length > 6 && (
               <Button
-                onClick={moreCallbackTemplates}
+                onClick={() => {
+                  viewCallback('Templates');
+                }}
                 icon={<MoreHoriz />}
                 variant="minimal"
               >

--- a/frog/imports/client/UserDashboard/containers/DashboardContentContainer.jsx
+++ b/frog/imports/client/UserDashboard/containers/DashboardContentContainer.jsx
@@ -12,7 +12,6 @@ import {
   TemplatesListT
 } from '/imports/ui/Types/types';
 import { clearAllTemplates } from '/imports/api/templates';
-import { getUser } from '/imports/api/users';
 
 type DashboardContentContainerPropsT = {
   history: RouterHistory,

--- a/frog/imports/client/UserDashboard/containers/DashboardContentContainer.jsx
+++ b/frog/imports/client/UserDashboard/containers/DashboardContentContainer.jsx
@@ -4,6 +4,7 @@ import { RecentsPage } from '/imports/client/UserDashboard/components/RecentsPag
 import { DraftsPage } from '/imports/client/UserDashboard/components/DraftsPage';
 import { TemplatesPage } from '/imports/client/UserDashboard/components/TemplatesPage';
 import { ArchivesPage } from '/imports/client/UserDashboard/components/ArchivesPage';
+import { AdminsPage } from '/imports/client/UserDashboard/components/AdminsPage';
 import { SessionsPage } from '/imports/client/UserDashboard/components/SessionsPage';
 import {
   DraftsListT,
@@ -11,6 +12,7 @@ import {
   TemplatesListT
 } from '/imports/ui/Types/types';
 import { clearAllTemplates } from '/imports/api/templates';
+import { getUser } from '/imports/api/users';
 
 type DashboardContentContainerPropsT = {
   history: RouterHistory,
@@ -26,68 +28,9 @@ export const DashboardContentContainer = ({
   templatesList,
   archives
 }: DashboardContentContainerPropsT) => {
-  const [selectedPage, setSelectedPage] = React.useState({
-    sessionsView: false,
-    draftsView: false,
-    templatesView: false,
-    recentsView: true,
-    archivesView: false
-  });
   const [activePage, setActivePage] = React.useState(
     draftsList.length === 0 ? 'Sessions' : 'Recents'
   );
-
-  const onSelectRecentsView = () => {
-    setActivePage('Recents');
-    setSelectedPage({
-      sessionsView: false,
-      draftsView: false,
-      templatesView: false,
-      recentsView: true,
-      archivesView: false
-    });
-  };
-  const onSelectSessionsView = () => {
-    setActivePage('Sessions');
-    setSelectedPage({
-      sessionsView: true,
-      recentsView: false,
-      templatesView: false,
-      draftsView: false,
-      archivesView: false
-    });
-  };
-  const onSelectDraftsView = () => {
-    setActivePage('Drafts');
-    setSelectedPage({
-      sessionsView: false,
-      draftsView: true,
-      templatesView: false,
-      recentsView: false,
-      archivesView: false
-    });
-  };
-  const onSelectTemplatesView = () => {
-    setActivePage('Templates');
-    setSelectedPage({
-      sessionsView: false,
-      draftsView: false,
-      templatesView: true,
-      recentsView: false,
-      archivesView: false
-    });
-  };
-
-  const onSelectArchivesView = () => {
-    setActivePage('Archives');
-    setSelectedPage({
-      sessionsView: false,
-      draftsView: false,
-      templatesView: false,
-      recentsView: false,
-      archivesView: true
-    });
-  };
 
   const sortList = (list): SessionListT | DraftsListT | TemplatesListT => {
     return list.sort((a, b) => b.dateObj - a.dateObj);
@@ -123,9 +66,7 @@ export const DashboardContentContainer = ({
             draftsList={sortedDraftsList}
             templatesList={sortedTemplatesList}
             actionCallback={() => history.push('/teacher/graph/new')}
-            moreCallbackSessions={onSelectSessionsView}
-            moreCallbackDrafts={onSelectDraftsView}
-            moreCallbackTemplates={onSelectTemplatesView}
+            viewCallback={setActivePage}
           />
         );
       case 'Sessions':
@@ -156,6 +97,9 @@ export const DashboardContentContainer = ({
           />
         );
 
+      case 'Admin Control':
+        return <AdminsPage history={history} />;
+
       default:
         return (
           <RecentsPage
@@ -163,28 +107,29 @@ export const DashboardContentContainer = ({
             draftsList={sortedDraftsList}
             templatesList={sortedTemplatesList}
             actionCallback={() => history.push('/teacher')}
-            moreCallbackSessions={onSelectSessionsView}
-            moreCallbackDrafts={onSelectDraftsView}
-            moreCallbackTemplates={onSelectTemplatesView}
+            viewCallback={setActivePage}
           />
         );
     }
   };
 
+  const [userAdmin, setUserAdmin] = React.useState(false);
+
+  React.useEffect(() => {
+    Meteor.call('check.admin', (err, res) => {
+      if (err) {
+        console.info(err);
+      }
+      setUserAdmin(res);
+    });
+  }, []);
+
   return (
     <DashboardSideBar
-      callbackSessionsView={onSelectSessionsView}
-      callbackRecentsView={onSelectRecentsView}
-      callbackDraftsView={onSelectDraftsView}
-      callbackTemplatesView={onSelectTemplatesView}
-      callbackArchivesView={onSelectArchivesView}
-      sessionsActive={draftsList.length === 0 || selectedPage.sessionsView}
-      draftsActive={selectedPage.draftsView}
-      recentsActive={selectedPage.recentsView}
-      templatesActive={selectedPage.templatesView}
-      archivesActive={selectedPage.archivesView}
+      callbackView={setActivePage}
       activePage={activePage}
       history={history}
+      showSessions={draftsList.length === 0 || activePage === 'Sessions'}
       showDrafts={draftsList.length > 0}
       showTemplates={templatesList.length > 0}
       showArchives={
@@ -192,6 +137,7 @@ export const DashboardContentContainer = ({
         archives.sessions.length > 0 ||
         archives.templates.length > 0
       }
+      showAdmin={userAdmin}
     >
       <ComponentToRender />
     </DashboardSideBar>

--- a/frog/imports/containers/TopBarWrapper/index.js
+++ b/frog/imports/containers/TopBarWrapper/index.js
@@ -13,7 +13,7 @@ import { OverflowMenu } from '/imports/ui/OverflowMenu';
 import { Button } from '/imports/ui/Button';
 import { useModal } from '/imports/ui/Modal';
 import { RowButton, RowDivider, RowTitle } from '/imports/ui/RowItems';
-import { getUsername, getUserType, checkUserAdmin } from '/imports/api/users';
+import { getUsername, getUserType, getUser } from '/imports/api/users';
 import { resetShareDBConnection } from '/imports/client/App/resetShareDBConnection';
 import AccountModal from '/imports/client/AccountModal/AccountModal';
 import { PersonalProfileModal } from '/imports/client/AccountModal/PersonalProfileModal';
@@ -33,6 +33,8 @@ const TopBarWrapper = ({
   const [showModal] = useModal();
 
   const [adminModal, setAdminModal] = React.useState(false);
+
+  const [userAdmin, setUserAdmin] = React.useState(false);
 
   const openAdminModal = () => {
     setAdminModal(true);
@@ -80,6 +82,15 @@ const TopBarWrapper = ({
   };
   const userType = getUserType();
 
+  React.useEffect(() => {
+    Meteor.call('check.admin', (err, res) => {
+      if (err) {
+        console.info(err);
+      }
+      setUserAdmin(res);
+    });
+  }, []);
+
   return (
     <>
       <TopBar
@@ -116,7 +127,7 @@ const TopBarWrapper = ({
                   <RowButton onClick={openPersonalProfileModal} icon={<Edit />}>
                     Edit your profile
                   </RowButton>
-                  {checkUserAdmin() && (
+                  {userAdmin && (
                     <RowButton
                       onClick={openAdminModal}
                       icon={<AccountBoxIcon />}
@@ -147,7 +158,7 @@ const TopBarWrapper = ({
           </>
         }
       />
-      {checkUserAdmin() && adminModal && (
+      {userAdmin && adminModal && (
         <UsersListModal
           open={adminModal}
           closeModal={closeAdminModal}

--- a/frog/imports/containers/TopBarWrapper/index.js
+++ b/frog/imports/containers/TopBarWrapper/index.js
@@ -13,7 +13,7 @@ import { OverflowMenu } from '/imports/ui/OverflowMenu';
 import { Button } from '/imports/ui/Button';
 import { useModal } from '/imports/ui/Modal';
 import { RowButton, RowDivider, RowTitle } from '/imports/ui/RowItems';
-import { getUsername, getUserType, getUser } from '/imports/api/users';
+import { getUsername, getUserType } from '/imports/api/users';
 import { resetShareDBConnection } from '/imports/client/App/resetShareDBConnection';
 import AccountModal from '/imports/client/AccountModal/AccountModal';
 import { PersonalProfileModal } from '/imports/client/AccountModal/PersonalProfileModal';

--- a/frog/imports/ui/Logo/index.js
+++ b/frog/imports/ui/Logo/index.js
@@ -6,7 +6,6 @@ import { makeStyles } from '@material-ui/core';
 const LogoSVG = () => (
   <svg
     width="80"
-    height="auto"
     viewBox="0 0 650 266"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/frog/imports/ui/UsersListModal/index.js
+++ b/frog/imports/ui/UsersListModal/index.js
@@ -10,6 +10,7 @@ import {
 } from '@material-ui/core';
 import { RowButton } from '/imports/ui/RowItems';
 import { Meteor } from 'meteor/meteor';
+import { getUser } from '/imports/api/users';
 
 const useStyle = makeStyles(theme => ({
   root: {
@@ -46,7 +47,7 @@ const UsersListModal = (props: UsersListModalProps) => {
   });
 
   React.useEffect(() => {
-    Meteor.call('frog.users.all', (err, res) => {
+    Meteor.call('admin.users.all', (err, res) => {
       if (err) {
         console.info(err);
         setValue({ ...value, message: 'Error Loading Users' });
@@ -57,18 +58,6 @@ const UsersListModal = (props: UsersListModalProps) => {
       }
     });
   }, []);
-
-  const parseUsername = user => {
-    if (user.isAnonymous) {
-      return 'Anonymous User';
-    } else if (user.emails && user.profile) {
-      return user.profile.displayName;
-    } else if (user.username) {
-      return user.username;
-    } else {
-      return 'Undefined User';
-    }
-  };
 
   const parseEmail = user => {
     try {
@@ -84,9 +73,7 @@ const UsersListModal = (props: UsersListModalProps) => {
     if (searchQuery.length > 0) {
       const filteredList = userList.filter(item => {
         return (
-          parseUsername(item)
-            .toLowerCase()
-            .indexOf(searchQuery) > -1 ||
+          item.nameReference.toLowerCase().indexOf(searchQuery) > -1 ||
           (parseEmail(item)
             ? parseEmail(item).indexOf(searchQuery) > -1
             : false)
@@ -127,7 +114,7 @@ const UsersListModal = (props: UsersListModalProps) => {
                     );
                   }}
                 >
-                  {parseUsername(user)}
+                  {user.nameReference}
                   <i className={classes.rowEmail}>{parseEmail(user)}</i>
                 </RowButton>
               ))

--- a/frog/imports/ui/UsersListModal/index.js
+++ b/frog/imports/ui/UsersListModal/index.js
@@ -10,7 +10,6 @@ import {
 } from '@material-ui/core';
 import { RowButton } from '/imports/ui/RowItems';
 import { Meteor } from 'meteor/meteor';
-import { getUser } from '/imports/api/users';
 
 const useStyle = makeStyles(theme => ({
   root: {

--- a/frog/server/user_accounts.js
+++ b/frog/server/user_accounts.js
@@ -158,7 +158,8 @@ Meteor.methods({
     return 'Fail';
   },
   'impersonation.token': userId => {
-    const userDoc = Meteor.users.findOne({ _id: getUser()._id });
+    const currentUser = getUser();
+    const userDoc = Meteor.users.findOne({ _id: currentUser._id });
     if (userDoc?.isAdmin) {
       const newToken = uuid();
       Meteor.users.update(userId, { $set: { impersonationToken: newToken } });
@@ -168,7 +169,8 @@ Meteor.methods({
     }
   },
   'admin.users.all': function() {
-    const userDoc = Meteor.users.findOne({ _id: getUser()._id });
+    const currentUser = getUser();
+    const userDoc = Meteor.users.findOne({ _id: currentUser._id });
     if (userDoc?.isAdmin) {
       const userList = Meteor.users
         .find({}, { sort: { createdAt: -1 } })
@@ -189,7 +191,8 @@ Meteor.methods({
     }
   },
   'check.admin': () => {
-    const userDoc = Meteor.users.findOne({ _id: getUser()._id });
+    const currentUser = getUser();
+    const userDoc = Meteor.users.findOne({ _id: currentUser._id });
     if (userDoc) {
       return userDoc.isAdmin;
     } else {
@@ -197,7 +200,8 @@ Meteor.methods({
     }
   },
   'admin.recentSessions': () => {
-    const userDoc = Meteor.users.findOne({ _id: getUser()._id });
+    const currentUser = getUser();
+    const userDoc = Meteor.users.findOne({ _id: currentUser._id });
     if (userDoc?.isAdmin) {
       const sessionsList = Sessions.find(
         {},
@@ -210,7 +214,8 @@ Meteor.methods({
     }
   },
   'admin.recentGraphs': () => {
-    const userDoc = Meteor.users.findOne({ _id: getUser()._id });
+    const currentUser = getUser();
+    const userDoc = Meteor.users.findOne({ _id: currentUser._id });
     if (userDoc?.isAdmin) {
       const graphsList = Graphs.find({}, { sort: { createdAt: -1 } }).fetch();
       return graphsList.map(doc => {

--- a/frog/server/user_accounts.js
+++ b/frog/server/user_accounts.js
@@ -177,6 +177,8 @@ Meteor.methods({
         .map(doc => {
           if (!doc.isAnonymous) {
             return { ...doc, nameReference: parseUsername(doc) };
+          } else {
+            return null;
           }
         })
         .filter(doc => {


### PR DESCRIPTION
This PR creates a new view for admin accounts with information about newly created user accounts, sessions, graphs, etc on the platform and the functionality to access these (graphs/sessions/accounts) by impersonating the owner account.

The PR also refactors the following code to make it cleaner: 

- The DashboardContentContainer element used an object of multiple boolean values to determine the active dashboard view. The object is now replaced by a single state variable, with subsequent reduction of props in the children component (SideBar, RecentsPage, etc) that this element uses.

- The old admin check functionality was made through a front-end function that returns true or false after fetching a user object from the backend. To make this more secure, this check is now shifted to a back-end Meteor method that checks whether the account is an admin account or not. The change is also reflected in some other methods that send data to admin views.